### PR TITLE
fix #12: support current standard.lock formats

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,9 @@ jobs:
       - name: Test legacy branch-protection logic
         shell: pwsh
         run: ./tests/legacy-protection.tests.ps1
+      - name: Test standard-lock upgrade logic
+        shell: pwsh
+        run: ./tests/standard-lock.tests.ps1
       - name: Validate standard
         shell: pwsh
         run: ./scripts/doctor.ps1

--- a/scripts/lib/standard-lock.ps1
+++ b/scripts/lib/standard-lock.ps1
@@ -5,6 +5,35 @@ function Update-StandardLockText {
     [Parameter(Mandatory)][string]$PinnedAt
   )
 
-  # RED-first seam. Implementation follows once tests prove the current gap.
-  return $Text
+  if ($StandardSha -notmatch '^[0-9a-fA-F]{40}$') {
+    throw 'StandardSha must be a full 40-character commit SHA.'
+  }
+
+  $commitPattern = '(?m)^(?<prefix>\s*(?:commit|sha|standard_commit):\s*)(?<value>[0-9a-fA-F]{40})(?<suffix>\s*(?:#.*)?)$'
+  $commitRegex = [regex]::new($commitPattern)
+  $matches = $commitRegex.Matches($Text)
+
+  if ($matches.Count -eq 0) {
+    throw 'Unrecognized standard.lock format; expected exactly one commit:, sha:, or standard_commit: line.'
+  }
+  if ($matches.Count -gt 1) {
+    throw 'Ambiguous standard.lock format; found more than one recognized standard commit line.'
+  }
+
+  $updated = $commitRegex.Replace(
+    $Text,
+    { param($match) "$($match.Groups['prefix'].Value)$StandardSha$($match.Groups['suffix'].Value)" },
+    1
+  )
+
+  $dateRegex = [regex]::new('(?m)^(?<prefix>\s*pinned_at:\s*).*$')
+  if ($dateRegex.IsMatch($updated)) {
+    $updated = $dateRegex.Replace(
+      $updated,
+      { param($match) "$($match.Groups['prefix'].Value)`"$PinnedAt`"" },
+      1
+    )
+  }
+
+  return $updated
 }

--- a/scripts/lib/standard-lock.ps1
+++ b/scripts/lib/standard-lock.ps1
@@ -1,0 +1,10 @@
+function Update-StandardLockText {
+  param(
+    [Parameter(Mandatory)][string]$Text,
+    [Parameter(Mandatory)][string]$StandardSha,
+    [Parameter(Mandatory)][string]$PinnedAt
+  )
+
+  # RED-first seam. Implementation follows once tests prove the current gap.
+  return $Text
+}

--- a/scripts/upgrade-repos.ps1
+++ b/scripts/upgrade-repos.ps1
@@ -4,6 +4,8 @@ param(
 )
 
 $ErrorActionPreference = 'Stop'
+. (Join-Path $PSScriptRoot 'lib/standard-lock.ps1')
+
 foreach ($cmd in @('gh','git')) {
   if (-not (Get-Command $cmd -ErrorAction SilentlyContinue)) { throw "$cmd is required." }
 }
@@ -20,6 +22,7 @@ if ($StandardSha -notmatch '^[0-9a-fA-F]{40}$') { throw 'StandardSha must be a f
 $config = Get-Content $ConfigPath -Raw | ConvertFrom-Json
 $owner = $config.owner
 $short = $StandardSha.Substring(0,8)
+$pinnedAt = Get-Date -Format yyyy-MM-dd
 
 foreach ($name in $config.repositories) {
   if ($name -eq 'agent-engineering-standard') { continue }
@@ -43,17 +46,13 @@ foreach ($name in $config.repositories) {
         @"
 standard: $owner/agent-engineering-standard
 commit: $StandardSha
-pinned_at: "$(Get-Date -Format yyyy-MM-dd)"
+pinned_at: "$pinnedAt"
 pinned_by: upgrade-repos.ps1
 "@ | Set-Content $lock -Encoding utf8
       }
       else {
         $text = Get-Content $lock -Raw
-        if ($text -notmatch '(?m)^commit:\s*[0-9a-fA-F]{40}\s*$') {
-          throw 'Unrecognized standard.lock format; refusing to guess.'
-        }
-        $text = [regex]::Replace($text, '(?m)^commit:\s*[0-9a-fA-F]{40}\s*$', "commit: $StandardSha")
-        $text = [regex]::Replace($text, '(?m)^pinned_at:.*$', "pinned_at: `"$(Get-Date -Format yyyy-MM-dd)`"")
+        $text = Update-StandardLockText -Text $text -StandardSha $StandardSha -PinnedAt $pinnedAt
         Set-Content $lock $text -Encoding utf8
       }
 

--- a/tests/standard-lock.tests.ps1
+++ b/tests/standard-lock.tests.ps1
@@ -1,0 +1,58 @@
+$ErrorActionPreference = 'Stop'
+$root = (Resolve-Path (Join-Path $PSScriptRoot '..')).Path
+. (Join-Path $root 'scripts/lib/standard-lock.ps1')
+
+function Assert-Equal {
+  param(
+    [Parameter(Mandatory)][string]$Name,
+    [AllowEmptyString()][string]$Actual,
+    [AllowEmptyString()][string]$Expected
+  )
+  if ($Actual -cne $Expected) {
+    throw "$Name failed.`nEXPECTED:`n$Expected`nACTUAL:`n$Actual"
+  }
+}
+
+function Assert-Throws {
+  param(
+    [Parameter(Mandatory)][string]$Name,
+    [Parameter(Mandatory)][scriptblock]$Action
+  )
+  $threw = $false
+  try { & $Action | Out-Null }
+  catch { $threw = $true }
+  if (-not $threw) { throw "$Name failed: expected an exception." }
+}
+
+$newSha = '1111111111111111111111111111111111111111'
+$oldSha = '2222222222222222222222222222222222222222'
+$date = '2026-08-08'
+
+$cases = @(
+  @{ name = 'commit format'; key = 'commit' },
+  @{ name = 'sha format'; key = 'sha' },
+  @{ name = 'standard_commit format'; key = 'standard_commit' }
+)
+
+foreach ($case in $cases) {
+  $input = "header: keep`n$($case.key): $oldSha`npinned_at: `"2026-01-01`"`ntail: keep`n"
+  $expected = "header: keep`n$($case.key): $newSha`npinned_at: `"$date`"`ntail: keep`n"
+  $actual = Update-StandardLockText -Text $input -StandardSha $newSha -PinnedAt $date
+  Assert-Equal -Name $case.name -Actual $actual -Expected $expected
+}
+
+$inlineComment = "commit: $oldSha # keep me`npinned_at: old`n"
+$expectedInline = "commit: $newSha # keep me`npinned_at: `"$date`"`n"
+Assert-Equal -Name 'preserves inline comment and updates date' `
+  -Actual (Update-StandardLockText -Text $inlineComment -StandardSha $newSha -PinnedAt $date) `
+  -Expected $expectedInline
+
+Assert-Throws -Name 'refuses unknown lock format' -Action {
+  Update-StandardLockText -Text "revision: $oldSha`n" -StandardSha $newSha -PinnedAt $date
+}
+
+Assert-Throws -Name 'refuses ambiguous lock format' -Action {
+  Update-StandardLockText -Text "commit: $oldSha`nsha: $oldSha`n" -StandardSha $newSha -PinnedAt $date
+}
+
+Write-Host 'standard-lock tests: PASS' -ForegroundColor Green


### PR DESCRIPTION
## Work
Issue: #12
Risk: R3 control-plane tooling

## What changed
- Added a tested `Update-StandardLockText` helper supporting the three lock keys already used by managed repos: `commit`, `sha`, and `standard_commit`.
- The helper preserves the original key name and unrelated content, updates `pinned_at` when present, and refuses unknown or ambiguous lock formats.
- `upgrade-repos.ps1` now uses that helper instead of assuming every repo has `commit:`.
- `PR Gate` now runs the focused PowerShell regression tests.

## RED → GREEN evidence
- RED: CI run #72 failed with the intentionally non-working helper seam before implementation.
- GREEN: CI run #74 passed after the helper and `upgrade-repos.ps1` integration were implemented.

## Scope
No repository settings, risk thresholds, merge policy, labels, or product behavior changed. This fixes the advertised standard-upgrade fan-out so it can operate on the lock formats already present across the managed portfolio.

Requires fresh independent semantic review before merge.