### PR TITLE
fix #10: support every live standard-lock schema

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,9 @@ jobs:
       - name: Test legacy branch-protection logic
         shell: pwsh
         run: ./tests/legacy-protection.tests.ps1
+      - name: Test standard-lock upgrades
+        shell: pwsh
+        run: ./tests/standard-lock.tests.ps1
       - name: Validate standard
         shell: pwsh
         run: ./scripts/doctor.ps1

--- a/README.md
+++ b/README.md
@@ -71,6 +71,8 @@ pwsh -File scripts/sync-agentic-project.ps1
 pwsh -File scripts/doctor.ps1 -Remote
 ```
 
+`upgrade-repos.ps1` preserves each existing `.agent/standard.lock` revision key and supports the three live schemas: `sha`, `commit`, and `standard_commit`. It refuses a missing or ambiguous revision field rather than guessing.
+
 `policy/github-defaults.json` is the machine-readable portfolio policy.
 
 ## GitHub default

--- a/scripts/doctor.ps1
+++ b/scripts/doctor.ps1
@@ -32,8 +32,9 @@ $required = @(
   "AGENTS.md", ".github/CODEOWNERS", "policy/github-defaults.json",
   "scripts/setup-portfolio.ps1", "scripts/apply-github-standard.ps1", "scripts/sync-agentic-project.ps1",
   "scripts/codex-review.ps1", "scripts/auto-merge.ps1",
-  "scripts/bootstrap-repo.ps1", "scripts/upgrade-repos.ps1", "scripts/lib/legacy-protection.ps1",
-  "tests/legacy-protection.tests.ps1",
+  "scripts/bootstrap-repo.ps1", "scripts/upgrade-repos.ps1",
+  "scripts/lib/legacy-protection.ps1", "scripts/lib/standard-lock.ps1",
+  "tests/legacy-protection.tests.ps1", "tests/standard-lock.tests.ps1",
   ".github/workflows/ci.yml", "templates/AGENTS.md", "templates/CODEOWNERS", "templates/PR_GATE.yml",
   "templates/PRD.md", "templates/SPEC.md", "templates/ADR.md",
   "templates/ISSUE.md", "templates/PULL_REQUEST.md"
@@ -82,7 +83,8 @@ $psScripts = @(
   "scripts/setup-portfolio.ps1", "scripts/apply-github-standard.ps1", "scripts/sync-agentic-project.ps1",
   "scripts/codex-review.ps1", "scripts/auto-merge.ps1",
   "scripts/bootstrap-repo.ps1", "scripts/upgrade-repos.ps1", "scripts/doctor.ps1",
-  "scripts/lib/legacy-protection.ps1", "tests/legacy-protection.tests.ps1"
+  "scripts/lib/legacy-protection.ps1", "scripts/lib/standard-lock.ps1",
+  "tests/legacy-protection.tests.ps1", "tests/standard-lock.tests.ps1"
 )
 foreach ($relative in $psScripts) {
   $tokens = $null

--- a/scripts/lib/standard-lock.ps1
+++ b/scripts/lib/standard-lock.ps1
@@ -43,3 +43,29 @@ function Update-StandardLockContent {
   $pinnedAtReplacement = $pinnedAtMatch.Groups['prefix'].Value + '"' + $PinnedAt + '"' + $pinnedAtMatch.Groups['suffix'].Value
   return $updated.Substring(0, $pinnedAtMatch.Index) + $pinnedAtReplacement + $updated.Substring($pinnedAtMatch.Index + $pinnedAtMatch.Length)
 }
+
+function Update-StandardProjectContent {
+  param(
+    [Parameter(Mandatory)][string]$Content,
+    [Parameter(Mandatory)][string]$PreviousStandardSha,
+    [Parameter(Mandatory)][string]$StandardSha
+  )
+
+  foreach ($candidate in @($PreviousStandardSha, $StandardSha)) {
+    if ($candidate -notmatch '^[0-9a-fA-F]{40}$') {
+      throw 'Project standard revisions must be full 40-character commit SHAs.'
+    }
+  }
+
+  $escapedPreviousSha = [regex]::Escape($PreviousStandardSha)
+  $pattern = "(?m)^(?<prefix>\s*(?:sha|standard_sha|standard_commit|commit):\s*)$escapedPreviousSha(?<suffix>\s*(?:#.*)?)$"
+  $matches = [regex]::Matches($Content, $pattern)
+  if ($matches.Count -gt 1) {
+    throw "project.yaml contains more than one reference to the previous standard revision; found $($matches.Count)."
+  }
+  if ($matches.Count -eq 0) { return $Content }
+
+  $match = $matches[0]
+  $replacement = $match.Groups['prefix'].Value + $StandardSha + $match.Groups['suffix'].Value
+  return $Content.Substring(0, $match.Index) + $replacement + $Content.Substring($match.Index + $match.Length)
+}

--- a/scripts/lib/standard-lock.ps1
+++ b/scripts/lib/standard-lock.ps1
@@ -1,7 +1,7 @@
 function Get-StandardLockRevisionMatch {
   param([Parameter(Mandatory)][string]$Content)
 
-  $revisionPattern = '(?m)^(?<prefix>[ \t]*(?:sha|commit|standard_commit):[ \t]*)(?<value>[0-9a-fA-F]{40})(?<suffix>[ \t]*(?:#.*)?)$'
+  $revisionPattern = '(?m)^(?<prefix>[ \t]*(?:sha|commit|standard_commit):[ \t]*)(?<value>[0-9a-fA-F]{40})(?<suffix>[ \t]*(?:#.*)?\r?)$'
   $revisionMatches = [regex]::Matches($Content, $revisionPattern)
   if ($revisionMatches.Count -ne 1) {
     throw "standard.lock must contain exactly one sha, commit, or standard_commit field; found $($revisionMatches.Count)."
@@ -33,7 +33,7 @@ function Update-StandardLockContent {
   $revisionReplacement = $revision.Groups['prefix'].Value + $StandardSha + $revision.Groups['suffix'].Value
   $updated = $Content.Substring(0, $revision.Index) + $revisionReplacement + $Content.Substring($revision.Index + $revision.Length)
 
-  $pinnedAtPattern = '(?m)^(?<prefix>[ \t]*pinned_at:[ \t]*)(?<value>[^#\r\n]*?)(?<suffix>[ \t]*(?:#.*)?)$'
+  $pinnedAtPattern = '(?m)^(?<prefix>[ \t]*pinned_at:[ \t]*)(?<value>[^#\r\n]*?)(?<suffix>[ \t]*(?:#.*)?\r?)$'
   $pinnedAtMatches = [regex]::Matches($updated, $pinnedAtPattern)
   if ($pinnedAtMatches.Count -ne 1) {
     throw "standard.lock must contain exactly one pinned_at field; found $($pinnedAtMatches.Count)."
@@ -58,7 +58,7 @@ function Update-StandardProjectContent {
   }
 
   $escapedPreviousSha = [regex]::Escape($PreviousStandardSha)
-  $pattern = "(?m)^(?<prefix>\s*(?:sha|standard_sha|standard_commit|commit):\s*)$escapedPreviousSha(?<suffix>\s*(?:#.*)?)$"
+  $pattern = "(?m)^(?<prefix>\s*(?:sha|standard_sha|standard_commit|commit):\s*)$escapedPreviousSha(?<suffix>\s*(?:#.*)?\r?)$"
   $matches = [regex]::Matches($Content, $pattern)
   if ($matches.Count -gt 1) {
     throw "project.yaml contains more than one reference to the previous standard revision; found $($matches.Count)."

--- a/scripts/lib/standard-lock.ps1
+++ b/scripts/lib/standard-lock.ps1
@@ -1,3 +1,20 @@
+function Get-StandardLockRevisionMatch {
+  param([Parameter(Mandatory)][string]$Content)
+
+  $revisionPattern = '(?m)^(?<prefix>[ \t]*(?:sha|commit|standard_commit):[ \t]*)(?<value>[0-9a-fA-F]{40})(?<suffix>[ \t]*(?:#.*)?)$'
+  $revisionMatches = [regex]::Matches($Content, $revisionPattern)
+  if ($revisionMatches.Count -ne 1) {
+    throw "standard.lock must contain exactly one sha, commit, or standard_commit field; found $($revisionMatches.Count)."
+  }
+  return $revisionMatches[0]
+}
+
+function Get-StandardLockRevision {
+  param([Parameter(Mandatory)][string]$Content)
+
+  return (Get-StandardLockRevisionMatch -Content $Content).Groups['value'].Value
+}
+
 function Update-StandardLockContent {
   param(
     [Parameter(Mandatory)][string]$Content,
@@ -12,13 +29,7 @@ function Update-StandardLockContent {
     throw 'PinnedAt must use YYYY-MM-DD.'
   }
 
-  $revisionPattern = '(?m)^(?<prefix>[ \t]*(?:sha|commit|standard_commit):[ \t]*)(?<value>[0-9a-fA-F]{40})(?<suffix>[ \t]*(?:#.*)?)$'
-  $revisionMatches = [regex]::Matches($Content, $revisionPattern)
-  if ($revisionMatches.Count -ne 1) {
-    throw "standard.lock must contain exactly one sha, commit, or standard_commit field; found $($revisionMatches.Count)."
-  }
-
-  $revision = $revisionMatches[0]
+  $revision = Get-StandardLockRevisionMatch -Content $Content
   $revisionReplacement = $revision.Groups['prefix'].Value + $StandardSha + $revision.Groups['suffix'].Value
   $updated = $Content.Substring(0, $revision.Index) + $revisionReplacement + $Content.Substring($revision.Index + $revision.Length)
 

--- a/scripts/lib/standard-lock.ps1
+++ b/scripts/lib/standard-lock.ps1
@@ -5,5 +5,30 @@ function Update-StandardLockContent {
     [Parameter(Mandatory)][string]$PinnedAt
   )
 
-  return $Content
+  if ($StandardSha -notmatch '^[0-9a-fA-F]{40}$') {
+    throw 'StandardSha must be a full 40-character commit SHA.'
+  }
+  if ($PinnedAt -notmatch '^\d{4}-\d{2}-\d{2}$') {
+    throw 'PinnedAt must use YYYY-MM-DD.'
+  }
+
+  $revisionPattern = '(?m)^(?<prefix>[ \t]*(?:sha|commit|standard_commit):[ \t]*)(?<value>[0-9a-fA-F]{40})(?<suffix>[ \t]*(?:#.*)?)$'
+  $revisionMatches = [regex]::Matches($Content, $revisionPattern)
+  if ($revisionMatches.Count -ne 1) {
+    throw "standard.lock must contain exactly one sha, commit, or standard_commit field; found $($revisionMatches.Count)."
+  }
+
+  $revision = $revisionMatches[0]
+  $revisionReplacement = $revision.Groups['prefix'].Value + $StandardSha + $revision.Groups['suffix'].Value
+  $updated = $Content.Substring(0, $revision.Index) + $revisionReplacement + $Content.Substring($revision.Index + $revision.Length)
+
+  $pinnedAtPattern = '(?m)^(?<prefix>[ \t]*pinned_at:[ \t]*)(?<value>[^#\r\n]*?)(?<suffix>[ \t]*(?:#.*)?)$'
+  $pinnedAtMatches = [regex]::Matches($updated, $pinnedAtPattern)
+  if ($pinnedAtMatches.Count -ne 1) {
+    throw "standard.lock must contain exactly one pinned_at field; found $($pinnedAtMatches.Count)."
+  }
+
+  $pinnedAtMatch = $pinnedAtMatches[0]
+  $pinnedAtReplacement = $pinnedAtMatch.Groups['prefix'].Value + '"' + $PinnedAt + '"' + $pinnedAtMatch.Groups['suffix'].Value
+  return $updated.Substring(0, $pinnedAtMatch.Index) + $pinnedAtReplacement + $updated.Substring($pinnedAtMatch.Index + $pinnedAtMatch.Length)
 }

--- a/scripts/lib/standard-lock.ps1
+++ b/scripts/lib/standard-lock.ps1
@@ -1,0 +1,9 @@
+function Update-StandardLockContent {
+  param(
+    [Parameter(Mandatory)][string]$Content,
+    [Parameter(Mandatory)][string]$StandardSha,
+    [Parameter(Mandatory)][string]$PinnedAt
+  )
+
+  return $Content
+}

--- a/scripts/upgrade-repos.ps1
+++ b/scripts/upgrade-repos.ps1
@@ -41,6 +41,7 @@ foreach ($name in $config.repositories) {
       if ($LASTEXITCODE -ne 0) { throw 'branch creation failed' }
 
       $lock = '.agent/standard.lock'
+      $previousStandardSha = $null
       if (-not (Test-Path $lock)) {
         New-Item -ItemType Directory -Force '.agent' | Out-Null
         @"
@@ -52,14 +53,17 @@ pinned_by: upgrade-repos.ps1
       }
       else {
         $text = Get-Content $lock -Raw
+        $previousStandardSha = Get-StandardLockRevision -Content $text
         $text = Update-StandardLockContent -Content $text -StandardSha $StandardSha -PinnedAt $pinnedAt
         Set-Content $lock $text -Encoding utf8 -NoNewline
       }
 
       $project = '.agent/project.yaml'
-      if (Test-Path $project) {
+      if ((Test-Path $project) -and $previousStandardSha) {
         $p = Get-Content $project -Raw
-        $p = [regex]::Replace($p, '(?m)^(\s*(?:sha|standard_sha|standard_commit|commit):\s*)[0-9a-fA-F]{40}(\s*(?:#.*)?)$', "`$1$StandardSha`$2")
+        $escapedPreviousSha = [regex]::Escape($previousStandardSha)
+        $pattern = "(?m)^(\s*(?:sha|standard_sha|standard_commit|commit):\s*)$escapedPreviousSha(\s*(?:#.*)?)$"
+        $p = [regex]::Replace($p, $pattern, "`$1$StandardSha`$2")
         Set-Content $project $p -Encoding utf8 -NoNewline
       }
 

--- a/scripts/upgrade-repos.ps1
+++ b/scripts/upgrade-repos.ps1
@@ -4,6 +4,8 @@ param(
 )
 
 $ErrorActionPreference = 'Stop'
+. (Join-Path $PSScriptRoot 'lib/standard-lock.ps1')
+
 foreach ($cmd in @('gh','git')) {
   if (-not (Get-Command $cmd -ErrorAction SilentlyContinue)) { throw "$cmd is required." }
 }
@@ -20,6 +22,7 @@ if ($StandardSha -notmatch '^[0-9a-fA-F]{40}$') { throw 'StandardSha must be a f
 $config = Get-Content $ConfigPath -Raw | ConvertFrom-Json
 $owner = $config.owner
 $short = $StandardSha.Substring(0,8)
+$pinnedAt = Get-Date -Format yyyy-MM-dd
 
 foreach ($name in $config.repositories) {
   if ($name -eq 'agent-engineering-standard') { continue }
@@ -43,25 +46,21 @@ foreach ($name in $config.repositories) {
         @"
 standard: $owner/agent-engineering-standard
 commit: $StandardSha
-pinned_at: "$(Get-Date -Format yyyy-MM-dd)"
+pinned_at: "$pinnedAt"
 pinned_by: upgrade-repos.ps1
-"@ | Set-Content $lock -Encoding utf8
+"@ | Set-Content $lock -Encoding utf8 -NoNewline
       }
       else {
         $text = Get-Content $lock -Raw
-        if ($text -notmatch '(?m)^commit:\s*[0-9a-fA-F]{40}\s*$') {
-          throw 'Unrecognized standard.lock format; refusing to guess.'
-        }
-        $text = [regex]::Replace($text, '(?m)^commit:\s*[0-9a-fA-F]{40}\s*$', "commit: $StandardSha")
-        $text = [regex]::Replace($text, '(?m)^pinned_at:.*$', "pinned_at: `"$(Get-Date -Format yyyy-MM-dd)`"")
-        Set-Content $lock $text -Encoding utf8
+        $text = Update-StandardLockContent -Content $text -StandardSha $StandardSha -PinnedAt $pinnedAt
+        Set-Content $lock $text -Encoding utf8 -NoNewline
       }
 
       $project = '.agent/project.yaml'
       if (Test-Path $project) {
         $p = Get-Content $project -Raw
-        $p = [regex]::Replace($p, '(?m)^(\s*(?:sha|standard_sha|commit):\s*)[0-9a-fA-F]{40}(\s*(?:#.*)?)$', "`$1$StandardSha`$2")
-        Set-Content $project $p -Encoding utf8
+        $p = [regex]::Replace($p, '(?m)^(\s*(?:sha|standard_sha|standard_commit|commit):\s*)[0-9a-fA-F]{40}(\s*(?:#.*)?)$', "`$1$StandardSha`$2")
+        Set-Content $project $p -Encoding utf8 -NoNewline
       }
 
       $paths = @($lock)

