### PR TITLE
Verify effective CODEOWNERS ownership

### DIFF
--- a/DELIVERY_GITHUB.md
+++ b/DELIVERY_GITHUB.md
@@ -26,6 +26,8 @@ Do not require every available test category on every change.
 
 Bind the required `PR Gate` context to the GitHub Actions App integration, not only to a status name.
 
+CODEOWNERS must protect both the required workflow and the small repo-specific entrypoints that determine what it executes (for example test scripts/config, coverage-gate code, or locked acceptance evaluators). Do not CODEOWN all product tests merely to satisfy this rule; protect only the control-plane mechanisms whose weakening could make `PR Gate` falsely green.
+
 Use **loose** required status checks (`strict_required_status_checks_policy: false`) by default so a PR does not rebuild merely because `main` moved. A merge queue, when available, provides the final combined-head integration check.
 
 ## 3. Expensive assurance

--- a/DELIVERY_GITHUB.md
+++ b/DELIVERY_GITHUB.md
@@ -26,7 +26,9 @@ Do not require every available test category on every change.
 
 Bind the required `PR Gate` context to the GitHub Actions App integration, not only to a status name.
 
-CODEOWNERS must protect both the required workflow and the small repo-specific entrypoints that determine what it executes (for example test scripts/config, coverage-gate code, or locked acceptance evaluators). Do not CODEOWN all product tests merely to satisfy this rule; protect only the control-plane mechanisms whose weakening could make `PR Gate` falsely green.
+CODEOWNERS should map the required workflow plus the small repo-specific entrypoints that determine what it executes (for example test scripts/config, coverage-gate code, or locked acceptance evaluators). Do not CODEOWN all product tests merely to satisfy this rule.
+
+For today's single-developer, user-owned repositories, CODEOWNERS is **advisory**, not a required approval gate: a pull-request author cannot approve their own PR, so requiring Code Owner approval would deadlock the normal solo workflow. R3/R4/control-plane changes instead require fresh external semantic review and are excluded from automatic merge. Once repositories move to an organization with an independent reviewer/team, enable required Code Owner review and prefer an organization-required workflow sourced from this standards repo.
 
 Use **loose** required status checks (`strict_required_status_checks_policy: false`) by default so a PR does not rebuild merely because `main` moved. A merge queue, when available, provides the final combined-head integration check.
 
@@ -63,7 +65,7 @@ For the default branch:
 
 R0–R2 may use risk-aware auto-merge after the PR is ready. R3/R4 and control-plane changes require a fresh independent semantic review after the final substantive push and must not auto-merge while a material finding is unresolved.
 
-Today, repo-local workflow files are still editable by a control-plane PR, so this R3 review requirement is a deliberate extra trust boundary rather than a claim that the local evaluator is immutable. Once repositories live in an eligible organization, prefer an organization-required workflow sourced from the standards repo so application PRs cannot rewrite their own top-level evaluator.
+Today, repo-local workflow files are still editable by a control-plane PR, so this R3 review requirement is an extra trust boundary rather than a claim that the local evaluator is immutable. Organization-required workflows are the stronger future boundary.
 
 ## 6. Merge queue
 
@@ -78,7 +80,7 @@ Default queue posture:
 - 1-minute maximum grouping wait
 - 10-minute required-check response timeout
 
-GitHub currently limits merge queues to organization-owned repositories: public organization repositories, or private organization repositories on Enterprise Cloud. User-owned repositories remain queue-ready but cannot enable the queue until moved to a supported organization.
+User-owned repositories remain queue-ready but cannot enable the queue until moved to a supported organization.
 
 ## 7. Release
 

--- a/README.md
+++ b/README.md
@@ -40,18 +40,19 @@ Every artifact, rule, gate, and CI run must reduce meaningful uncertainty, preve
 
 `AGENTS.md` is the operating map for agents working on this control-plane repo.
 
-## Automation today
+## One-time portfolio setup
+
+After cloning this repo and authenticating GitHub CLI:
 
 ```powershell
-# Configure active repos: Issues, Actions, labels, merge settings, branch rules.
-pwsh -File scripts/apply-github-standard.ps1
+pwsh -File scripts/setup-portfolio.ps1
+```
 
