### PR TITLE
docs: add PROP-NNN, test-evidence prefixes, and branch-naming convention

### DIFF
--- a/DELIVERY_GITHUB.md
+++ b/DELIVERY_GITHUB.md
@@ -14,6 +14,8 @@ Prefer:
 
 Do not make PRs artificially large to save CI minutes. Save minutes by verifying slices locally, pushing less often, canceling superseded runs, caching, and reserving expensive assurance for changes that justify it.
 
+Name short-lived branches `<type>/<issue-number>-<short-description>` so each branch traces directly to its Issue (for example `feat/42-optional-sections`, `fix/81-router-timeout`, `chore/105-ci-cache`).
+
 ## 2. Required PR Gate
 
 Every managed repository exposes one stable required status context named **`PR Gate`**.

--- a/QUALITY_RULES.md
+++ b/QUALITY_RULES.md
@@ -26,15 +26,17 @@ Refactor only after required evidence is green.
 
 Typical evidence:
 
-- pure/local logic → unit + property/invariant
-- bug → reproduction + regression
-- API/schema → contract + integration
-- user journey → acceptance/E2E
-- hostile/untrusted input → security/fuzz
-- data migration → data invariants + recovery proof
+- pure/local logic → unit + property/invariant (T-U-NNN / T-P-NNN)
+- bug → reproduction + regression (T-R-NNN)
+- API/schema → contract + integration (T-C-NNN / T-I-NNN)
+- user journey → acceptance/E2E (T-A-NNN / T-E-NNN)
+- hostile/untrusted input → security/fuzz (T-S-NNN)
+- data migration → data invariants (T-P-NNN) + recovery proof
 - risky release → runtime smoke/black-box proof
 
 Do not run every test category for every change.
+
+Use `T-*-NNN` identifiers (unit, property/invariant, integration, contract, end-to-end, security, regression, acceptance) as the durable reference for a piece of test evidence when a slice or spec cites it. `T-M-NNN` records mutation-test evidence for a specific test — proof that the test actually kills an injected mutant — independent of which category the mutated test belongs to.
 
 ## 4. Independent evaluation
 

--- a/templates/ISSUE.md
+++ b/templates/ISSUE.md
@@ -14,6 +14,7 @@ R0 / R1 / R2 / R3 / R4
 
 ## Spec / Slices
 Spec needed: Yes / No
+Properties (if a SPEC exists): PROP-NNN, ...
 
 - [ ] SL-001:
 

--- a/templates/SPEC.md
+++ b/templates/SPEC.md
@@ -11,7 +11,7 @@ Requirement:
 - [ ] 
 
 ## Important Properties / Edge Cases
--
+- PROP-001:
 
 ## Slices
 - [ ] SL-001:


### PR DESCRIPTION
## What changed

Three small, additive documentation/template changes — the exact three gaps a 2026-08-08 read-only audit found when comparing this repo against a separately-pitched "generic lean GitHub standard." The audit confirmed everything else in that generic standard is already implemented here in enforced code (PRD/FR-/NFR-, Issue-as-work-item, SPEC/SL-NNN, R0-R4 risk, CI-minute optimization, risk-aware auto-merge, branch-protection defaults). Nothing else was changed.

1. **`QUALITY_RULES.md`** — mapped the test-evidence categories already described in section 3's prose to letter-code IDs inline: `T-U-NNN` (unit), `T-P-NNN` (property/invariant), `T-I-NNN` (integration), `T-C-NNN` (contract), `T-E-NNN` (end-to-end), `T-S-NNN` (security), `T-R-NNN` (regression), `T-A-NNN` (acceptance). Added a short paragraph defining `T-M-NNN` for mutation-test evidence, which wasn't named anywhere before.
2. **`templates/SPEC.md`** — the free-text "Important Properties / Edge Cases" bullet now reads `- PROP-001:` instead of a bare `-`, giving properties/invariants a durable, numbered identifier a slice or test can cite.
3. **`templates/ISSUE.md`** — added an optional `Properties (if a SPEC exists): PROP-NNN, ...` field under "Spec / Slices" so an Issue can point at the specific properties its linked SPEC defines.
4. **`DELIVERY_GITHUB.md`** — added the formal short-lived-branch naming convention: `type/issue-number-short-description` (examples: `feat/42-optional-sections`, `fix/81-router-timeout`, `chore/105-ci-cache`), right after the existing Issue → SPEC → slices → PR flow description in section 1. This extends the existing "short-lived branch" guidance (in `AGENTS.md`) rather than replacing it — no prose was removed. (Note: the pattern uses angle-bracket placeholders in the actual file, e.g. `&lt;type&gt;/&lt;issue-number&gt;-&lt;short-description&gt;` — see the file diff, not this PR-body rendering, for the exact committed text.)

`README.md` was checked but has no section literally enumerating the naming/identifier vocabulary (PRD/FR/NFR/ADR/Issue/SPEC/SL-NNN), so per the task scope it was left untouched.

## Why

Per the 2026-08-08 lean-GitHub-migration audit: these were the only three genuinely missing pieces that don't contradict anything already in this standard (not a rewrite, not new philosophy — just closing three specific identifier/convention gaps).

## Not changed

`policy/github-defaults.json`, `scripts/*.ps1`, and `.github/workflows/**` are untouched — none of these three additions require code changes, only documentation/template changes.

## Risk: R3 — requires independent review, NOT auto-merge-eligible

This repo's own `.agent/project.yaml` marks `QUALITY_RULES.md`, `DELIVERY_GITHUB.md`, and (by extension) `templates/**` as control-plane / R3-minimum protected paths. Per this repo's own `AGENT_RULES.md` §6 and `DELIVERY_GITHUB.md` §5:

- This PR is **R3** and is explicitly **NOT eligible** for `scripts/auto-merge.ps1`, which caps automated merge at R2.
- It requires a fresh independent semantic review (not from the implementing agent) before merge.
- I have **not** self-approved, enabled auto-merge, or marked this ready for review — it stays **draft** pending that independent review.

## `scripts/doctor.ps1`

I **read** `DELIVERY_GITHUB.md`'s description of what `scripts/doctor.ps1 -Remote` verifies, but did **not run it** — this change touches no policy, script, or workflow file, only prose/templates, so there is no `policy/github-defaults.json` drift for `doctor.ps1` to detect. It was out of scope per the task instructions (do not touch `policy/*`, `scripts/*`, or `.github/workflows/**`), and PowerShell (`pwsh`) is not confirmed available in this Linux agent environment regardless.

## PR template

No `pull_request_template.md` or `.github/PULL_REQUEST_TEMPLATE/` exists in this repo, so this body was written directly against the structure `AGENT_RULES.md`/`DELIVERY_GITHUB.md` ask for (what/why/risk).