--- a/scripts/upgrade-repos.ps1
+++ b/scripts/upgrade-repos.ps1
@@ -61,9 +61,7 @@ pinned_by: upgrade-repos.ps1
       $project = '.agent/project.yaml'
       if ((Test-Path $project) -and $previousStandardSha) {
         $p = Get-Content $project -Raw
-        $escapedPreviousSha = [regex]::Escape($previousStandardSha)
-        $pattern = "(?m)^(\s*(?:sha|standard_sha|standard_commit|commit):\s*)$escapedPreviousSha(\s*(?:#.*)?)$"
-        $p = [regex]::Replace($p, $pattern, "`$1$StandardSha`$2")
+        $p = Update-StandardProjectContent -Content $p -PreviousStandardSha $previousStandardSha -StandardSha $StandardSha
         Set-Content $project $p -Encoding utf8 -NoNewline
       }
 

--- a/tests/standard-lock.tests.ps1
+++ b/tests/standard-lock.tests.ps1
@@ -86,6 +86,52 @@ Assert-Equal -Name 'updates standard_commit schema' `
   -Actual (Update-StandardLockContent -Content $standardCommitLock -StandardSha $new -PinnedAt $date) `
   -Expected $standardCommitExpected
 
+$projectStandardSha = @"
+project:
+  name: app
+  standard_sha: $old
+other:
+  commit: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+"@
+$projectStandardShaExpected = @"
+project:
+  name: app
+  standard_sha: $new
+other:
+  commit: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+"@
+Assert-Equal -Name 'updates only matching standard_sha project metadata' `
+  -Actual (Update-StandardProjectContent -Content $projectStandardSha -PreviousStandardSha $old -StandardSha $new) `
+  -Expected $projectStandardShaExpected
+
+$projectNestedSha = @"
+standard:
+  repo: kgsmith19/agent-engineering-standard
+  sha: $old
+runtime:
+  image_sha: bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+"@
+$projectNestedShaExpected = @"
+standard:
+  repo: kgsmith19/agent-engineering-standard
+  sha: $new
+runtime:
+  image_sha: bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+"@
+Assert-Equal -Name 'updates matching nested sha project metadata' `
+  -Actual (Update-StandardProjectContent -Content $projectNestedSha -PreviousStandardSha $old -StandardSha $new) `
+  -Expected $projectNestedShaExpected
+
+$projectUnrelated = @"
+standard:
+  repo: kgsmith19/agent-engineering-standard
+other:
+  commit: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+"@
+Assert-Equal -Name 'leaves unrelated project commit unchanged' `
+  -Actual (Update-StandardProjectContent -Content $projectUnrelated -PreviousStandardSha $old -StandardSha $new) `
+  -Expected $projectUnrelated
+
 Assert-Throws -Name 'refuses missing revision field' -Action {
   Update-StandardLockContent -Content "revision: $old`npinned_at: 2026-08-08" -StandardSha $new -PinnedAt $date
 }
