### PR TITLE
fix #8: detect stale legacy required-check contexts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,8 +17,12 @@ jobs:
   pr-gate:
     name: PR Gate
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - name: Test legacy branch-protection logic
+        shell: pwsh
+        run: ./tests/legacy-protection.tests.ps1
       - name: Validate standard
         shell: pwsh
         run: ./scripts/doctor.ps1

--- a/DELIVERY_GITHUB.md
+++ b/DELIVERY_GITHUB.md
@@ -94,8 +94,8 @@ For higher-risk releases, build once, identify the immutable artifact/commit, pr
 
 `policy/github-defaults.json` is the machine-readable portfolio default.
 
-- `scripts/apply-github-standard.ps1` applies repository settings, Actions, labels, and default-branch rules.
+- `scripts/apply-github-standard.ps1` applies repository settings, Actions, labels, and default-branch rules. After the canonical ruleset succeeds, it removes only a stale legacy required-status-check block so retired check names cannot keep a branch unmergeable; all other legacy protections remain untouched.
 - `scripts/auto-merge.ps1` is the risk-aware R0–R2 happy path and refuses R3/R4/control-plane PRs.
-- `scripts/doctor.ps1 -Remote` verifies effective remote policy and exits nonzero on drift.
+- `scripts/doctor.ps1 -Remote` verifies effective remote policy, including the absence of noncanonical legacy required-check contexts, and exits nonzero on drift.
 
 Prefer centrally maintained policy and stable check naming; keep stack-specific test commands inside each product repo.

--- a/scripts/apply-github-standard.ps1
+++ b/scripts/apply-github-standard.ps1
@@ -170,7 +170,7 @@ foreach ($name in $targets) {
     if ($staleContexts.Count -gt 0) {
       $deleteRaw = & gh api --method DELETE "repos/$repo/branches/$($meta.default_branch)/protection/required_status_checks" 2>&1
       if ($LASTEXITCODE -ne 0) {
-        throw "Could not remove stale legacy required checks from $repo: $($deleteRaw -join ' ')"
+        throw "Could not remove stale legacy required checks from ${repo}: $($deleteRaw -join ' ')"
       }
       Write-Host "legacy required checks: removed $($staleContexts -join ', ')" -ForegroundColor Yellow
     }
@@ -184,7 +184,7 @@ foreach ($name in $targets) {
       Write-Host "legacy branch protection: absent"
     }
     else {
-      throw "Could not inspect legacy branch protection for $repo: $legacyError"
+      throw "Could not inspect legacy branch protection for ${repo}: $legacyError"
     }
   }
 }

--- a/scripts/apply-github-standard.ps1
+++ b/scripts/apply-github-standard.ps1
@@ -4,6 +4,7 @@ param(
 )
 
 $ErrorActionPreference = "Stop"
+. (Join-Path $PSScriptRoot 'lib/legacy-protection.ps1')
 
 function Invoke-GhJson {
   param(
@@ -157,6 +158,34 @@ foreach ($name in $targets) {
       Write-Host "ruleset: applied without queue; retry after organization transfer/plan eligibility" -ForegroundColor Yellow
     }
     else { throw }
+  }
+
+  # The canonical ruleset is now active. Remove only a stale legacy required-check
+  # block so retired contexts cannot silently keep the default branch unmergeable.
+  # Other legacy protections (reviews, force-push, deletion, etc.) are untouched.
+  $legacyRaw = & gh api "repos/$repo/branches/$($meta.default_branch)/protection" 2>&1
+  if ($LASTEXITCODE -eq 0) {
+    $legacy = ($legacyRaw -join "`n") | ConvertFrom-Json
+    $staleContexts = @(Get-StaleLegacyRequiredCheckContexts -Protection $legacy -RequiredContext $config.required_status_context)
+    if ($staleContexts.Count -gt 0) {
+      $deleteRaw = & gh api --method DELETE "repos/$repo/branches/$($meta.default_branch)/protection/required_status_checks" 2>&1
+      if ($LASTEXITCODE -ne 0) {
+        throw "Could not remove stale legacy required checks from $repo: $($deleteRaw -join ' ')"
+      }
+      Write-Host "legacy required checks: removed $($staleContexts -join ', ')" -ForegroundColor Yellow
+    }
+    else {
+      Write-Host "legacy required checks: clean"
+    }
+  }
+  else {
+    $legacyError = $legacyRaw -join "`n"
+    if (Test-GitHubBranchProtectionAbsent -ErrorText $legacyError) {
+      Write-Host "legacy branch protection: absent"
+    }
+    else {
+      throw "Could not inspect legacy branch protection for $repo: $legacyError"
+    }
   }
 }
 

