### PR TITLE
feat #17: automate cost-aware independent AI review

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,9 @@ jobs:
       - name: Test standard-lock upgrades
         shell: pwsh
         run: ./tests/standard-lock.tests.ps1
+      - name: Test independent review policy
+        shell: pwsh
+        run: ./tests/review-policy.tests.ps1
       - name: Validate standard
         shell: pwsh
         run: ./scripts/doctor.ps1

--- a/AGENT_RULES.md
+++ b/AGENT_RULES.md
@@ -40,10 +40,64 @@ Before retrying, classify the failure as specification/oracle, implementation, e
 
 Do not repeat the same failing strategy indefinitely. Escalate consequential ambiguity rather than forcing a result.
 
-## 6. PR and merge behavior
+## 6. Independent review and merge
 
 Keep a PR draft while implementation is still changing. Run the repo's local/fast verification during slices, then mark the coherent PR ready so the independent `PR Gate` runs.
 
-- R0–R2: once the PR is ready and policy permits, enable auto-merge; required checks/review threads still decide when it actually merges.
-- R3/R4 or control-plane changes: request a fresh independent semantic review after the final substantive push. Do not enable auto-merge until that review has no unresolved material finding.
-- An agent that implemented a control-plane change must never treat its own review as independent.
+**The implementing agent must request a different review agent after the final substantive push.** Do not leave reviewer selection as a human reminder. Use the shared review router when available; otherwise perform the equivalent bounded handoff and record the reviewer provider.
+
+Every auto-merged PR needs a current-head independent AI review. Independence means the reviewer provider did not implement the PR and the reviewer did not inherit the implementation session/context.
+
+Default routing:
+
+- Claude implementation → Codex GitHub review
+- Copilot implementation → Codex GitHub review
+- Codex implementation → one Copilot review; use a fresh Claude session/model/context only if Copilot is unavailable
+- human/unknown implementation → Codex by default
+
+The default reviewer performs **one batched multi-lens pass** rather than spawning several paid reviewers:
+
+1. software correctness/security
+2. business/product outcome and ROI
+3. business systems/operational optimization
+4. leanness/complexity/dead-code/manual-toil review
+
+A second semantic reviewer is justified only when the first review finds material ambiguity, the risk model requires stronger independence, or the primary reviewer is unavailable.
+
+Cost rules:
+
+- deterministic checks run before LLM review
+- Codex is primary; local deep review defaults to `gpt-5.4-mini`
+- at most 2 Codex reviews per PR: initial + one post-fix re-review
+- Copilot is fallback-only, low effort, at most 1 review per PR
+- do not enable Copilot review-on-push or draft review by default
+- do not repeatedly pay for a reviewer because implementation was pushed in noisy micro-commits; keep active work draft and request review after the final substantive push
+
+R0–R3 may auto-merge only after the current head has an independent AI review, required `PR Gate` is live/enforced, and review threads are resolved. Control-plane changes are at least R3; they are not forced through a human approval merely because they are important.
+
+R4 never auto-merges. The manual gate is authorization for destructive/financial/privileged/irreversible consequence, not a substitute for technical review.
+
+## 7. Manual gates must earn their existence
+
+Never add or preserve a manual gate merely because work is "important", "sensitive", or traditionally reviewed by a person.
+
+Every manual gate must state all four:
+
+1. **failure class prevented** — the concrete bad outcome
+2. **why automation is insufficient today** — the missing signal/capability, not a vague trust claim
+3. **decision owner** — who has the authority the machine lacks
+4. **gate removal condition** — the measurable condition that lets us automate/delete the gate
+
+If any field is missing, the gate is unjustified and should be removed or replaced with objective automation.
+
+Manual review is not automatically required for R3. Prefer independent AI review + deterministic controls. Use a manual gate only when a real authority/intent decision cannot yet be safely derived or bounded.
+
+## 8. Turn manual toil into system improvement
+
+When an agent or human performs a manual workaround, ask whether the same work could recur.
+
+- If the automation is small, safe, and in scope: automate it now.
+- Otherwise record one concise automation/research candidate with the observed problem, evidence/frequency, current human cost, research needed, smallest experiment, expected payoff, and deletion/expiry condition.
+- Do not create idea landfill. A candidate without evidence, plausible ROI, or a next experiment is discarded.
+
+Repeated manual work must not become normal merely because an agent can keep doing it.

--- a/SECURITY_RISK_AUTONOMY.md
+++ b/SECURITY_RISK_AUTONOMY.md
@@ -39,17 +39,40 @@ Prefer autonomy when the change is:
 - reversible
 - low blast radius
 
-Require stronger authorization when uncertainty or consequences rise.
+Routine low-risk work should not require human babysitting. R3 is not automatically a human gate: a reversible sensitive change may integrate automatically after deterministic verification plus a current-head independent semantic review from a provider that did not implement it.
 
-Routine low-risk work should not require human babysitting.
+## 4. Manual gates require written justification
 
-## 4. Protect the control plane
+A manual gate is an exception, not a default. Every manual gate must state:
 
-The implementing agent must not modify the evaluator, risk policy, required checks, deployment authority, or other controls governing its current run.
+1. the concrete failure/consequence it prevents
+2. why deterministic checks plus independent agent review cannot safely decide it today
+3. who/what owns the authorization decision
+4. the exact removal condition that lets the gate be automated or deleted
 
-Changes to those controls use a separate authorized path.
+Never keep a gate merely because a change is “important” or “high risk.”
 
-## 5. Security baseline
+Current justified defaults:
+
+- **Control plane:** manual because a PR can modify the evaluator/merge authority judging itself. Remove this gate when enforcement is an immutable external or organization-required workflow the PR cannot edit.
+- **R4 action authorization:** manual because the decision grants destructive, financial, privileged, or irreversible authority. Agent review may still be fully automated; the manual step is authorization, not code review. Remove/reclassify only when the action becomes mechanically bounded and reversible.
+
+## 5. Protect the control plane
+
+The implementing agent must not modify the evaluator, risk policy, required checks, deployment authority, or other controls governing its current run and then use those modified controls to approve itself.
+
+Changes to those controls use a separate authorized path and fresh cross-provider review.
+
+## 6. Independent review
+
+Use the cheapest independent reviewer that satisfies the risk after deterministic checks have run.
+
+- Prefer subscription-backed Codex review; local Codex defaults to a small capable model.
+- Copilot is a bounded fallback, not a review-on-every-push tax.
+- The reviewer provider must differ from the implementation provider to count as independent.
+- Re-review only after a substantive fix that changes the evidence, not for unchanged failures.
+
+## 7. Security baseline
 
 Automate applicable:
 

--- a/docs/adr/0001-independent-review-routing.md
+++ b/docs/adr/0001-independent-review-routing.md
@@ -1,0 +1,25 @@
+# ADR 0001: Cost-aware independent AI review
+
+Status: accepted for implementation in Issue #17
+
+## Decision
+
+Use one cheap, current-head, cross-provider semantic review before automated merge.
+
+- Deterministic evidence runs first.
+- Claude/Copilot implementations prefer Codex review.
+- Codex implementations prefer one Copilot review; a fresh Claude session/model/context is the fallback when available.
+- The default semantic pass batches software/security, business/product, systems/optimization, and leanness lenses into one call.
+- Default budget: at most two Codex passes (initial + one re-review) and one Copilot fallback per PR.
+- Draft churn and every-push Copilot re-review are disabled by default.
+- R0-R3 may auto-merge after current-head independent review plus required GitHub evidence when live policy permits.
+- R4 remains an authorization gate for destructive/financial/privileged/irreversible consequence.
+- A manual gate is invalid unless it states the failure class, why automation is insufficient, decision owner, and removal condition.
+
+## Why
+
+Independent semantic review has value, but multiple paid reviewers on every PR waste time and budget. One batched cross-provider review catches implementation, product, business-system, and complexity problems without multiplying calls. Provider separation reduces correlated implementation/review blind spots.
+
+## Removal / evolution
+
+Change provider/model/budget only from measured quality, latency, and cost evidence. Eliminate remaining manual control-plane review once the governing evaluator and merge authority are external/immutable to the PR being judged.

--- a/policy/github-defaults.json
+++ b/policy/github-defaults.json
@@ -10,8 +10,38 @@
   "merge_method": "squash",
   "allow_auto_merge": true,
   "allow_update_branch": true,
-  "auto_merge_max_risk": "R2",
+  "auto_merge_max_risk": "R3",
   "control_plane_requires_fresh_external_review": true,