-# Create/sync the optional cross-repo Project view. Issues remain truth.
-pwsh -File scripts/sync-agentic-project.ps1
+That applies repo settings/rules, enables Actions, creates the risk/status labels, syncs the optional `Agentic Portfolio` GitHub Project, and runs the remote doctor. If GitHub CLI lacks Project scope, run `gh auth refresh -s project` once and rerun.
 
-# Verify local + remote control-plane state; exits nonzero on drift.
-pwsh -File scripts/doctor.ps1 -Remote
+## Other automation
 
+```powershell
 # Bootstrap a brand-new GitHub repo with an immediately safe bootstrap gate.
 pwsh -File scripts/bootstrap-repo.ps1 -Name my-app
 
@@ -63,17 +64,22 @@ pwsh -File scripts/codex-review.ps1
 
 # Enable auto-merge only for an eligible R0-R2 PR.
 pwsh -File scripts/auto-merge.ps1 -Repo kgsmith19/my-app -Pr 12 -Risk R2
+
+# Direct lower-level maintenance when needed.
+pwsh -File scripts/apply-github-standard.ps1
+pwsh -File scripts/sync-agentic-project.ps1
+pwsh -File scripts/doctor.ps1 -Remote
 ```
 
 `policy/github-defaults.json` is the machine-readable portfolio policy.
 
 ## GitHub default
 
-Managed repos use GitHub Issues for durable work, one stable GitHub-Actions-produced required `PR Gate`, draft PRs while agents iterate, squash merge, risk-aware auto-merge, merged-branch cleanup, protected `main`, resolved review threads, and merge queues when GitHub supports them.
+Managed repos use GitHub Issues for durable work, one stable GitHub-Actions-produced required `PR Gate`, draft PRs while agents iterate, squash merge, risk-aware auto-merge, merged-branch cleanup, protected `main`, and resolved review threads.
+
+Current user-owned repos keep CODEOWNERS advisory so a solo PR author is not deadlocked by self-approval rules. R3/R4 and control-plane changes instead require fresh independent semantic review and do not use the R0-R2 auto-merge helper. Organization-owned repos can automatically harden to required Code Owner review and merge queues where the GitHub plan supports them.
 
 The optional cross-repo GitHub Project is a portfolio view only; it is never a competing task database.
-
-R3/R4 and control-plane changes require fresh independent semantic review after the final substantive push. They do not use the automatic R0-R2 merge helper.
 
 ## Repo-specific truth
 

--- a/policy/github-defaults.json
+++ b/policy/github-defaults.json
@@ -5,12 +5,16 @@
   "required_status_context": "PR Gate",
   "strict_required_status_checks_policy": false,
   "required_approving_review_count": 0,
-  "require_code_owner_review": true,
+  "require_code_owner_review": false,
   "required_review_thread_resolution": true,
   "merge_method": "squash",
   "allow_auto_merge": true,
   "auto_merge_max_risk": "R2",
   "control_plane_requires_fresh_external_review": true,
+  "org_hardening": {
+    "require_code_owner_review": true,
+    "prefer_required_workflow_from_standard_repo": true
+  },
   "delete_branch_on_merge": true,
   "allow_merge_commit": false,
   "allow_rebase_merge": false,