--- a/scripts/doctor.ps1
+++ b/scripts/doctor.ps1
@@ -5,6 +5,7 @@ param(
 
 $ErrorActionPreference = "Stop"
 $root = (Resolve-Path (Join-Path $PSScriptRoot "..")).Path
+. (Join-Path $PSScriptRoot 'lib/legacy-protection.ps1')
 
 function Test-CodeownersTail {
   param(
@@ -31,7 +32,8 @@ $required = @(
   "AGENTS.md", ".github/CODEOWNERS", "policy/github-defaults.json",
   "scripts/setup-portfolio.ps1", "scripts/apply-github-standard.ps1", "scripts/sync-agentic-project.ps1",
   "scripts/codex-review.ps1", "scripts/auto-merge.ps1",
-  "scripts/bootstrap-repo.ps1", "scripts/upgrade-repos.ps1",
+  "scripts/bootstrap-repo.ps1", "scripts/upgrade-repos.ps1", "scripts/lib/legacy-protection.ps1",
+  "tests/legacy-protection.tests.ps1",
   ".github/workflows/ci.yml", "templates/AGENTS.md", "templates/CODEOWNERS", "templates/PR_GATE.yml",
   "templates/PRD.md", "templates/SPEC.md", "templates/ADR.md",
   "templates/ISSUE.md", "templates/PULL_REQUEST.md"
@@ -79,7 +81,8 @@ if (-not (Test-CodeownersTail -Content $localTemplateCodeowners -ExpectedTail $a
 $psScripts = @(
   "scripts/setup-portfolio.ps1", "scripts/apply-github-standard.ps1", "scripts/sync-agentic-project.ps1",
   "scripts/codex-review.ps1", "scripts/auto-merge.ps1",
-  "scripts/bootstrap-repo.ps1", "scripts/upgrade-repos.ps1", "scripts/doctor.ps1"
+  "scripts/bootstrap-repo.ps1", "scripts/upgrade-repos.ps1", "scripts/doctor.ps1",
+  "scripts/lib/legacy-protection.ps1", "tests/legacy-protection.tests.ps1"
 )
 foreach ($relative in $psScripts) {
   $tokens = $null
@@ -174,6 +177,20 @@ foreach ($name in $config.repositories) {
 
         if ($config.merge_queue.desired -and $isOrgOwned -and $types -notcontains 'merge_queue') { $problems.Add("merge queue missing on eligible repo") }
       }
+    }
+  }
+
+  $legacyRaw = & gh api "repos/$repo/branches/$($meta.default_branch)/protection" 2>&1
+  if ($LASTEXITCODE -eq 0) {
+    $legacy = ($legacyRaw -join "`n") | ConvertFrom-Json
+    foreach ($context in @(Get-StaleLegacyRequiredCheckContexts -Protection $legacy -RequiredContext $config.required_status_context)) {
+      $problems.Add("stale legacy required check: $context")
+    }
+  }
+  else {
+    $legacyError = $legacyRaw -join "`n"
+    if (-not (Test-GitHubBranchProtectionAbsent -ErrorText $legacyError)) {
+      $problems.Add("cannot read legacy branch protection")
     }
   }
 

--- a/scripts/lib/legacy-protection.ps1
+++ b/scripts/lib/legacy-protection.ps1
@@ -1,7 +1,29 @@
 function Get-LegacyRequiredCheckContexts {
   param([AllowNull()]$Protection)
 
-  return @()
+  if ($null -eq $Protection -or $null -eq $Protection.required_status_checks) {
+    return @()
+  }
+
+  $seen = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::Ordinal)
+  $contexts = [System.Collections.Generic.List[string]]::new()
+
+  foreach ($candidate in @($Protection.required_status_checks.contexts)) {
+    $context = [string]$candidate
+    if (-not [string]::IsNullOrWhiteSpace($context) -and $seen.Add($context)) {
+      $contexts.Add($context)
+    }
+  }
+
+  foreach ($check in @($Protection.required_status_checks.checks)) {
+    if ($null -eq $check) { continue }
+    $context = [string]$check.context
+    if (-not [string]::IsNullOrWhiteSpace($context) -and $seen.Add($context)) {
+      $contexts.Add($context)
+    }
+  }
+
+  return @($contexts)
 }
 
 function Get-StaleLegacyRequiredCheckContexts {
@@ -10,5 +32,14 @@ function Get-StaleLegacyRequiredCheckContexts {
     [Parameter(Mandatory)][string]$RequiredContext
   )
 
-  return @()
+  return @(
+    Get-LegacyRequiredCheckContexts -Protection $Protection |
+      Where-Object { $_ -cne $RequiredContext }
+  )
+}
+
+function Test-GitHubBranchProtectionAbsent {
+  param([AllowEmptyString()][string]$ErrorText)
+
+  return $ErrorText -match '(?i)(\b404\b|branch not protected)'
 }

--- a/scripts/lib/legacy-protection.ps1
+++ b/scripts/lib/legacy-protection.ps1
@@ -41,5 +41,5 @@ function Get-StaleLegacyRequiredCheckContexts {
 function Test-GitHubBranchProtectionAbsent {
   param([AllowEmptyString()][string]$ErrorText)
 
-  return $ErrorText -match '(?i)(\b404\b|branch not protected)'
+  return ($ErrorText -match '(?i)branch not protected') -and ($ErrorText -match '\b404\b')
 }

--- a/scripts/lib/legacy-protection.ps1
+++ b/scripts/lib/legacy-protection.ps1
@@ -1,0 +1,14 @@
+function Get-LegacyRequiredCheckContexts {
+  param([AllowNull()]$Protection)
+
+  return @()
+}
+
+function Get-StaleLegacyRequiredCheckContexts {
+  param(
+    [AllowNull()]$Protection,
+    [Parameter(Mandatory)][string]$RequiredContext
+  )
+
+  return @()
+}

--- a/tests/legacy-protection.tests.ps1
+++ b/tests/legacy-protection.tests.ps1
@@ -61,6 +61,9 @@ Assert-Sequence -Name 'accepts absent legacy protection' `
 Assert-True -Name 'recognizes branch-not-protected 404' `
   -Condition (Test-GitHubBranchProtectionAbsent -ErrorText 'gh: Branch not protected (HTTP 404)')
 
+Assert-True -Name 'does not hide an unrelated not-found response' `
+  -Condition (-not (Test-GitHubBranchProtectionAbsent -ErrorText 'gh: Not Found (HTTP 404)'))
+
 Assert-True -Name 'does not hide an authorization failure' `
   -Condition (-not (Test-GitHubBranchProtectionAbsent -ErrorText 'gh: Resource not accessible (HTTP 403)'))
 

--- a/tests/legacy-protection.tests.ps1
+++ b/tests/legacy-protection.tests.ps1
@@ -16,6 +16,15 @@ function Assert-Sequence {
   }
 }
 
+function Assert-True {
+  param(
+    [Parameter(Mandatory)][string]$Name,
+    [Parameter(Mandatory)][bool]$Condition
+  )
+
+  if (-not $Condition) { throw "$Name failed." }
+}
+
 $mixed = [pscustomobject]@{
   required_status_checks = [pscustomobject]@{
     contexts = @('PR Gate', 'test')
@@ -48,5 +57,11 @@ Assert-Sequence -Name 'accepts canonical context alone' `
 Assert-Sequence -Name 'accepts absent legacy protection' `
   -Actual @(Get-StaleLegacyRequiredCheckContexts -Protection $null -RequiredContext 'PR Gate') `
   -Expected @()
+
+Assert-True -Name 'recognizes branch-not-protected 404' `
+  -Condition (Test-GitHubBranchProtectionAbsent -ErrorText 'gh: Branch not protected (HTTP 404)')
+
+Assert-True -Name 'does not hide an authorization failure' `
+  -Condition (-not (Test-GitHubBranchProtectionAbsent -ErrorText 'gh: Resource not accessible (HTTP 403)'))
 
 Write-Host 'legacy-protection tests: PASS' -ForegroundColor Green

--- a/tests/legacy-protection.tests.ps1
+++ b/tests/legacy-protection.tests.ps1
@@ -1,0 +1,52 @@
+$ErrorActionPreference = 'Stop'
+$root = (Resolve-Path (Join-Path $PSScriptRoot '..')).Path
+. (Join-Path $root 'scripts/lib/legacy-protection.ps1')
+
+function Assert-Sequence {
+  param(
+    [Parameter(Mandatory)][string]$Name,
+    [AllowEmptyCollection()][object[]]$Actual,
+    [AllowEmptyCollection()][object[]]$Expected
+  )
+
+  $actualText = @($Actual) -join ','
+  $expectedText = @($Expected) -join ','
+  if ($actualText -ne $expectedText) {
+    throw "$Name failed. Expected [$expectedText], got [$actualText]."
+  }
+}
+
+$mixed = [pscustomobject]@{
+  required_status_checks = [pscustomobject]@{
+    contexts = @('PR Gate', 'test')
+    checks = @(
+      [pscustomobject]@{ context = 'quality'; app_id = 1 },
+      [pscustomobject]@{ context = 'test'; app_id = 2 }
+    )
+  }
+}
+
+Assert-Sequence -Name 'extracts unique contexts from both GitHub shapes' `
+  -Actual @(Get-LegacyRequiredCheckContexts -Protection $mixed) `
+  -Expected @('PR Gate', 'test', 'quality')
+
+Assert-Sequence -Name 'reports every noncanonical legacy context' `
+  -Actual @(Get-StaleLegacyRequiredCheckContexts -Protection $mixed -RequiredContext 'PR Gate') `
+  -Expected @('test', 'quality')
+
+$canonicalOnly = [pscustomobject]@{
+  required_status_checks = [pscustomobject]@{
+    contexts = @('PR Gate')
+    checks = @()
+  }
+}
+
+Assert-Sequence -Name 'accepts canonical context alone' `
+  -Actual @(Get-StaleLegacyRequiredCheckContexts -Protection $canonicalOnly -RequiredContext 'PR Gate') `
+  -Expected @()
+
+Assert-Sequence -Name 'accepts absent legacy protection' `
+  -Actual @(Get-StaleLegacyRequiredCheckContexts -Protection $null -RequiredContext 'PR Gate') `
+  -Expected @()
+
+Write-Host 'legacy-protection tests: PASS' -ForegroundColor Green


### PR DESCRIPTION
## Work
Issue: #8
Risk: R3 control-plane change

## What changed
- Added dependency-free PowerShell helpers that read both GitHub legacy required-check shapes (`contexts` and `checks[].context`), preserve unique order, and identify every context other than canonical `PR Gate`.
- `doctor.ps1 -Remote` now reports each stale legacy context by name, treats a real 404/“branch not protected” response as clean, and still reports unreadable protection state.
- `apply-github-standard.ps1` now inspects legacy protection only after the canonical ruleset has succeeded. When stale contexts exist, it deletes only the legacy `required_status_checks` block; reviews, force-push, deletion, and every other legacy protection remain untouched.
- Added a dependency-free test script, local integrity/parse coverage, a five-minute CI timeout, and matching delivery documentation.

## RED evidence
CI run 31275341176 failed on the intended assertion:
`Expected [PR Gate,test,quality], got []`.
The test loaded successfully and failed because behavior was absent.

## GREEN evidence
CI run 31275583138 passed:
- legacy-protection tests: PASS
- local `doctor.ps1`: PASS
- PowerShell parse validation: PASS

A first GREEN attempt exposed a real PowerShell interpolation parser defect (`$repo:`); the two strings were corrected to `${repo}:`, after which the gate passed.

## Safety boundaries
- Cleanup runs only after successful canonical ruleset reconciliation.
- Only the legacy required-status-check subresource is deleted, and only when a noncanonical context exists.
- Legacy `PR Gate` alone is accepted.
- No legacy branch-protection rule is also accepted.
- The seven-label lean baseline is unchanged.

## Operational note
This PR implements and verifies the control-plane behavior. It does not claim the authenticated remote reconciliation has already run. After merge, `scripts/setup-portfolio.ps1` remains the authoritative live apply + doctor command.

## Review
Fresh GitHub Copilot code review has been requested after the final substantive push.