@@ -100,6 +146,10 @@ Assert-Throws -Name 'refuses missing pinned_at field' -Action {
 
 Assert-Throws -Name 'refuses invalid target SHA' -Action {
   Update-StandardLockContent -Content $commitLock -StandardSha 'not-a-sha' -PinnedAt $date
+}
+
+Assert-Throws -Name 'refuses ambiguous project references' -Action {
+  Update-StandardProjectContent -Content "sha: $old`nstandard_sha: $old" -PreviousStandardSha $old -StandardSha $new
 }
 
 Write-Host 'standard-lock tests: PASS' -ForegroundColor Green

--- a/tests/standard-lock.tests.ps1
+++ b/tests/standard-lock.tests.ps1
@@ -1,0 +1,96 @@
+$ErrorActionPreference = 'Stop'
+$root = (Resolve-Path (Join-Path $PSScriptRoot '..')).Path
+. (Join-Path $root 'scripts/lib/standard-lock.ps1')
+
+function Assert-Equal {
+  param(
+    [Parameter(Mandatory)][string]$Name,
+    [AllowEmptyString()][string]$Actual,
+    [AllowEmptyString()][string]$Expected
+  )
+
+  if ($Actual -cne $Expected) {
+    throw "$Name failed.`nEXPECTED:`n$Expected`nACTUAL:`n$Actual"
+  }
+}
+
+function Assert-Throws {
+  param(
+    [Parameter(Mandatory)][string]$Name,
+    [Parameter(Mandatory)][scriptblock]$Action
+  )
+
+  try {
+    & $Action | Out-Null
+  }
+  catch {
+    return
+  }
+  throw "$Name failed: expected an exception."
+}
+
+$old = '79ba6aaf18651b1c46f0b81368748fe0e4f8813e'
+$new = '0123456789abcdef0123456789abcdef01234567'
+$date = '2026-08-09'
+
+$shaLock = @"
+standard: kgsmith19/agent-engineering-standard
+sha: $old
+pinned_at: "2026-08-08"
+"@
+$shaExpected = @"
+standard: kgsmith19/agent-engineering-standard
+sha: $new
+pinned_at: "$date"
+"@
+Assert-Equal -Name 'updates sha schema' `
+  -Actual (Update-StandardLockContent -Content $shaLock -StandardSha $new -PinnedAt $date) `
+  -Expected $shaExpected
+
+$commitLock = @"
+repo: https://github.com/kgsmith19/agent-engineering-standard
+commit: $old
+pinned_at: 2026-08-08
+"@
+$commitExpected = @"
+repo: https://github.com/kgsmith19/agent-engineering-standard
+commit: $new
+pinned_at: "$date"
+"@
+Assert-Equal -Name 'updates commit schema' `
+  -Actual (Update-StandardLockContent -Content $commitLock -StandardSha $new -PinnedAt $date) `
+  -Expected $commitExpected
+
+$standardCommitLock = @"
+standard_repo: kgsmith19/agent-engineering-standard
+standard_commit: $old
+pinned_at: 2026-08-08
+pinned_by: lean PR Gate conformance
+"@
+$standardCommitExpected = @"
+standard_repo: kgsmith19/agent-engineering-standard
+standard_commit: $new
+pinned_at: "$date"
+pinned_by: lean PR Gate conformance
+"@
+Assert-Equal -Name 'updates standard_commit schema' `
+  -Actual (Update-StandardLockContent -Content $standardCommitLock -StandardSha $new -PinnedAt $date) `
+  -Expected $standardCommitExpected
+
+Assert-Throws -Name 'refuses missing revision field' -Action {
+  Update-StandardLockContent -Content "revision: $old`npinned_at: 2026-08-08" -StandardSha $new -PinnedAt $date
+}
+
+Assert-Throws -Name 'refuses ambiguous revision fields' -Action {
+  Update-StandardLockContent -Content "sha: $old`ncommit: $old`npinned_at: 2026-08-08" -StandardSha $new -PinnedAt $date
+}
+
+Assert-Throws -Name 'refuses missing pinned_at field' -Action {
+  Update-StandardLockContent -Content "commit: $old" -StandardSha $new -PinnedAt $date
+}
+
+Assert-Throws -Name 'refuses invalid target SHA' -Action {
+  Update-StandardLockContent -Content $commitLock -StandardSha 'not-a-sha' -PinnedAt $date
+}
+
+Write-Host 'standard-lock tests: PASS' -ForegroundColor Green

--- a/tests/standard-lock.tests.ps1
+++ b/tests/standard-lock.tests.ps1
@@ -43,6 +43,9 @@ standard: kgsmith19/agent-engineering-standard
 sha: $new
 pinned_at: "$date"
 "@
+Assert-Equal -Name 'reads sha schema revision' `
+  -Actual (Get-StandardLockRevision -Content $shaLock) `
+  -Expected $old
 Assert-Equal -Name 'updates sha schema' `
   -Actual (Update-StandardLockContent -Content $shaLock -StandardSha $new -PinnedAt $date) `
   -Expected $shaExpected
@@ -57,6 +60,9 @@ repo: https://github.com/kgsmith19/agent-engineering-standard
 commit: $new
 pinned_at: "$date"
 "@
+Assert-Equal -Name 'reads commit schema revision' `
+  -Actual (Get-StandardLockRevision -Content $commitLock) `
+  -Expected $old
 Assert-Equal -Name 'updates commit schema' `
   -Actual (Update-StandardLockContent -Content $commitLock -StandardSha $new -PinnedAt $date) `
   -Expected $commitExpected
@@ -73,6 +79,9 @@ standard_commit: $new
 pinned_at: "$date"
 pinned_by: lean PR Gate conformance
 "@
+Assert-Equal -Name 'reads standard_commit schema revision' `
+  -Actual (Get-StandardLockRevision -Content $standardCommitLock) `
+  -Expected $old
 Assert-Equal -Name 'updates standard_commit schema' `
   -Actual (Update-StandardLockContent -Content $standardCommitLock -StandardSha $new -PinnedAt $date) `
   -Expected $standardCommitExpected
@@ -82,7 +91,7 @@ Assert-Throws -Name 'refuses missing revision field' -Action {
 }
 
 Assert-Throws -Name 'refuses ambiguous revision fields' -Action {
-  Update-StandardLockContent -Content "sha: $old`ncommit: $old`npinned_at: 2026-08-08" -StandardSha $new -PinnedAt $date
+  Get-StandardLockRevision -Content "sha: $old`ncommit: $old`npinned_at: 2026-08-08"
 }
 
 Assert-Throws -Name 'refuses missing pinned_at field' -Action {


### PR DESCRIPTION
## Work
Issue: #10
Risk: R3 control-plane change

## What changed
- Added a strict, dependency-free standard-lock helper that supports the three revision fields currently used by managed repositories: `sha`, `commit`, and `standard_commit`.
- Preserves each repository’s existing key and surrounding lock content; updates only the revision and normalizes `pinned_at` to a quoted `YYYY-MM-DD` value.
- Refuses zero revision fields, multiple revision fields, missing `pinned_at`, invalid target SHAs, and ambiguous project metadata.
- Exposes the exact old pinned revision so `.agent/project.yaml` updates are limited to that same old standard SHA. Unrelated `commit:` or `sha:` metadata remains untouched.
- Updated `upgrade-repos.ps1`, the local doctor integrity contract, CI, tests, and operator documentation.

## RED evidence
CI run 31276334946 failed on the first real portfolio schema:
`updates sha schema failed` — expected the new revision/date, received the unchanged lock content.
The helper loaded successfully; behavior was absent.

## GREEN evidence
Final CI run 31276662686 passed on commit `f6a5328`:
- legacy branch-protection tests: PASS
- all three standard-lock schemas: PASS
- exact old revision extraction: PASS
- missing/ambiguous/invalid refusal cases: PASS
- unrelated project commit preservation: PASS
- PowerShell parse and local doctor: PASS

## Safety boundaries
- Never follows a moving branch; target must be a full 40-character commit SHA.
- Existing lock key is preserved rather than cosmetically normalized.
- Project metadata changes only when a supported key contains the exact previous standard SHA from that repo’s lock.
- More than one matching project reference is a halt, not a bulk replacement.
- No product code or repository quality gate is changed.

## After merge
Fan the exact merged standard commit to all seven product repositories as isolated, reviewable R3 pin-bump PRs. Existing repository gates remain authoritative.

## Review
Fresh GitHub Copilot review requested on the final green head.