--- a/scripts/apply-github-standard.ps1
+++ b/scripts/apply-github-standard.ps1
@@ -51,6 +51,11 @@ foreach ($name in $targets) {
   $metaRaw = & gh api "repos/$repo" 2>&1
   if ($LASTEXITCODE -ne 0) { Write-Warning "Cannot read $repo; skipping. $($metaRaw -join ' ')"; continue }
   $meta = ($metaRaw -join "`n") | ConvertFrom-Json
+  $isOrgOwned = $meta.owner.type -eq 'Organization'
+  $requireCodeOwnerReview = [bool]$config.require_code_owner_review
+  if ($isOrgOwned -and $config.org_hardening -and [bool]$config.org_hardening.require_code_owner_review) {
+    $requireCodeOwnerReview = $true
+  }
 
   $settings = @{
     has_issues               = $true
@@ -81,7 +86,7 @@ foreach ($name in $targets) {
       parameters = @{
         allowed_merge_methods             = @("squash")
         dismiss_stale_reviews_on_push     = $false
-        require_code_owner_review         = [bool]$config.require_code_owner_review
+        require_code_owner_review         = $requireCodeOwnerReview
         require_last_push_approval        = $false
         required_approving_review_count   = [int]$config.required_approving_review_count
         required_review_thread_resolution = [bool]$config.required_review_thread_resolution
@@ -100,7 +105,7 @@ foreach ($name in $targets) {
   )
 
   $queueWanted = [bool]$config.merge_queue.desired
-  $queueEligibleOwner = $meta.owner.type -eq "Organization"
+  $queueEligibleOwner = $isOrgOwned
   if ($queueWanted -and $queueEligibleOwner) {
     $rules += @{
       type = "merge_queue"
@@ -138,6 +143,8 @@ foreach ($name in $targets) {
       Invoke-GhJson -Method POST -Endpoint "repos/$repo/rulesets" -Body $payload | Out-Null
       Write-Host "ruleset: created $($config.ruleset_name)"
     }
+    if ($requireCodeOwnerReview) { Write-Host "CODEOWNERS approval: enforced" }
+    else { Write-Host "CODEOWNERS approval: advisory (solo personal-account safe)" }
     if ($queueWanted -and $queueEligibleOwner) { Write-Host "merge queue: requested" }
     elseif ($queueWanted) { Write-Host "merge queue: queue-ready only; GitHub does not support merge queues on user-owned repos" -ForegroundColor Yellow }
   }
@@ -153,4 +160,4 @@ foreach ($name in $targets) {
   }
 }
 
-Write-Host "`nDone. Re-run after moving eligible repos into a supported GitHub organization to add merge queues automatically." -ForegroundColor Green
+Write-Host "`nDone. Re-run after moving eligible repos into a supported GitHub organization to add merge queues and stronger review enforcement automatically." -ForegroundColor Green

--- a/scripts/bootstrap-repo.ps1
+++ b/scripts/bootstrap-repo.ps1
@@ -95,6 +95,7 @@ Replace the bootstrap-only PR Gate with the smallest objective gate appropriate 
 ## Acceptance
 - Detect and record verified build/test/type/lint/E2E commands in `.agent/project.yaml`.
 - Replace `.github/workflows/pr-gate.yml` so `PR Gate` executes the cheapest sufficient independent evidence.
+- Extend `.github/CODEOWNERS` with the small repo-specific gate entrypoints whose weakening could make `PR Gate` falsely green; keep the canonical control-plane ownership rules as the final non-comment rules.
 - Keep draft iteration local; ready PR and `merge_group` must produce the real `PR Gate`.
 - Add only tests/tools justified by actual product risk; do not invent a framework just for conformity.
 - Update `ci.gate_profile` away from `bootstrap-only`.

--- a/scripts/doctor.ps1
+++ b/scripts/doctor.ps1
@@ -29,7 +29,7 @@ $required = @(
   "README.md", "LIFECYCLE.md", "AGENT_RULES.md", "QUALITY_RULES.md",
   "SECURITY_RISK_AUTONOMY.md", "DELIVERY_GITHUB.md", "EVIDENCE_LEARNING.md",
   "AGENTS.md", ".github/CODEOWNERS", "policy/github-defaults.json",
-  "scripts/apply-github-standard.ps1", "scripts/sync-agentic-project.ps1",
+  "scripts/setup-portfolio.ps1", "scripts/apply-github-standard.ps1", "scripts/sync-agentic-project.ps1",
   "scripts/codex-review.ps1", "scripts/auto-merge.ps1",
   "scripts/bootstrap-repo.ps1", "scripts/upgrade-repos.ps1",
   ".github/workflows/ci.yml", "templates/AGENTS.md", "templates/CODEOWNERS", "templates/PR_GATE.yml",
@@ -77,7 +77,7 @@ if (-not (Test-CodeownersTail -Content $localTemplateCodeowners -ExpectedTail $a
 }
 
 $psScripts = @(
-  "scripts/apply-github-standard.ps1", "scripts/sync-agentic-project.ps1",
+  "scripts/setup-portfolio.ps1", "scripts/apply-github-standard.ps1", "scripts/sync-agentic-project.ps1",
   "scripts/codex-review.ps1", "scripts/auto-merge.ps1",
   "scripts/bootstrap-repo.ps1", "scripts/upgrade-repos.ps1", "scripts/doctor.ps1"
 )

--- a/scripts/doctor.ps1
+++ b/scripts/doctor.ps1
@@ -6,6 +6,25 @@ param(
 $ErrorActionPreference = "Stop"
 $root = (Resolve-Path (Join-Path $PSScriptRoot "..")).Path
 
+function Test-CodeownersTail {
+  param(
+    [Parameter(Mandatory)][string]$Content,
+    [Parameter(Mandatory)][string[]]$ExpectedTail
+  )
+
+  $rules = @(
+    $Content -split "`r?`n" |
+      ForEach-Object { $_.Trim() } |
+      Where-Object { $_ -and -not $_.StartsWith('#') }
+  )
+  if ($rules.Count -lt $ExpectedTail.Count) { return $false }
+  $start = $rules.Count - $ExpectedTail.Count
+  for ($i = 0; $i -lt $ExpectedTail.Count; $i++) {
+    if ($rules[$start + $i] -ne $ExpectedTail[$i]) { return $false }
+  }
+  return $true
+}
+
 $required = @(
   "README.md", "LIFECYCLE.md", "AGENT_RULES.md", "QUALITY_RULES.md",
   "SECURITY_RISK_AUTONOMY.md", "DELIVERY_GITHUB.md", "EVIDENCE_LEARNING.md",
@@ -27,6 +46,34 @@ if ($config.required_approving_review_count -ne 0) { throw "Default approval cou
 if (-not $config.require_code_owner_review) { throw "Control-plane CODEOWNERS review must remain enabled." }
 if ($config.auto_merge_max_risk -ne 'R2') { throw "auto_merge_max_risk must remain R2 unless the risk model is explicitly redesigned." }
 if (-not $config.control_plane_requires_fresh_external_review) { throw "Control-plane changes must require fresh external review." }
+
+$ownerToken = "@$($config.owner)"
+$appCodeownersTail = @(
+  "/.github/workflows/ $ownerToken",
+  "/.github/CODEOWNERS $ownerToken",
+  "/.agent/ $ownerToken",
+  "/AGENTS.md $ownerToken"
+)
+$standardCodeownersTail = @(
+  "/.github/workflows/ $ownerToken",
+  "/.github/CODEOWNERS $ownerToken",
+  "/policy/ $ownerToken",
+  "/scripts/ $ownerToken",
+  "/AGENTS.md $ownerToken",
+  "/AGENT_RULES.md $ownerToken",
+  "/QUALITY_RULES.md $ownerToken",
+  "/SECURITY_RISK_AUTONOMY.md $ownerToken",
+  "/DELIVERY_GITHUB.md $ownerToken"
+)
+
+$localStandardCodeowners = Get-Content (Join-Path $root '.github/CODEOWNERS') -Raw
+if (-not (Test-CodeownersTail -Content $localStandardCodeowners -ExpectedTail $standardCodeownersTail)) {
+  throw "Local .github/CODEOWNERS does not end with the canonical standards control-plane ownership rules."
+}
+$localTemplateCodeowners = Get-Content (Join-Path $root 'templates/CODEOWNERS') -Raw
+if (-not (Test-CodeownersTail -Content $localTemplateCodeowners -ExpectedTail $appCodeownersTail)) {
+  throw "templates/CODEOWNERS does not end with the canonical app control-plane ownership rules."
+}
 
 $psScripts = @(
   "scripts/apply-github-standard.ps1", "scripts/sync-agentic-project.ps1",
@@ -77,16 +124,9 @@ foreach ($name in $config.repositories) {
   }
   else {
     $codeowners = $codeownersRaw -join "`n"
-    $ownerToken = "@$($config.owner)"
-    $requiredOwnedPaths = if ($name -eq 'agent-engineering-standard') {
-      @('/.github/workflows/', '/policy/', '/scripts/', '/AGENTS.md')
-    }
-    else {
-      @('/.github/workflows/', '/.agent/', '/AGENTS.md')
-    }
-    foreach ($ownedPath in $requiredOwnedPaths) {
-      $pattern = '(?m)^' + [regex]::Escape($ownedPath) + '\s+' + [regex]::Escape($ownerToken) + '\s*$'
-      if ($codeowners -notmatch $pattern) { $problems.Add("CODEOWNERS missing ${ownedPath} -> ${ownerToken}") }
+    $expectedTail = if ($name -eq 'agent-engineering-standard') { $standardCodeownersTail } else { $appCodeownersTail }
+    if (-not (Test-CodeownersTail -Content $codeowners -ExpectedTail $expectedTail)) {
+      $problems.Add("CODEOWNERS effective tail does not match canonical protected ownership")
     }
   }
 

--- a/scripts/doctor.ps1
+++ b/scripts/doctor.ps1
@@ -42,8 +42,9 @@ foreach ($relative in $required) {
 
 $config = Get-Content (Join-Path $root "policy/github-defaults.json") -Raw | ConvertFrom-Json
 if ($config.required_status_context -ne "PR Gate") { throw "required_status_context must be 'PR Gate'" }
-if ($config.required_approving_review_count -ne 0) { throw "Default approval count must remain 0; control-plane review is CODEOWNERS/risk-driven." }
-if (-not $config.require_code_owner_review) { throw "Control-plane CODEOWNERS review must remain enabled." }
+if ($config.required_approving_review_count -ne 0) { throw "Default approval count must remain 0; review is risk-driven." }
+if ($config.require_code_owner_review) { throw "Personal-account default must not require Code Owner approval; the PR author cannot approve their own PR." }
+if (-not $config.org_hardening -or -not [bool]$config.org_hardening.require_code_owner_review) { throw "Organization hardening must retain Code Owner review." }
 if ($config.auto_merge_max_risk -ne 'R2') { throw "auto_merge_max_risk must remain R2 unless the risk model is explicitly redesigned." }
 if (-not $config.control_plane_requires_fresh_external_review) { throw "Control-plane changes must require fresh external review." }
 
@@ -68,11 +69,11 @@ $standardCodeownersTail = @(
 
 $localStandardCodeowners = Get-Content (Join-Path $root '.github/CODEOWNERS') -Raw
 if (-not (Test-CodeownersTail -Content $localStandardCodeowners -ExpectedTail $standardCodeownersTail)) {
-  throw "Local .github/CODEOWNERS does not end with the canonical standards control-plane ownership rules."
+  throw "Local .github/CODEOWNERS does not end with the canonical standards ownership map."
 }
 $localTemplateCodeowners = Get-Content (Join-Path $root 'templates/CODEOWNERS') -Raw
 if (-not (Test-CodeownersTail -Content $localTemplateCodeowners -ExpectedTail $appCodeownersTail)) {
-  throw "templates/CODEOWNERS does not end with the canonical app control-plane ownership rules."
+  throw "templates/CODEOWNERS does not end with the canonical app ownership map."
 }
 
 $psScripts = @(
@@ -103,6 +104,11 @@ foreach ($name in $config.repositories) {
   $metaRaw = & gh api "repos/$repo" 2>&1
   if ($LASTEXITCODE -ne 0) { $remoteFailures.Add("${repo}: cannot read repository"); continue }
   $meta = ($metaRaw -join "`n") | ConvertFrom-Json
+  $isOrgOwned = $meta.owner.type -eq 'Organization'
+  $expectedCodeOwnerReview = [bool]$config.require_code_owner_review
+  if ($isOrgOwned -and $config.org_hardening -and [bool]$config.org_hardening.require_code_owner_review) {
+    $expectedCodeOwnerReview = $true
+  }
 
   if (-not $meta.has_issues) { $problems.Add("Issues disabled") }
   if (-not $meta.allow_auto_merge) { $problems.Add("auto-merge off") }
@@ -126,7 +132,7 @@ foreach ($name in $config.repositories) {
     $codeowners = $codeownersRaw -join "`n"
     $expectedTail = if ($name -eq 'agent-engineering-standard') { $standardCodeownersTail } else { $appCodeownersTail }
     if (-not (Test-CodeownersTail -Content $codeowners -ExpectedTail $expectedTail)) {
-      $problems.Add("CODEOWNERS effective tail does not match canonical protected ownership")
+      $problems.Add("CODEOWNERS effective tail does not match canonical ownership map")
     }
   }
 
@@ -153,7 +159,7 @@ foreach ($name in $config.repositories) {
         $prRule = $detail.rules | Where-Object { $_.type -eq 'pull_request' } | Select-Object -First 1
         if ($prRule) {
           if ([int]$prRule.parameters.required_approving_review_count -ne [int]$config.required_approving_review_count) { $problems.Add("approval-count drift") }
-          if ([bool]$prRule.parameters.require_code_owner_review -ne [bool]$config.require_code_owner_review) { $problems.Add("CODEOWNERS review policy drift") }
+          if ([bool]$prRule.parameters.require_code_owner_review -ne $expectedCodeOwnerReview) { $problems.Add("CODEOWNERS review policy drift") }
           if (-not $prRule.parameters.required_review_thread_resolution) { $problems.Add("review-thread resolution not required") }
           if (@($prRule.parameters.allowed_merge_methods) -notcontains 'squash') { $problems.Add("squash not allowed by PR rule") }
         }
@@ -166,7 +172,7 @@ foreach ($name in $config.repositories) {
           elseif ([int]$requiredCheck.integration_id -ne $actionsAppId) { $problems.Add("PR Gate not bound to GitHub Actions") }
         }
 
-        if ($config.merge_queue.desired -and $meta.owner.type -eq 'Organization' -and $types -notcontains 'merge_queue') { $problems.Add("merge queue missing on eligible repo") }
+        if ($config.merge_queue.desired -and $isOrgOwned -and $types -notcontains 'merge_queue') { $problems.Add("merge queue missing on eligible repo") }
       }
     }
   }
@@ -177,7 +183,7 @@ foreach ($name in $config.repositories) {
     foreach ($problem in $problems) { $remoteFailures.Add("${repo}: $problem") }
   }
 
-  if ($config.merge_queue.desired -and $meta.owner.type -ne "Organization") {
+  if ($config.merge_queue.desired -and -not $isOrgOwned) {
     Write-Host "  merge queue: waiting on transfer to a supported GitHub organization" -ForegroundColor DarkYellow
   }
 }

--- a/scripts/setup-portfolio.ps1
+++ b/scripts/setup-portfolio.ps1
@@ -1,0 +1,33 @@
+param(
+  [switch]$SkipProject
+)
+
+$ErrorActionPreference = 'Stop'
+$here = $PSScriptRoot
+
+foreach ($cmd in @('gh','git','pwsh')) {
+  if (-not (Get-Command $cmd -ErrorAction SilentlyContinue)) { throw "$cmd is required." }
+}
+
+& gh auth status | Out-Host
+if ($LASTEXITCODE -ne 0) { throw 'Authenticate first with: gh auth login' }
+
+Write-Host "`n1/3 Applying repository settings, Actions, labels, and branch rules..." -ForegroundColor Cyan
+& pwsh -NoProfile -File (Join-Path $here 'apply-github-standard.ps1')
+if ($LASTEXITCODE -ne 0) { throw 'GitHub standard application failed.' }
+
+if (-not $SkipProject) {
+  Write-Host "`n2/3 Syncing the optional Agentic Portfolio project..." -ForegroundColor Cyan
+  & pwsh -NoProfile -File (Join-Path $here 'sync-agentic-project.ps1')
+  if ($LASTEXITCODE -ne 0) {
+    Write-Warning 'Project sync failed. If gh reports a missing project scope, run: gh auth refresh -s project, then rerun this script.'
+  }
+} else {
+  Write-Host "`n2/3 Project sync skipped." -ForegroundColor DarkGray
+}
+
+Write-Host "`n3/3 Verifying effective remote state..." -ForegroundColor Cyan
+& pwsh -NoProfile -File (Join-Path $here 'doctor.ps1') -Remote
+if ($LASTEXITCODE -ne 0) { throw 'Remote doctor found configuration drift. Fix the reported item, then rerun this script.' }
+
+Write-Host "`nPORTFOLIO CONTROL PLANE: READY" -ForegroundColor Green


### PR DESCRIPTION
Closes #5

Final control-plane hardening:
- doctor validates effective CODEOWNERS ownership using final-rule semantics
- CODEOWNERS maps the workflow and gate-control entrypoints without forcing all product tests behind human approval
- current single-developer personal-account repos keep Code Owner approval advisory to avoid self-review deadlock
- org-owned repos automatically harden to required Code Owner review and remain merge-queue/required-workflow ready
- bootstrap guidance requires each new repo to protect the small stack-specific entrypoints that could make PR Gate falsely green

No product behavior change.

Risk: R3 control-plane change. Fresh external Codex review required on the final head before merge.