+  "independent_review": {
+    "required_for_auto_merge": true,
+    "preferred_provider": "codex",
+    "local_codex_model": "gpt-5.4-mini",
+    "max_codex_reviews_per_pr": 2,
+    "copilot_fallback": true,
+    "copilot_effort": "low",
+    "copilot_review_drafts": false,
+    "copilot_review_on_push": false,
+    "max_copilot_reviews_per_pr": 1,
+    "same_provider_counts_as_independent": false
+  },
+  "manual_gate_required_fields": [
+    "failure_class_prevented",
+    "why_automation_is_insufficient",
+    "decision_owner",
+    "gate_removal_condition"
+  ],
+  "manual_gates": {
+    "control_plane": {
+      "required": true,
+      "reason": "A control-plane PR can modify the evaluator or authority that judges its own merge.",
+      "removal_condition": "Move the governing evaluator and merge authority to an immutable external or organization-required workflow that the PR cannot modify."
+    },
+    "R4": {
+      "required": true,
+      "reason": "The decision authorizes destructive, financial, privileged, or irreversible consequence; review quality alone cannot grant that authority.",
+      "removal_condition": "Replace the irreversible action with a bounded reversible mechanism whose blast radius and rollback are mechanically enforced and reclassify the operation below R4."
+    }
+  },
   "org_hardening": {
     "require_code_owner_review": true,
     "prefer_required_workflow_from_standard_repo": true

--- a/scripts/auto-merge.ps1
+++ b/scripts/auto-merge.ps1
@@ -21,12 +21,8 @@ if ($prInfo.state -ne 'OPEN') { throw "PR #$Pr is not open." }
 if ($prInfo.isDraft) { throw "PR #$Pr is still draft. Finish implementation and mark it ready first." }
 if (@($prInfo.labels | ForEach-Object { $_.name }) -contains 'status:blocked') { throw "Auto-merge refused: PR #$Pr is status:blocked." }
 
-if ($Implementer -eq 'unknown' -and $prInfo.body -match '(?im)^\s*Implementer:\s*(claude|copilot|codex|human)\s*$') {
-  $Implementer = $Matches[1].ToLowerInvariant()
-}
-if ($Implementer -eq 'unknown') {
-  throw "Auto-merge requires an Implementer: claude|copilot|codex|human line in the PR body (or -Implementer explicitly) so reviewer independence can be proven."
-}
+if ($Implementer -eq 'unknown' -and $prInfo.body -match '(?im)^\s*Implementer:\s*(claude|copilot|codex|human)\s*$') { $Implementer = $Matches[1].ToLowerInvariant() }
+if ($Implementer -eq 'unknown') { throw "Auto-merge requires an Implementer: claude|copilot|codex|human line in the PR body (or -Implementer explicitly)." }
 
 $riskNumber = [int]$Risk.Substring(1)
 $maxRisk = [int]([string]$config.auto_merge_max_risk).Substring(1)
@@ -44,16 +40,16 @@ $controlPlanePatterns = @(
 $controlPlane = $Repo -match '/agent-engineering-standard$'
 foreach ($file in $files) { if ($controlPlanePatterns | Where-Object { $file -match $_ }) { $controlPlane = $true; break } }
 if ($controlPlane -and $riskNumber -lt 3) { throw "Auto-merge refused: control-plane changes must declare at least R3." }
-if ($controlPlane -and [bool]$config.manual_gates.control_plane.required) {
-  throw "Auto-merge refused: control-plane gate is currently justified because this PR can modify its own evaluator/authority. Removal condition: $($config.manual_gates.control_plane.removal_condition)"
-}
+if ($controlPlane -and [bool]$config.manual_gates.control_plane.required) { throw "Auto-merge refused: control-plane gate remains justified. Removal condition: $($config.manual_gates.control_plane.removal_condition)" }
 
-# Fail closed unless the live GitHub integration plane is actually enforcing the intended policy.
 $metaRaw = & gh api "repos/$Repo" 2>&1
 if ($LASTEXITCODE -ne 0) { throw "Cannot inspect live repository settings for $Repo." }
 $meta = ($metaRaw -join "`n") | ConvertFrom-Json
 if (-not $meta.allow_auto_merge) { throw "Live GitHub setting drift: auto-merge is off. Run setup-portfolio.ps1." }
 if (-not $meta.allow_squash_merge -or $meta.allow_merge_commit -or $meta.allow_rebase_merge) { throw "Live GitHub merge-method drift: repository is not squash-only. Run setup-portfolio.ps1." }
+$isOrgOwned = $meta.owner.type -eq 'Organization'
+$expectedCodeOwnerReview = [bool]$config.require_code_owner_review
+if ($isOrgOwned -and $config.org_hardening -and [bool]$config.org_hardening.require_code_owner_review) { $expectedCodeOwnerReview = $true }
 
 $actionsAppRaw = & gh api /apps/github-actions 2>&1
 if ($LASTEXITCODE -ne 0) { throw 'Cannot resolve GitHub Actions App identity.' }
@@ -61,8 +57,7 @@ $actionsAppId = [int]((($actionsAppRaw -join "`n") | ConvertFrom-Json).id)
 
 $rulesetsRaw = & gh api "repos/$Repo/rulesets" 2>&1
 if ($LASTEXITCODE -ne 0) { throw "Cannot inspect live rulesets for $Repo." }
-$rulesets = ($rulesetsRaw -join "`n") | ConvertFrom-Json
-$summary = $rulesets | Where-Object { $_.name -eq $config.ruleset_name } | Select-Object -First 1
+$summary = ((($rulesetsRaw -join "`n") | ConvertFrom-Json) | Where-Object { $_.name -eq $config.ruleset_name } | Select-Object -First 1)
 if (-not $summary) { throw "Live ruleset '$($config.ruleset_name)' is missing. Run setup-portfolio.ps1." }
 $detailRaw = & gh api "repos/$Repo/rulesets/$($summary.id)" 2>&1
 if ($LASTEXITCODE -ne 0) { throw "Cannot inspect live ruleset '$($config.ruleset_name)'." }
@@ -73,7 +68,7 @@ if ($detail.bypass_actors -and @($detail.bypass_actors).Count -gt 0) { throw 'Li
 $prRule = $detail.rules | Where-Object { $_.type -eq 'pull_request' } | Select-Object -First 1
 if (-not $prRule) { throw 'Live ruleset does not require pull requests.' }
 if ([int]$prRule.parameters.required_approving_review_count -ne 0) { throw 'Human approval requirement detected; portfolio default must be 0.' }
-if ([bool]$prRule.parameters.require_code_owner_review) { throw 'Required Code Owner review detected on the personal-repo lane.' }
+if ([bool]$prRule.parameters.require_code_owner_review -ne $expectedCodeOwnerReview) { throw 'Code Owner review policy drift detected.' }
 if (-not [bool]$prRule.parameters.required_review_thread_resolution) { throw 'Review-thread resolution is not required; refusing auto-merge.' }
 $methods = @($prRule.parameters.allowed_merge_methods)
 if ($methods.Count -ne 1 -or $methods[0] -ne 'squash') { throw 'Ruleset is not squash-only.' }
@@ -84,18 +79,18 @@ $requiredCheck = @($statusRule.parameters.required_status_checks) | Where-Object
 if (-not $requiredCheck) { throw "Live ruleset does not require '$($config.required_status_context)'." }
 if ([int]$requiredCheck.integration_id -ne $actionsAppId) { throw "Required '$($config.required_status_context)' is not bound to GitHub Actions." }
 
-# Require a current-head reviewer from a different provider.
 $reviewsRaw = & gh api --paginate --slurp "repos/$Repo/pulls/$Pr/reviews?per_page=100" 2>&1
 if ($LASTEXITCODE -ne 0) { throw ($reviewsRaw -join "`n") }
 $reviewPages = ($reviewsRaw -join "`n") | ConvertFrom-Json
-$reviews = @($reviewPages | ForEach-Object { $_ })
-$currentIndependent = @($reviews | Where-Object {
+$currentIndependent = @($reviewPages | ForEach-Object { $_ } | Where-Object {
   $provider = Get-ReviewProviderFromLogin -Login $_.user.login
-  $_.commit_id -eq $prInfo.headRefOid -and $provider -and (Test-IndependentReview -Implementer $Implementer -ReviewerProvider $provider)
-})
+  $_.commit_id -eq $prInfo.headRefOid -and $_.state -notin @('DISMISSED','PENDING') -and $provider -and (Test-IndependentReview -Implementer $Implementer -ReviewerProvider $provider)
+} | Sort-Object submitted_at)
 if ($currentIndependent.Count -eq 0) { throw "No independent AI review exists on current head $($prInfo.headRefOid). Run request-independent-review.ps1 after the final substantive push." }
+$latestReview = $currentIndependent[-1]
+if ($latestReview.state -eq 'CHANGES_REQUESTED') { throw "Latest independent review by $($latestReview.user.login) requests changes; refusing auto-merge." }
 
-$reviewer = $currentIndependent[-1].user.login
+$reviewer = $latestReview.user.login
 & gh pr merge $Pr --repo $Repo --auto --squash
 if ($LASTEXITCODE -ne 0) { throw "Could not enable auto-merge for $Repo PR #$Pr." }
 Write-Host "AUTO-MERGE ARMED: $Repo PR #$Pr ($Risk), independent reviewer $reviewer. GitHub remains the authority: required PR Gate + resolved threads must pass before merge." -ForegroundColor Green

--- a/scripts/auto-merge.ps1
+++ b/scripts/auto-merge.ps1
@@ -1,42 +1,101 @@
 param(
   [Parameter(Mandatory)][string]$Repo,
   [Parameter(Mandatory)][int]$Pr,
-  [ValidateSet('R0','R1','R2','R3','R4')][string]$Risk = 'R2'
+  [ValidateSet('R0','R1','R2','R3','R4')][string]$Risk = 'R2',
+  [ValidateSet('claude','copilot','codex','human','unknown')][string]$Implementer = 'unknown'
 )
 
 $ErrorActionPreference = 'Stop'
+. (Join-Path $PSScriptRoot 'lib/review-policy.ps1')
+
 if (-not (Get-Command gh -ErrorAction SilentlyContinue)) { throw 'GitHub CLI (gh) is required.' }
 & gh auth status | Out-Host
 if ($LASTEXITCODE -ne 0) { throw 'gh is not authenticated.' }
 
-$prRaw = & gh pr view $Pr --repo $Repo --json isDraft,state,headRefOid 2>&1
+$config = Get-Content (Join-Path $PSScriptRoot '..\policy\github-defaults.json') -Raw | ConvertFrom-Json
+
+$prRaw = & gh pr view $Pr --repo $Repo --json isDraft,state,headRefOid,body,labels 2>&1
 if ($LASTEXITCODE -ne 0) { throw ($prRaw -join "`n") }
 $prInfo = ($prRaw -join "`n") | ConvertFrom-Json
 if ($prInfo.state -ne 'OPEN') { throw "PR #$Pr is not open." }
-if ($prInfo.isDraft) { throw "PR #$Pr is still draft. Finish local verification and mark it ready first." }
+if ($prInfo.isDraft) { throw "PR #$Pr is still draft. Finish implementation and mark it ready first." }
+if (@($prInfo.labels | ForEach-Object { $_.name }) -contains 'status:blocked') { throw "Auto-merge refused: PR #$Pr is status:blocked." }
+
+if ($Implementer -eq 'unknown' -and $prInfo.body -match '(?im)^\s*Implementer:\s*(claude|copilot|codex|human)\s*$') {
+  $Implementer = $Matches[1].ToLowerInvariant()
+}
+if ($Implementer -eq 'unknown') {
+  throw "Auto-merge requires an Implementer: claude|copilot|codex|human line in the PR body (or -Implementer explicitly) so reviewer independence can be proven."
+}
+
+$riskNumber = [int]$Risk.Substring(1)
+$maxRisk = [int]([string]$config.auto_merge_max_risk).Substring(1)
+if ($riskNumber -gt $maxRisk) { throw "Auto-merge refused: $Risk exceeds configured auto_merge_max_risk $($config.auto_merge_max_risk)." }
+if ($Risk -eq 'R4') { throw "Auto-merge refused: R4 requires explicit authority for destructive/financial/privileged/irreversible consequence." }
 
 $filesRaw = & gh api --paginate "repos/$Repo/pulls/$Pr/files?per_page=100" --jq '.[].filename' 2>&1
 if ($LASTEXITCODE -ne 0) { throw ($filesRaw -join "`n") }
 $files = @($filesRaw)
-
 $controlPlanePatterns = @(
-  '^\.github/workflows/',
-  '^\.agent/',
-  '^AGENTS\.md$',
-  '^policy/',
-  '^scripts/(apply-github-standard|doctor|auto-merge|upgrade-repos|bootstrap-repo|codex-review|sync-agentic-project)\.ps1$',
-  '^(QUALITY_RULES|SECURITY_RISK_AUTONOMY|DELIVERY_GITHUB)\.md$'
+  '^\.github/workflows/', '^\.agent/', '^AGENTS\.md$', '^policy/', '^scripts/lib/',
+  '^scripts/(apply-github-standard|doctor|auto-merge|request-independent-review|upgrade-repos|bootstrap-repo|codex-review|sync-agentic-project)\.ps1$',
+  '^(AGENT_RULES|QUALITY_RULES|SECURITY_RISK_AUTONOMY|DELIVERY_GITHUB|EVIDENCE_LEARNING)\.md$'
 )
 $controlPlane = $Repo -match '/agent-engineering-standard$'
-foreach ($file in $files) {
-  if ($controlPlanePatterns | Where-Object { $file -match $_ }) { $controlPlane = $true; break }
+foreach ($file in $files) { if ($controlPlanePatterns | Where-Object { $file -match $_ }) { $controlPlane = $true; break } }
+if ($controlPlane -and $riskNumber -lt 3) { throw "Auto-merge refused: control-plane changes must declare at least R3." }
+if ($controlPlane -and [bool]$config.manual_gates.control_plane.required) {
+  throw "Auto-merge refused: control-plane gate is currently justified because this PR can modify its own evaluator/authority. Removal condition: $($config.manual_gates.control_plane.removal_condition)"
 }
 
-$riskNumber = [int]$Risk.Substring(1)
-if ($controlPlane -or $riskNumber -ge 3) {
-  throw "Auto-merge refused: PR #$Pr is R3/R4 or changes the control plane. Request a fresh external Codex review after the final substantive push, resolve every material review thread, then merge through an independent authority path."
-}
+# Fail closed unless the live GitHub integration plane is actually enforcing the intended policy.
+$metaRaw = & gh api "repos/$Repo" 2>&1
+if ($LASTEXITCODE -ne 0) { throw "Cannot inspect live repository settings for $Repo." }
+$meta = ($metaRaw -join "`n") | ConvertFrom-Json
+if (-not $meta.allow_auto_merge) { throw "Live GitHub setting drift: auto-merge is off. Run setup-portfolio.ps1." }
+if (-not $meta.allow_squash_merge -or $meta.allow_merge_commit -or $meta.allow_rebase_merge) { throw "Live GitHub merge-method drift: repository is not squash-only. Run setup-portfolio.ps1." }
 
+$actionsAppRaw = & gh api /apps/github-actions 2>&1
+if ($LASTEXITCODE -ne 0) { throw 'Cannot resolve GitHub Actions App identity.' }
+$actionsAppId = [int]((($actionsAppRaw -join "`n") | ConvertFrom-Json).id)
+
+$rulesetsRaw = & gh api "repos/$Repo/rulesets" 2>&1
+if ($LASTEXITCODE -ne 0) { throw "Cannot inspect live rulesets for $Repo." }
+$rulesets = ($rulesetsRaw -join "`n") | ConvertFrom-Json
+$summary = $rulesets | Where-Object { $_.name -eq $config.ruleset_name } | Select-Object -First 1
+if (-not $summary) { throw "Live ruleset '$($config.ruleset_name)' is missing. Run setup-portfolio.ps1." }
+$detailRaw = & gh api "repos/$Repo/rulesets/$($summary.id)" 2>&1
+if ($LASTEXITCODE -ne 0) { throw "Cannot inspect live ruleset '$($config.ruleset_name)'." }
+$detail = ($detailRaw -join "`n") | ConvertFrom-Json
+if ($detail.enforcement -ne 'active') { throw 'Live ruleset is not active.' }
+if ($detail.bypass_actors -and @($detail.bypass_actors).Count -gt 0) { throw 'Live ruleset has bypass actors; refusing auto-merge.' }
+
+$prRule = $detail.rules | Where-Object { $_.type -eq 'pull_request' } | Select-Object -First 1
+if (-not $prRule) { throw 'Live ruleset does not require pull requests.' }
+if ([int]$prRule.parameters.required_approving_review_count -ne 0) { throw 'Human approval requirement detected; portfolio default must be 0.' }
+if ([bool]$prRule.parameters.require_code_owner_review) { throw 'Required Code Owner review detected on the personal-repo lane.' }
+if (-not [bool]$prRule.parameters.required_review_thread_resolution) { throw 'Review-thread resolution is not required; refusing auto-merge.' }
+$methods = @($prRule.parameters.allowed_merge_methods)
+if ($methods.Count -ne 1 -or $methods[0] -ne 'squash') { throw 'Ruleset is not squash-only.' }
+
+$statusRule = $detail.rules | Where-Object { $_.type -eq 'required_status_checks' } | Select-Object -First 1
+if (-not $statusRule) { throw 'Live ruleset has no required-status-check rule.' }
+$requiredCheck = @($statusRule.parameters.required_status_checks) | Where-Object { $_.context -eq $config.required_status_context } | Select-Object -First 1
+if (-not $requiredCheck) { throw "Live ruleset does not require '$($config.required_status_context)'." }
+if ([int]$requiredCheck.integration_id -ne $actionsAppId) { throw "Required '$($config.required_status_context)' is not bound to GitHub Actions." }
+
+# Require a current-head reviewer from a different provider.
+$reviewsRaw = & gh api --paginate --slurp "repos/$Repo/pulls/$Pr/reviews?per_page=100" 2>&1
+if ($LASTEXITCODE -ne 0) { throw ($reviewsRaw -join "`n") }
+$reviewPages = ($reviewsRaw -join "`n") | ConvertFrom-Json
+$reviews = @($reviewPages | ForEach-Object { $_ })
+$currentIndependent = @($reviews | Where-Object {
+  $provider = Get-ReviewProviderFromLogin -Login $_.user.login
+  $_.commit_id -eq $prInfo.headRefOid -and $provider -and (Test-IndependentReview -Implementer $Implementer -ReviewerProvider $provider)
+})
+if ($currentIndependent.Count -eq 0) { throw "No independent AI review exists on current head $($prInfo.headRefOid). Run request-independent-review.ps1 after the final substantive push." }
+
+$reviewer = $currentIndependent[-1].user.login
 & gh pr merge $Pr --repo $Repo --auto --squash
 if ($LASTEXITCODE -ne 0) { throw "Could not enable auto-merge for $Repo PR #$Pr." }
-Write-Host "AUTO-MERGE ENABLED: $Repo PR #$Pr ($Risk). GitHub will merge only after required checks and review threads pass." -ForegroundColor Green
+Write-Host "AUTO-MERGE ARMED: $Repo PR #$Pr ($Risk), independent reviewer $reviewer. GitHub remains the authority: required PR Gate + resolved threads must pass before merge." -ForegroundColor Green

--- a/scripts/codex-review.ps1
+++ b/scripts/codex-review.ps1
@@ -6,12 +6,8 @@ param(
 
 $ErrorActionPreference = "Stop"
 
-if (-not (Get-Command codex -ErrorAction SilentlyContinue)) {
-  throw "Codex CLI is required. Install/authenticate Codex before running this review."
-}
-if (-not (Get-Command git -ErrorAction SilentlyContinue)) {
-  throw "git is required."
-}
+if (-not (Get-Command codex -ErrorAction SilentlyContinue)) { throw "Codex CLI is required. Install/authenticate Codex before running this review." }
+if (-not (Get-Command git -ErrorAction SilentlyContinue)) { throw "git is required." }
 
 $root = (& git rev-parse --show-toplevel).Trim()
 if ($LASTEXITCODE -ne 0) { throw "Run from inside a Git repository." }
@@ -24,32 +20,45 @@ $dir = Split-Path -Parent $Output
 if ($dir -and -not (Test-Path $dir)) { New-Item -ItemType Directory -Force $dir | Out-Null }
 
 $prompt = @"
-Act as an independent software reviewer. You did not participate in implementation and must not modify files.
+Act as ONE independent review agent performing a batched multi-lens review. You did not participate in implementation, have no implementation-session context, and must not modify files.
 
-Review the current branch against $Base. Inspect only the relevant repository context needed to judge the change, including:
-- AGENTS.md
-- the PRD / source of product truth
-- the active SPEC or linked Issue when present
-- the diff against $Base
-- tests/evaluators that claim to prove the change
-- nearby implementation and security/authority boundaries
+Review the current branch against $Base. Read only the minimum relevant context: AGENTS.md, product truth/PRD, linked Issue/SPEC/slice when present, the diff, claimed test evidence, and nearby security/authority boundaries.
+
+Use these four lenses in one pass to minimize model cost:
+
+1. SOFTWARE / SECURITY
+   - requirement/spec correctness versus merely satisfying tests
+   - false-green tests, missing evidence, regressions, security/authority boundary weakening
+   - data loss, migration, auth, PII, secrets, concurrency, failure/recovery risk when relevant
+
+2. BUSINESS / PRODUCT
+   - does this change solve the stated user/business outcome?
+   - is there scope that adds cost or complexity without measurable value?
+   - did implementation miss the highest-ROI or simplest acceptable outcome?
+   - flag only material product mismatch, not taste
+
+3. SYSTEMS / OPTIMIZATION
+   - unnecessary layers, dependencies, state, files, jobs, services, model calls, or repeated manual work
+   - opportunities to replace recurring manual effort with a small deterministic automation
+   - CI/runtime/cost waste introduced by the change
+   - preserve maintainability; do not optimize into cleverness
+
+4. LEANNESS
+   - smallest correct implementation, low LOC/complexity, reuse before abstraction
+   - dead code, stale branches/config, duplicated process, speculative framework-building
+   - modern idiomatic approach without novelty for novelty's sake
 
 Prioritize only material findings:
 P0 catastrophic/security/data-loss
-P1 likely correctness, requirement, security, or false-green defect
-P2 meaningful maintainability/reliability/test gap likely to cause rework
+P1 likely correctness, requirement, security, authority, or false-green defect
+P2 meaningful business-value, maintainability, reliability, complexity, cost, or test gap likely to cause rework
 
-Explicitly check:
-1. Did implementation match the stated requirement/spec rather than merely the tests?
-2. Could tests pass while the requirement is still wrong or incomplete?
-3. Are acceptance, property, integration/contract, E2E, security, or migration tests missing where the risk calls for them?
-4. Did the change weaken or bypass an evaluator, permission boundary, CI gate, or invariant?
-5. Did scope/complexity expand without concrete benefit?
-6. For UI work, do Playwright journeys exercise the important user-visible flow rather than only implementation details?
+For each finding give: priority, lens, file/location, concrete failure/cost scenario, why current evidence misses it, and the smallest credible fix.
 
-Do not report formatting/style nits that deterministic tooling can catch. Do not disagree for the sake of disagreement. If there are no P0-P2 findings, say exactly: NO MATERIAL FINDINGS.
+If you discover a repeated manual workaround or missing automation that is OUTSIDE this PR's approved scope, do not widen the PR. Report it as:
+AUTOMATION CANDIDATE: problem | evidence | expected ROI | smallest experiment | research needed
 
-For each finding give: priority, file/location, concrete failure scenario, why existing evidence misses it, and smallest credible fix.
+Do not report formatting/style nits deterministic tooling can catch. Do not disagree for the sake of disagreement. If there are no P0-P2 findings, say exactly: NO MATERIAL FINDINGS.
 "@
 
 & codex exec --ephemeral --ignore-user-config --sandbox read-only -m $Model -o $Output $prompt

--- a/scripts/doctor.ps1
+++ b/scripts/doctor.ps1
@@ -8,91 +8,65 @@ $root = (Resolve-Path (Join-Path $PSScriptRoot "..")).Path
 . (Join-Path $PSScriptRoot 'lib/legacy-protection.ps1')
 
 function Test-CodeownersTail {
-  param(
-    [Parameter(Mandatory)][string]$Content,
-    [Parameter(Mandatory)][string[]]$ExpectedTail
-  )
-
-  $rules = @(
-    $Content -split "`r?`n" |
-      ForEach-Object { $_.Trim() } |
-      Where-Object { $_ -and -not $_.StartsWith('#') }
-  )
+  param([Parameter(Mandatory)][string]$Content,[Parameter(Mandatory)][string[]]$ExpectedTail)
+  $rules = @($Content -split "`r?`n" | ForEach-Object { $_.Trim() } | Where-Object { $_ -and -not $_.StartsWith('#') })
   if ($rules.Count -lt $ExpectedTail.Count) { return $false }
   $start = $rules.Count - $ExpectedTail.Count
-  for ($i = 0; $i -lt $ExpectedTail.Count; $i++) {
-    if ($rules[$start + $i] -ne $ExpectedTail[$i]) { return $false }
-  }
+  for ($i = 0; $i -lt $ExpectedTail.Count; $i++) { if ($rules[$start + $i] -ne $ExpectedTail[$i]) { return $false } }
   return $true
 }
 
 $required = @(
-  "README.md", "LIFECYCLE.md", "AGENT_RULES.md", "QUALITY_RULES.md",
-  "SECURITY_RISK_AUTONOMY.md", "DELIVERY_GITHUB.md", "EVIDENCE_LEARNING.md",
+  "README.md", "LIFECYCLE.md", "AGENT_RULES.md", "QUALITY_RULES.md", "SECURITY_RISK_AUTONOMY.md", "DELIVERY_GITHUB.md", "EVIDENCE_LEARNING.md",
   "AGENTS.md", ".github/CODEOWNERS", "policy/github-defaults.json",
-  "scripts/setup-portfolio.ps1", "scripts/apply-github-standard.ps1", "scripts/sync-agentic-project.ps1",
-  "scripts/codex-review.ps1", "scripts/auto-merge.ps1",
-  "scripts/bootstrap-repo.ps1", "scripts/upgrade-repos.ps1",
-  "scripts/lib/legacy-protection.ps1", "scripts/lib/standard-lock.ps1",
-  "tests/legacy-protection.tests.ps1", "tests/standard-lock.tests.ps1",
-  ".github/workflows/ci.yml", "templates/AGENTS.md", "templates/CODEOWNERS", "templates/PR_GATE.yml",
-  "templates/PRD.md", "templates/SPEC.md", "templates/ADR.md",
-  "templates/ISSUE.md", "templates/PULL_REQUEST.md"
+  "scripts/setup-portfolio.ps1", "scripts/apply-github-standard.ps1", "scripts/sync-agentic-project.ps1", "scripts/codex-review.ps1", "scripts/request-independent-review.ps1", "scripts/auto-merge.ps1",
+  "scripts/bootstrap-repo.ps1", "scripts/upgrade-repos.ps1", "scripts/lib/legacy-protection.ps1", "scripts/lib/standard-lock.ps1", "scripts/lib/review-policy.ps1",
+  "tests/legacy-protection.tests.ps1", "tests/standard-lock.tests.ps1", "tests/review-policy.tests.ps1",
+  ".github/workflows/ci.yml", "templates/AGENTS.md", "templates/CODEOWNERS", "templates/PR_GATE.yml", "templates/PRD.md", "templates/SPEC.md", "templates/ADR.md", "templates/ISSUE.md", "templates/PULL_REQUEST.md"
 )
-foreach ($relative in $required) {
-  if (-not (Test-Path (Join-Path $root $relative))) { throw "Missing required file: $relative" }
-}
+foreach ($relative in $required) { if (-not (Test-Path (Join-Path $root $relative))) { throw "Missing required file: $relative" } }
 
 $config = Get-Content (Join-Path $root "policy/github-defaults.json") -Raw | ConvertFrom-Json
 if ($config.required_status_context -ne "PR Gate") { throw "required_status_context must be 'PR Gate'" }
-if ($config.required_approving_review_count -ne 0) { throw "Default approval count must remain 0; review is risk-driven." }
-if ($config.require_code_owner_review) { throw "Personal-account default must not require Code Owner approval; the PR author cannot approve their own PR." }
+if ($config.required_approving_review_count -ne 0) { throw "Default human approval count must remain 0." }
+if ($config.require_code_owner_review) { throw "Personal-account default must not require Code Owner approval." }
 if (-not $config.org_hardening -or -not [bool]$config.org_hardening.require_code_owner_review) { throw "Organization hardening must retain Code Owner review." }
-if (-not [bool]$config.allow_auto_merge) { throw "allow_auto_merge must remain true for the safe R0-R2 lane." }
-if (-not [bool]$config.allow_update_branch) { throw "allow_update_branch must remain true so stale safe PRs can be updated before merge." }
+if (-not [bool]$config.allow_auto_merge) { throw "allow_auto_merge must remain true for the reviewed R0-R3 lane." }
+if (-not [bool]$config.allow_update_branch) { throw "allow_update_branch must remain true." }
 if ([bool]$config.allow_merge_commit -or [bool]$config.allow_rebase_merge -or -not [bool]$config.allow_squash_merge) { throw "Repository merge policy must remain squash-only." }
 if ($config.merge_method -ne 'squash') { throw "merge_method must remain squash." }
-if ($config.auto_merge_max_risk -ne 'R2') { throw "auto_merge_max_risk must remain R2 unless the risk model is explicitly redesigned." }
-if (-not $config.control_plane_requires_fresh_external_review) { throw "Control-plane changes must require fresh external review." }
+if ($config.auto_merge_max_risk -ne 'R3') { throw "auto_merge_max_risk must remain R3; R4 requires explicit authority." }
+if (-not $config.control_plane_requires_fresh_external_review) { throw "Control-plane changes must require fresh independent review." }
+
+$review = $config.independent_review
+if (-not $review -or -not [bool]$review.required_for_auto_merge) { throw "Independent AI review must be required before auto-merge." }
+if ($review.preferred_provider -ne 'codex') { throw "Codex must remain the preferred independent reviewer unless evidence changes." }
+if ($review.local_codex_model -ne 'gpt-5.4-mini') { throw "Local Codex review must default to gpt-5.4-mini." }
+if ([int]$review.max_codex_reviews_per_pr -ne 2) { throw "Codex review budget must remain capped at 2 per PR." }
+if (-not [bool]$review.copilot_fallback) { throw "Copilot must remain a bounded fallback reviewer." }
+if ([int]$review.max_copilot_reviews_per_pr -ne 1) { throw "Copilot review budget must remain capped at 1 per PR." }
+if ([bool]$review.copilot_review_on_push -or [bool]$review.copilot_review_drafts) { throw "Copilot draft/push re-review must remain off by default." }
+if ($review.copilot_effort -ne 'low') { throw "Copilot fallback effort must remain low." }
+if ([bool]$review.same_provider_counts_as_independent) { throw "The implementation provider cannot count as its own independent reviewer." }
+
+$requiredGateFields = @('failure_class_prevented','why_automation_is_insufficient','decision_owner','gate_removal_condition')
+foreach ($field in $requiredGateFields) { if (@($config.manual_gate_required_fields) -notcontains $field) { throw "manual_gate_required_fields is missing '$field'." } }
+foreach ($gateName in @('control_plane','R4')) {
+  $gate = $config.manual_gates.PSObject.Properties[$gateName].Value
+  if (-not $gate -or -not [bool]$gate.required) { throw "Manual gate '$gateName' must be explicitly configured." }
+  if ([string]::IsNullOrWhiteSpace([string]$gate.reason)) { throw "Manual gate '$gateName' lacks a concrete reason." }
+  if ([string]::IsNullOrWhiteSpace([string]$gate.removal_condition)) { throw "Manual gate '$gateName' lacks a removal condition." }
+}
 
 $ownerToken = "@$($config.owner)"
-$appCodeownersTail = @(
-  "/.github/workflows/ $ownerToken",
-  "/.github/CODEOWNERS $ownerToken",
-  "/.agent/ $ownerToken",
-  "/AGENTS.md $ownerToken"
-)
-$standardCodeownersTail = @(
-  "/.github/workflows/ $ownerToken",
-  "/.github/CODEOWNERS $ownerToken",
-  "/policy/ $ownerToken",
-  "/scripts/ $ownerToken",
-  "/AGENTS.md $ownerToken",
-  "/AGENT_RULES.md $ownerToken",
-  "/QUALITY_RULES.md $ownerToken",
-  "/SECURITY_RISK_AUTONOMY.md $ownerToken",
-  "/DELIVERY_GITHUB.md $ownerToken"
-)
+$appCodeownersTail = @("/.github/workflows/ $ownerToken","/.github/CODEOWNERS $ownerToken","/.agent/ $ownerToken","/AGENTS.md $ownerToken")
+$standardCodeownersTail = @("/.github/workflows/ $ownerToken","/.github/CODEOWNERS $ownerToken","/policy/ $ownerToken","/scripts/ $ownerToken","/AGENTS.md $ownerToken","/AGENT_RULES.md $ownerToken","/QUALITY_RULES.md $ownerToken","/SECURITY_RISK_AUTONOMY.md $ownerToken","/DELIVERY_GITHUB.md $ownerToken")
+if (-not (Test-CodeownersTail -Content (Get-Content (Join-Path $root '.github/CODEOWNERS') -Raw) -ExpectedTail $standardCodeownersTail)) { throw "Local .github/CODEOWNERS does not match canonical ownership map." }
+if (-not (Test-CodeownersTail -Content (Get-Content (Join-Path $root 'templates/CODEOWNERS') -Raw) -ExpectedTail $appCodeownersTail)) { throw "templates/CODEOWNERS does not match canonical app ownership map." }
 
-$localStandardCodeowners = Get-Content (Join-Path $root '.github/CODEOWNERS') -Raw
-if (-not (Test-CodeownersTail -Content $localStandardCodeowners -ExpectedTail $standardCodeownersTail)) {
-  throw "Local .github/CODEOWNERS does not end with the canonical standards ownership map."
-}
-$localTemplateCodeowners = Get-Content (Join-Path $root 'templates/CODEOWNERS') -Raw
-if (-not (Test-CodeownersTail -Content $localTemplateCodeowners -ExpectedTail $appCodeownersTail)) {
-  throw "templates/CODEOWNERS does not end with the canonical app ownership map."
-}
-
-$psScripts = @(
-  "scripts/setup-portfolio.ps1", "scripts/apply-github-standard.ps1", "scripts/sync-agentic-project.ps1",
-  "scripts/codex-review.ps1", "scripts/auto-merge.ps1",
-  "scripts/bootstrap-repo.ps1", "scripts/upgrade-repos.ps1", "scripts/doctor.ps1",
-  "scripts/lib/legacy-protection.ps1", "scripts/lib/standard-lock.ps1",
-  "tests/legacy-protection.tests.ps1", "tests/standard-lock.tests.ps1"
-)
+$psScripts = @("scripts/setup-portfolio.ps1","scripts/apply-github-standard.ps1","scripts/sync-agentic-project.ps1","scripts/codex-review.ps1","scripts/request-independent-review.ps1","scripts/auto-merge.ps1","scripts/bootstrap-repo.ps1","scripts/upgrade-repos.ps1","scripts/doctor.ps1","scripts/lib/legacy-protection.ps1","scripts/lib/standard-lock.ps1","scripts/lib/review-policy.ps1","tests/legacy-protection.tests.ps1","tests/standard-lock.tests.ps1","tests/review-policy.tests.ps1")
 foreach ($relative in $psScripts) {
-  $tokens = $null
-  $errors = $null
+  $tokens = $null; $errors = $null
   [System.Management.Automation.Language.Parser]::ParseFile((Join-Path $root $relative), [ref]$tokens, [ref]$errors) | Out-Null
   if ($errors.Count -gt 0) { throw "PowerShell parse failed: $relative :: $($errors[0].Message)" }
 }
@@ -107,17 +81,13 @@ $actionsAppId = [int]((($actionsAppRaw -join "`n") | ConvertFrom-Json).id)
 $remoteFailures = New-Object System.Collections.Generic.List[string]
 
 foreach ($name in $config.repositories) {
-  $repo = "$($config.owner)/$name"
-  $problems = New-Object System.Collections.Generic.List[string]
-
+  $repo = "$($config.owner)/$name"; $problems = New-Object System.Collections.Generic.List[string]
   $metaRaw = & gh api "repos/$repo" 2>&1
   if ($LASTEXITCODE -ne 0) { $remoteFailures.Add("${repo}: cannot read repository"); continue }
   $meta = ($metaRaw -join "`n") | ConvertFrom-Json
   $isOrgOwned = $meta.owner.type -eq 'Organization'
   $expectedCodeOwnerReview = [bool]$config.require_code_owner_review
-  if ($isOrgOwned -and $config.org_hardening -and [bool]$config.org_hardening.require_code_owner_review) {
-    $expectedCodeOwnerReview = $true
-  }
+  if ($isOrgOwned -and $config.org_hardening -and [bool]$config.org_hardening.require_code_owner_review) { $expectedCodeOwnerReview = $true }
 
   if (-not $meta.has_issues) { $problems.Add("Issues disabled") }
   if (-not $meta.allow_auto_merge) { $problems.Add("auto-merge off") }
@@ -128,61 +98,40 @@ foreach ($name in $config.repositories) {
   if ($meta.allow_rebase_merge) { $problems.Add("rebase enabled") }
 
   $actionsRaw = & gh api "repos/$repo/actions/permissions" 2>&1
-  if ($LASTEXITCODE -ne 0) { $problems.Add("cannot read Actions permissions") }
-  else {
-    $actions = ($actionsRaw -join "`n") | ConvertFrom-Json
-    if (-not $actions.enabled) { $problems.Add("Actions disabled") }
-  }
+  if ($LASTEXITCODE -ne 0) { $problems.Add("cannot read Actions permissions") } else { if (-not ((($actionsRaw -join "`n") | ConvertFrom-Json).enabled)) { $problems.Add("Actions disabled") } }
 
   $codeownersRaw = & gh api -H "Accept: application/vnd.github.raw+json" "repos/$repo/contents/.github/CODEOWNERS?ref=$($meta.default_branch)" 2>&1
-  if ($LASTEXITCODE -ne 0) {
-    $problems.Add("CODEOWNERS missing on default branch")
-  }
-  else {
-    $codeowners = $codeownersRaw -join "`n"
+  if ($LASTEXITCODE -ne 0) { $problems.Add("CODEOWNERS missing on default branch") } else {
     $expectedTail = if ($name -eq 'agent-engineering-standard') { $standardCodeownersTail } else { $appCodeownersTail }
-    if (-not (Test-CodeownersTail -Content $codeowners -ExpectedTail $expectedTail)) {
-      $problems.Add("CODEOWNERS effective tail does not match canonical ownership map")
-    }
+    if (-not (Test-CodeownersTail -Content ($codeownersRaw -join "`n") -ExpectedTail $expectedTail)) { $problems.Add("CODEOWNERS effective tail does not match canonical ownership map") }
   }
 
   $rulesetsRaw = & gh api "repos/$repo/rulesets" 2>&1
-  if ($LASTEXITCODE -ne 0) { $problems.Add("cannot read rulesets") }
-  else {
-    $rulesets = ($rulesetsRaw -join "`n") | ConvertFrom-Json
-    $summary = $rulesets | Where-Object { $_.name -eq $config.ruleset_name } | Select-Object -First 1
-    if (-not $summary) { $problems.Add("ruleset missing") }
-    else {
+  if ($LASTEXITCODE -ne 0) { $problems.Add("cannot read rulesets") } else {
+    $summary = ((($rulesetsRaw -join "`n") | ConvertFrom-Json) | Where-Object { $_.name -eq $config.ruleset_name } | Select-Object -First 1)
+    if (-not $summary) { $problems.Add("ruleset missing") } else {
       $detailRaw = & gh api "repos/$repo/rulesets/$($summary.id)" 2>&1
-      if ($LASTEXITCODE -ne 0) { $problems.Add("cannot read ruleset details") }
-      else {
+      if ($LASTEXITCODE -ne 0) { $problems.Add("cannot read ruleset details") } else {
         $detail = ($detailRaw -join "`n") | ConvertFrom-Json
         if ($detail.enforcement -ne 'active') { $problems.Add("ruleset not active") }
         if ($detail.bypass_actors -and @($detail.bypass_actors).Count -gt 0) { $problems.Add("ruleset has bypass actors") }
         if (-not (@($detail.conditions.ref_name.include) -contains '~DEFAULT_BRANCH')) { $problems.Add("ruleset does not target default branch") }
-
         $types = @($detail.rules | ForEach-Object { $_.type })
-        foreach ($requiredType in @('deletion','non_fast_forward','pull_request','required_status_checks')) {
-          if ($types -notcontains $requiredType) { $problems.Add("missing rule: $requiredType") }
-        }
-
+        foreach ($requiredType in @('deletion','non_fast_forward','pull_request','required_status_checks')) { if ($types -notcontains $requiredType) { $problems.Add("missing rule: $requiredType") } }
         $prRule = $detail.rules | Where-Object { $_.type -eq 'pull_request' } | Select-Object -First 1
         if ($prRule) {
-          if ([int]$prRule.parameters.required_approving_review_count -ne [int]$config.required_approving_review_count) { $problems.Add("approval-count drift") }
+          if ([int]$prRule.parameters.required_approving_review_count -ne 0) { $problems.Add("human approval requirement is not zero") }
           if ([bool]$prRule.parameters.require_code_owner_review -ne $expectedCodeOwnerReview) { $problems.Add("CODEOWNERS review policy drift") }
           if (-not $prRule.parameters.required_review_thread_resolution) { $problems.Add("review-thread resolution not required") }
           $allowedMethods = @($prRule.parameters.allowed_merge_methods)
           if ($allowedMethods.Count -ne 1 -or $allowedMethods[0] -ne 'squash') { $problems.Add("ruleset merge methods not squash-only") }
         }
-
         $statusRule = $detail.rules | Where-Object { $_.type -eq 'required_status_checks' } | Select-Object -First 1
         if ($statusRule) {
           if ([bool]$statusRule.parameters.strict_required_status_checks_policy -ne [bool]$config.strict_required_status_checks_policy) { $problems.Add("strict-status policy drift") }
           $requiredCheck = @($statusRule.parameters.required_status_checks) | Where-Object { $_.context -eq $config.required_status_context } | Select-Object -First 1
-          if (-not $requiredCheck) { $problems.Add("required PR Gate context missing") }
-          elseif ([int]$requiredCheck.integration_id -ne $actionsAppId) { $problems.Add("PR Gate not bound to GitHub Actions") }
+          if (-not $requiredCheck) { $problems.Add("required PR Gate context missing") } elseif ([int]$requiredCheck.integration_id -ne $actionsAppId) { $problems.Add("PR Gate not bound to GitHub Actions") }
         }
-
         if ($config.merge_queue.desired -and $isOrgOwned -and $types -notcontains 'merge_queue') { $problems.Add("merge queue missing on eligible repo") }
       }
     }
@@ -190,27 +139,17 @@ foreach ($name in $config.repositories) {
 
   $legacyRaw = & gh api "repos/$repo/branches/$($meta.default_branch)/protection" 2>&1
   if ($LASTEXITCODE -eq 0) {
-    $legacy = ($legacyRaw -join "`n") | ConvertFrom-Json
-    foreach ($context in @(Get-StaleLegacyRequiredCheckContexts -Protection $legacy -RequiredContext $config.required_status_context)) {
-      $problems.Add("stale legacy required check: $context")
-    }
-  }
-  else {
+    foreach ($context in @(Get-StaleLegacyRequiredCheckContexts -Protection (($legacyRaw -join "`n") | ConvertFrom-Json) -RequiredContext $config.required_status_context)) { $problems.Add("stale legacy required check: $context") }
+  } else {
     $legacyError = $legacyRaw -join "`n"
-    if (-not (Test-GitHubBranchProtectionAbsent -ErrorText $legacyError)) {
-      $problems.Add("cannot read legacy branch protection")
-    }
+    if (-not (Test-GitHubBranchProtectionAbsent -ErrorText $legacyError)) { $problems.Add("cannot read legacy branch protection") }
   }
 
-  if ($problems.Count -eq 0) { Write-Host "${repo} : READY" -ForegroundColor Green }
-  else {
+  if ($problems.Count -eq 0) { Write-Host "${repo} : READY" -ForegroundColor Green } else {
     Write-Host "${repo} : $($problems -join ', ')" -ForegroundColor Yellow
     foreach ($problem in $problems) { $remoteFailures.Add("${repo}: $problem") }
   }
-
-  if ($config.merge_queue.desired -and -not $isOrgOwned) {
-    Write-Host "  merge queue: waiting on transfer to a supported GitHub organization" -ForegroundColor DarkYellow
-  }
+  if ($config.merge_queue.desired -and -not $isOrgOwned) { Write-Host "  merge queue: waiting on transfer to a supported GitHub organization" -ForegroundColor DarkYellow }
 }
 
 if ($remoteFailures.Count -gt 0) { throw "REMOTE: DRIFT DETECTED`n$($remoteFailures -join "`n")" }

--- a/scripts/lib/review-policy.ps1
+++ b/scripts/lib/review-policy.ps1
@@ -1,0 +1,51 @@
+function Get-ReviewProviderFromLogin {
+  param([Parameter(Mandatory)][string]$Login)
+
+  $normalized = $Login.ToLowerInvariant()
+  if ($normalized -in @('chatgpt-codex-connector', 'chatgpt-codex-connector[bot]')) { return 'codex' }
+  if ($normalized -in @('copilot-pull-request-reviewer', 'copilot-pull-request-reviewer[bot]')) { return 'copilot' }
+  return $null
+}
+
+function Get-PreferredIndependentReviewer {
+  param(
+    [ValidateSet('claude','copilot','codex','human','unknown')][string]$Implementer = 'unknown',
+    [bool]$CodexAvailable = $true,
+    [bool]$CopilotAvailable = $true,
+    [bool]$ClaudeAvailable = $true
+  )
+
+  if ($Implementer -ne 'codex' -and $CodexAvailable) { return 'codex' }
+  if ($Implementer -ne 'copilot' -and $CopilotAvailable) { return 'copilot' }
+  if ($Implementer -ne 'claude' -and $ClaudeAvailable) { return 'claude' }
+  throw "No independent AI reviewer is available for implementer '$Implementer'."
+}
+
+function Test-IndependentReview {
+  param(
+    [Parameter(Mandatory)][string]$Implementer,
+    [Parameter(Mandatory)][string]$ReviewerProvider
+  )
+
+  if ($Implementer -in @('human','unknown')) { return $true }
+  return $Implementer -ne $ReviewerProvider
+}
+
+function Assert-ManualGateJustification {
+  param([Parameter(Mandatory)]$Justification)
+
+  $required = @(
+    'failure_class_prevented',
+    'why_automation_is_insufficient',
+    'decision_owner',
+    'gate_removal_condition'
+  )
+
+  foreach ($field in $required) {
+    $property = $Justification.PSObject.Properties[$field]
+    if (-not $property -or [string]::IsNullOrWhiteSpace([string]$property.Value)) {
+      throw "Manual gate is not justified: missing '$field'."
+    }
+  }
+  return $true
+}

--- a/scripts/request-independent-review.ps1
+++ b/scripts/request-independent-review.ps1
@@ -22,9 +22,10 @@ if ($prInfo.state -ne 'OPEN') { throw "PR #$Pr is not open." }
 if ($prInfo.isDraft) { throw "PR #$Pr is draft. Keep implementation churn in draft; request independent review only when ready." }
 
 if ($Implementer -eq 'auto') {
-  $match = [regex]::Match([string]$prInfo.body, '(?im)^\s*Implementer:\s*(claude|copilot|codex|human|unknown)\s*$')
+  $match = [regex]::Match([string]$prInfo.body, '(?im)^\s*Implementer:\s*(claude|copilot|codex|human)\s*$')
   $Implementer = if ($match.Success) { $match.Groups[1].Value.ToLowerInvariant() } else { 'unknown' }
 }
+if ($Implementer -eq 'unknown') { throw "Independent review routing requires a concrete Implementer: claude|copilot|codex|human line in the PR body (or -Implementer explicitly)." }
 
 $reviewsRaw = & gh api --paginate --slurp "repos/$Repo/pulls/$Pr/reviews?per_page=100" 2>&1
 if ($LASTEXITCODE -ne 0) { throw ($reviewsRaw -join "`n") }
@@ -33,10 +34,10 @@ $reviews = @($reviewPages | ForEach-Object { $_ })
 
 $currentIndependent = @($reviews | Where-Object {
   $provider = Get-ReviewProviderFromLogin -Login $_.user.login
-  $_.commit_id -eq $prInfo.headRefOid -and $provider -and (Test-IndependentReview -Implementer $Implementer -ReviewerProvider $provider)
+  $_.commit_id -eq $prInfo.headRefOid -and $_.state -ne 'DISMISSED' -and $provider -and (Test-IndependentReview -Implementer $Implementer -ReviewerProvider $provider)
 })
 if ($currentIndependent.Count -gt 0) {
-  Write-Host "CURRENT-HEAD INDEPENDENT REVIEW ALREADY EXISTS: $($currentIndependent[0].user.login)" -ForegroundColor Green
+  Write-Host "CURRENT-HEAD INDEPENDENT REVIEW ALREADY EXISTS: $($currentIndependent[-1].user.login)" -ForegroundColor Green
   exit 0
 }
 
@@ -61,15 +62,14 @@ if (-not (Test-IndependentReview -Implementer $Implementer -ReviewerProvider $Pr
 
 switch ($Provider) {
   'codex' {
-    if ($codexReviews -ge [int]$reviewPolicy.max_codex_reviews_per_pr -or $codexRequests -ge [int]$reviewPolicy.max_codex_reviews_per_pr) {
-      throw "Codex review budget exhausted for PR #$Pr. Use one bounded fallback reviewer instead of repeatedly re-requesting Codex."
-    }
+    if ($codexReviews -ge [int]$reviewPolicy.max_codex_reviews_per_pr -or $codexRequests -ge [int]$reviewPolicy.max_codex_reviews_per_pr) { throw "Codex review budget exhausted for PR #$Pr." }
     & gh pr comment $Pr --repo $Repo --body '@codex review' | Out-Host
     if ($LASTEXITCODE -ne 0) { throw "Could not request Codex review for $Repo PR #$Pr." }
     Write-Host "REVIEW REQUESTED: Codex GitHub ($($codexRequests + 1)/$($reviewPolicy.max_codex_reviews_per_pr)); implementer=$Implementer." -ForegroundColor Green
   }
   'copilot' {
     if ($copilotReviews -ge [int]$reviewPolicy.max_copilot_reviews_per_pr) { throw "Copilot review budget exhausted for PR #$Pr." }
+    # @copilot is GitHub's documented reviewer alias; the submitted review is authored by copilot-pull-request-reviewer[bot].
     & gh pr edit $Pr --repo $Repo --add-reviewer '@copilot' | Out-Host
     if ($LASTEXITCODE -ne 0) { throw "Could not request Copilot review for $Repo PR #$Pr." }
     Write-Host "REVIEW REQUESTED: Copilot fallback ($($copilotReviews + 1)/$($reviewPolicy.max_copilot_reviews_per_pr)); implementer=$Implementer; review-on-push remains disabled." -ForegroundColor Yellow

--- a/scripts/request-independent-review.ps1
+++ b/scripts/request-independent-review.ps1
@@ -1,0 +1,77 @@
+param(
+  [Parameter(Mandatory)][string]$Repo,
+  [Parameter(Mandatory)][int]$Pr,
+  [ValidateSet('auto','claude','copilot','codex','human','unknown')][string]$Implementer = 'auto',
+  [ValidateSet('auto','codex','copilot')][string]$Provider = 'auto'
+)
+
+$ErrorActionPreference = 'Stop'
+. (Join-Path $PSScriptRoot 'lib/review-policy.ps1')
+
+if (-not (Get-Command gh -ErrorAction SilentlyContinue)) { throw 'GitHub CLI (gh) is required.' }
+& gh auth status | Out-Host
+if ($LASTEXITCODE -ne 0) { throw 'gh is not authenticated.' }
+
+$config = Get-Content (Join-Path $PSScriptRoot '..\policy\github-defaults.json') -Raw | ConvertFrom-Json
+$reviewPolicy = $config.independent_review
+
+$prRaw = & gh pr view $Pr --repo $Repo --json isDraft,state,headRefOid,body 2>&1
+if ($LASTEXITCODE -ne 0) { throw ($prRaw -join "`n") }
+$prInfo = ($prRaw -join "`n") | ConvertFrom-Json
+if ($prInfo.state -ne 'OPEN') { throw "PR #$Pr is not open." }
+if ($prInfo.isDraft) { throw "PR #$Pr is draft. Keep implementation churn in draft; request independent review only when ready." }
+
+if ($Implementer -eq 'auto') {
+  $match = [regex]::Match([string]$prInfo.body, '(?im)^\s*Implementer:\s*(claude|copilot|codex|human|unknown)\s*$')
+  $Implementer = if ($match.Success) { $match.Groups[1].Value.ToLowerInvariant() } else { 'unknown' }
+}
+
+$reviewsRaw = & gh api --paginate --slurp "repos/$Repo/pulls/$Pr/reviews?per_page=100" 2>&1
+if ($LASTEXITCODE -ne 0) { throw ($reviewsRaw -join "`n") }
+$reviewPages = ($reviewsRaw -join "`n") | ConvertFrom-Json
+$reviews = @($reviewPages | ForEach-Object { $_ })
+
+$currentIndependent = @($reviews | Where-Object {
+  $provider = Get-ReviewProviderFromLogin -Login $_.user.login
+  $_.commit_id -eq $prInfo.headRefOid -and $provider -and (Test-IndependentReview -Implementer $Implementer -ReviewerProvider $provider)
+})
+if ($currentIndependent.Count -gt 0) {
+  Write-Host "CURRENT-HEAD INDEPENDENT REVIEW ALREADY EXISTS: $($currentIndependent[0].user.login)" -ForegroundColor Green
+  exit 0
+}
+
+$codexReviews = @($reviews | Where-Object { (Get-ReviewProviderFromLogin -Login $_.user.login) -eq 'codex' }).Count
+$copilotReviews = @($reviews | Where-Object { (Get-ReviewProviderFromLogin -Login $_.user.login) -eq 'copilot' }).Count
+
+$commentsRaw = & gh api --paginate --slurp "repos/$Repo/issues/$Pr/comments?per_page=100" 2>&1
+if ($LASTEXITCODE -ne 0) { throw ($commentsRaw -join "`n") }
+$commentPages = ($commentsRaw -join "`n") | ConvertFrom-Json
+$comments = @($commentPages | ForEach-Object { $_ })
+$codexRequests = @($comments | Where-Object { $_.body -match '(?i)@codex\s+review' }).Count
+
+if ($Provider -eq 'auto') {
+  $Provider = Get-PreferredIndependentReviewer `
+    -Implementer $Implementer `
+    -CodexAvailable (($codexReviews -lt [int]$reviewPolicy.max_codex_reviews_per_pr) -and ($codexRequests -lt [int]$reviewPolicy.max_codex_reviews_per_pr)) `
+    -CopilotAvailable ([bool]$reviewPolicy.copilot_fallback -and $copilotReviews -lt [int]$reviewPolicy.max_copilot_reviews_per_pr) `
+    -ClaudeAvailable $false
+}
+
+if (-not (Test-IndependentReview -Implementer $Implementer -ReviewerProvider $Provider)) { throw "Reviewer '$Provider' is not independent from implementer '$Implementer'." }
+
+switch ($Provider) {
+  'codex' {
+    if ($codexReviews -ge [int]$reviewPolicy.max_codex_reviews_per_pr -or $codexRequests -ge [int]$reviewPolicy.max_codex_reviews_per_pr) {
+      throw "Codex review budget exhausted for PR #$Pr. Use one bounded fallback reviewer instead of repeatedly re-requesting Codex."
+    }
+    & gh pr comment $Pr --repo $Repo --body '@codex review' | Out-Host
+    if ($LASTEXITCODE -ne 0) { throw "Could not request Codex review for $Repo PR #$Pr." }
+    Write-Host "REVIEW REQUESTED: Codex GitHub ($($codexRequests + 1)/$($reviewPolicy.max_codex_reviews_per_pr)); implementer=$Implementer." -ForegroundColor Green
+  }
+  'copilot' {
+    if ($copilotReviews -ge [int]$reviewPolicy.max_copilot_reviews_per_pr) { throw "Copilot review budget exhausted for PR #$Pr." }
+    & gh pr edit $Pr --repo $Repo --add-reviewer '@copilot' | Out-Host
+    if ($LASTEXITCODE -ne 0) { throw "Could not request Copilot review for $Repo PR #$Pr." }
+    Write-Host "REVIEW REQUESTED: Copilot fallback ($($copilotReviews + 1)/$($reviewPolicy.max_copilot_reviews_per_pr)); implementer=$Implementer; review-on-push remains disabled." -ForegroundColor Yellow
+  }
+}

--- a/templates/PULL_REQUEST.md
+++ b/templates/PULL_REQUEST.md
@@ -4,6 +4,7 @@
 Issue:
 Spec:
 Slice(s):
+Implementer: claude / copilot / codex / human / unknown
 
 ## What Changed
 -
@@ -13,6 +14,7 @@ Slice(s):
 - [ ] Acceptance satisfied
 - [ ] Protected evaluator passes when applicable
 - [ ] Risk/security checks pass when applicable
+- [ ] Current-head independent review requested from a different provider/agent
 
 ## Risk
 R0 / R1 / R2 / R3 / R4
@@ -23,3 +25,11 @@ R0 / R1 / R2 / R3 / R4
 ## Integrity
 - [ ] Tests/policies were not weakened
 - [ ] Scope was not unnecessarily widened
+- [ ] Repeated manual work discovered here was automated in-scope or logged as one bounded automation/research candidate
+
+## Manual Gate (only when actually required)
+None, or state all four:
+- Failure class prevented:
+- Why automation is insufficient today:
+- Decision owner:
+- Gate removal condition:

--- a/tests/review-policy.tests.ps1
+++ b/tests/review-policy.tests.ps1
@@ -1,0 +1,44 @@
+$ErrorActionPreference = 'Stop'
+. (Join-Path $PSScriptRoot '..\scripts\lib\review-policy.ps1')
+
+function Assert-Equal {
+  param([string]$Name, $Actual, $Expected)
+  if ($Actual -cne $Expected) { throw "$Name failed: expected '$Expected', got '$Actual'." }
+}
+
+function Assert-Throws {
+  param([string]$Name, [scriptblock]$Action)
+  try { & $Action | Out-Null } catch { return }
+  throw "$Name failed: expected an exception."
+}
+
+Assert-Equal 'Claude implementation routes to Codex' (Get-PreferredIndependentReviewer -Implementer claude) 'codex'
+Assert-Equal 'Copilot implementation routes to Codex' (Get-PreferredIndependentReviewer -Implementer copilot) 'codex'
+Assert-Equal 'Codex implementation routes to Copilot' (Get-PreferredIndependentReviewer -Implementer codex) 'copilot'
+Assert-Equal 'Codex falls back to Claude when Copilot unavailable' (Get-PreferredIndependentReviewer -Implementer codex -CopilotAvailable $false) 'claude'
+Assert-Throws 'same-provider-only availability is refused' {
+  Get-PreferredIndependentReviewer -Implementer codex -CopilotAvailable $false -ClaudeAvailable $false
+}
+
+Assert-Equal 'Codex bot login recognized' (Get-ReviewProviderFromLogin -Login 'chatgpt-codex-connector[bot]') 'codex'
+Assert-Equal 'Copilot bot login recognized' (Get-ReviewProviderFromLogin -Login 'copilot-pull-request-reviewer[bot]') 'copilot'
+Assert-Equal 'unknown reviewer ignored' (Get-ReviewProviderFromLogin -Login 'random-bot[bot]') $null
+Assert-Equal 'different provider is independent' (Test-IndependentReview -Implementer claude -ReviewerProvider codex) $true
+Assert-Equal 'same provider is not independent' (Test-IndependentReview -Implementer codex -ReviewerProvider codex) $false
+
+$validGate = [pscustomobject]@{
+  failure_class_prevented = 'irreversible production data loss'
+  why_automation_is_insufficient = 'the intent to destroy cannot be inferred from repository state'
+  decision_owner = 'Kyle'
+  gate_removal_condition = 'operation becomes reversible with independently verified restore'
+}
+Assert-Equal 'complete manual gate justification accepted' (Assert-ManualGateJustification -Justification $validGate) $true
+Assert-Throws 'manual gate missing removal condition is refused' {
+  Assert-ManualGateJustification -Justification ([pscustomobject]@{
+    failure_class_prevented = 'x'
+    why_automation_is_insufficient = 'y'
+    decision_owner = 'z'
+  })
+}
+
+Write-Host 'review-policy tests: PASS' -ForegroundColor Green


### PR DESCRIPTION
## Work
Issue: #17
Spec: ADR 0001
Slice(s): review routing + review budget + safe merge enforcement
Implementer: human

## What Changed
- Requires a current-head review from a different implementation provider before auto-merge.
- Routes Claude/Copilot implementations to Codex; Codex implementations route to Copilot, with fresh Claude as fallback when available.
- Uses one batched reviewer pass for software/security, business/product ROI, systems/optimization, and leanness instead of paying for several reviewers.
- Codex is primary; local review defaults to `gpt-5.4-mini`; max two Codex passes (initial + one re-review).
- Copilot is fallback-only, low-effort, max one review; no default draft/every-push review spam.
- Auto-merge fails closed unless live GitHub policy proves squash-only, 0 human approvals, resolved review threads, no bypass actors, and GitHub-Actions-bound `PR Gate`.
- R0-R3 can use the reviewed automated lane when the evaluator is external to the change. R4 stays an explicit authorization gate.
- Every manual gate must state failure class, why automation is insufficient, decision owner, and removal condition.

## Evidence
- New dependency-free review-policy tests are part of `PR Gate`.
- Existing standard-lock tests remain current-main versions, including CRLF hardening.
- Branch was recut from current main; compare is ahead-only with 12 intended files.

## Risk
R3 control plane

## Manual Gate
- Failure class prevented: this PR can modify the evaluator/merge authority that would judge itself.
- Why automation is insufficient today: the governing policy/scripts are still editable in the same repository rather than enforced by an immutable external/organization-required workflow.
- Decision owner: repository owner.
- Gate removal condition: move governing evaluation/merge authority to an external or organization-required workflow this PR cannot modify.