### PR TITLE
fix #21: enforce exact-head AI Review before auto-merge

### DIFF
--- a/.github/workflows/ai-review-reusable.yml
+++ b/.github/workflows/ai-review-reusable.yml
@@ -1,0 +1,127 @@
+name: Reusable AI Review Gate
+
+on:
+  workflow_call:
+    inputs:
+      pr_number:
+        required: true
+        type: number
+
+jobs:
+  evaluate:
+    name: Update AI Review status
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    env:
+      GH_TOKEN: ${{ github.token }}
+      PR_NUMBER: ${{ inputs.pr_number }}
+    steps:
+      - name: Evaluate exact-head independent review
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $repo = $env:GITHUB_REPOSITORY
+          $prNumber = [int]$env:PR_NUMBER
+          $marker = '<!-- agent-engineering:implementer-attestation -->'
+
+          function Invoke-GhJson {
+            param([string]$Method, [string]$Endpoint, $Body)
+            $tmp = [System.IO.Path]::GetTempFileName()
+            try {
+              $Body | ConvertTo-Json -Depth 10 | Set-Content $tmp -Encoding utf8 -NoNewline
+              $raw = & gh api --method $Method $Endpoint --input $tmp 2>&1
+              if ($LASTEXITCODE -ne 0) { throw ($raw -join "`n") }
+              if ($raw) { return (($raw -join "`n") | ConvertFrom-Json) }
+            }
+            finally { Remove-Item $tmp -Force -ErrorAction SilentlyContinue }
+          }
+
+          function Get-ProviderFromReviewer([string]$Login) {
+            $value = $Login.ToLowerInvariant()
+            if ($value -in @('chatgpt-codex-connector','chatgpt-codex-connector[bot]')) { return 'codex' }
+            if ($value -in @('copilot-pull-request-reviewer','copilot-pull-request-reviewer[bot]')) { return 'copilot' }
+            return $null
+          }
+
+          function Set-AiReviewCheck([string]$HeadSha, [string]$Conclusion, [string]$Summary) {
+            $encoded = [uri]::EscapeDataString('AI Review')
+            $raw = & gh api -H 'Accept: application/vnd.github+json' "repos/$repo/commits/$HeadSha/check-runs?check_name=$encoded" 2>&1
+            if ($LASTEXITCODE -ne 0) { throw ($raw -join "`n") }
+            $runs = (($raw -join "`n") | ConvertFrom-Json).check_runs
+            $existing = @($runs | Where-Object { $_.name -eq 'AI Review' -and $_.app.slug -eq 'github-actions' } | Sort-Object id | Select-Object -Last 1)
+            $body = @{
+              status = 'completed'
+              conclusion = $Conclusion
+              output = @{ title = 'AI Review'; summary = $Summary }
+            }
+            if ($existing.Count -gt 0) {
+              Invoke-GhJson -Method PATCH -Endpoint "repos/$repo/check-runs/$($existing[0].id)" -Body $body | Out-Null
+            } else {
+              $body.name = 'AI Review'
+              $body.head_sha = $HeadSha
+              Invoke-GhJson -Method POST -Endpoint "repos/$repo/check-runs" -Body $body | Out-Null
+            }
+          }
+
+          $prRaw = & gh api "repos/$repo/pulls/$prNumber" 2>&1
+          if ($LASTEXITCODE -ne 0) { throw ($prRaw -join "`n") }
+          $pr = ($prRaw -join "`n") | ConvertFrom-Json
+          $headSha = [string]$pr.head.sha
+          $headRef = [string]$pr.head.ref
+          $author = [string]$pr.user.login
+          $body = [string]$pr.body
+
+          if ($pr.draft) {
+            Set-AiReviewCheck -HeadSha $headSha -Conclusion failure -Summary 'Draft PR: semantic review is intentionally deferred.'
+            exit 0
+          }
+
+          $commentsRaw = & gh api "repos/$repo/issues/$prNumber/comments?per_page=100" 2>&1
+          if ($LASTEXITCODE -ne 0) { throw ($commentsRaw -join "`n") }
+          $comments = @(($commentsRaw -join "`n") | ConvertFrom-Json)
+          $attestation = $comments | Where-Object { $_.user.login -eq 'github-actions[bot]' -and $_.body -like "*$marker*" } | Select-Object -First 1
+
+          $implementer = $null
+          if ($attestation -and $attestation.body -match '(?im)^Implementation provider:\s*`(claude|copilot|codex|human)`\s*$') {
+            $implementer = $Matches[1].ToLowerInvariant()
+          }
+
+          if (-not $implementer) {
+            if ($headRef -match '^agent/(codex|claude|copilot)/') { $implementer = $Matches[1].ToLowerInvariant() }
+            elseif ($headRef -match '^claude/') { $implementer = 'claude' }
+            elseif ($headRef -match '^copilot/' -or $author -eq 'Copilot') { $implementer = 'copilot' }
+            elseif ($author -match '^chatgpt-codex-connector(?:\[bot\])?$') { $implementer = 'codex' }
+            elseif ($body -match '(?im)^\s*Implementer:\s*human\s*$') { $implementer = 'human' }
+
+            if ($implementer) {
+              $attestationBody = "$marker`nImplementation provider: ``$implementer```nAttested by GitHub Actions for branch ``$headRef``. This provider is immutable for this PR; start a new PR if implementation ownership changes."
+              $post = @{ body = $attestationBody }
+              Invoke-GhJson -Method POST -Endpoint "repos/$repo/issues/$prNumber/comments" -Body $post | Out-Null
+            }
+          }
+
+          if (-not $implementer) {
+            Set-AiReviewCheck -HeadSha $headSha -Conclusion failure -Summary 'Implementation provenance is not trusted. Agent-created PRs must use agent/<provider>/... (or recognized provider branch/author); human PRs must declare Implementer: human.'
+            exit 0
+          }
+
+          $reviewsRaw = & gh api "repos/$repo/pulls/$prNumber/reviews?per_page=100" 2>&1
+          if ($LASTEXITCODE -ne 0) { throw ($reviewsRaw -join "`n") }
+          $reviews = @(($reviewsRaw -join "`n") | ConvertFrom-Json)
+          $current = @($reviews | Where-Object {
+            $provider = Get-ProviderFromReviewer ([string]$_.user.login)
+            $_.commit_id -eq $headSha -and $_.state -notin @('DISMISSED','PENDING') -and $provider -and ($implementer -eq 'human' -or $provider -ne $implementer)
+          } | Sort-Object submitted_at)
+
+          if ($current.Count -eq 0) {
+            Set-AiReviewCheck -HeadSha $headSha -Conclusion failure -Summary "No current-head independent AI review exists for $headSha (implementer: $implementer)."
+            exit 0
+          }
+
+          $latest = $current[-1]
+          if ($latest.state -eq 'CHANGES_REQUESTED') {
+            Set-AiReviewCheck -HeadSha $headSha -Conclusion failure -Summary "Latest current-head independent review by $($latest.user.login) requests changes."
+            exit 0
+          }
+
+          Set-AiReviewCheck -HeadSha $headSha -Conclusion success -Summary "Current head $headSha has an independent review by $($latest.user.login); implementer attestation: $implementer. Review-thread resolution remains separately required by the branch ruleset."

--- a/.github/workflows/ai-review-reusable.yml
+++ b/.github/workflows/ai-review-reusable.yml
@@ -22,7 +22,6 @@ jobs:
           $ErrorActionPreference = 'Stop'
           $repo = $env:GITHUB_REPOSITORY
           $prNumber = [int]$env:PR_NUMBER
-          $marker = '<!-- agent-engineering:implementer-attestation -->'
 
           function Invoke-GhJson {
             param([string]$Method, [string]$Endpoint, $Body)
@@ -32,8 +31,7 @@ jobs:
               $raw = & gh api --method $Method $Endpoint --input $tmp 2>&1
               if ($LASTEXITCODE -ne 0) { throw ($raw -join "`n") }
               if ($raw) { return (($raw -join "`n") | ConvertFrom-Json) }
-            }
-            finally { Remove-Item $tmp -Force -ErrorAction SilentlyContinue }
+            } finally { Remove-Item $tmp -Force -ErrorAction SilentlyContinue }
           }
 
           function Get-ProviderFromReviewer([string]$Login) {
@@ -49,17 +47,13 @@ jobs:
             if ($LASTEXITCODE -ne 0) { throw ($raw -join "`n") }
             $runs = (($raw -join "`n") | ConvertFrom-Json).check_runs
             $existing = @($runs | Where-Object { $_.name -eq 'AI Review' -and $_.app.slug -eq 'github-actions' } | Sort-Object id | Select-Object -Last 1)
-            $body = @{
-              status = 'completed'
-              conclusion = $Conclusion
-              output = @{ title = 'AI Review'; summary = $Summary }
-            }
+            $checkBody = @{ status = 'completed'; conclusion = $Conclusion; output = @{ title = 'AI Review'; summary = $Summary } }
             if ($existing.Count -gt 0) {
-              Invoke-GhJson -Method PATCH -Endpoint "repos/$repo/check-runs/$($existing[0].id)" -Body $body | Out-Null
+              Invoke-GhJson -Method PATCH -Endpoint "repos/$repo/check-runs/$($existing[0].id)" -Body $checkBody | Out-Null
             } else {
-              $body.name = 'AI Review'
-              $body.head_sha = $HeadSha
-              Invoke-GhJson -Method POST -Endpoint "repos/$repo/check-runs" -Body $body | Out-Null
+              $checkBody.name = 'AI Review'
+              $checkBody.head_sha = $HeadSha
+              Invoke-GhJson -Method POST -Endpoint "repos/$repo/check-runs" -Body $checkBody | Out-Null
             }
           }
 
@@ -69,39 +63,24 @@ jobs:
           $headSha = [string]$pr.head.sha
           $headRef = [string]$pr.head.ref
           $author = [string]$pr.user.login
-          $body = [string]$pr.body
+          $prBody = [string]$pr.body
 
           if ($pr.draft) {
-            Set-AiReviewCheck -HeadSha $headSha -Conclusion failure -Summary 'Draft PR: semantic review is intentionally deferred.'
+            Set-AiReviewCheck $headSha failure 'Draft PR: semantic review is intentionally deferred.'
             exit 0
           }
 
-          $commentsRaw = & gh api "repos/$repo/issues/$prNumber/comments?per_page=100" 2>&1
-          if ($LASTEXITCODE -ne 0) { throw ($commentsRaw -join "`n") }
-          $comments = @(($commentsRaw -join "`n") | ConvertFrom-Json)
-          $attestation = $comments | Where-Object { $_.user.login -eq 'github-actions[bot]' -and $_.body -like "*$marker*" } | Select-Object -First 1
-
+          # LLM identity is accepted only from controlled branch namespaces or recognized bot authors.
+          # Editable PR prose may identify a human implementation, but cannot self-attest an LLM provider.
           $implementer = $null
-          if ($attestation -and $attestation.body -match '(?im)^Implementation provider:\s*`(claude|copilot|codex|human)`\s*$') {
-            $implementer = $Matches[1].ToLowerInvariant()
-          }
+          if ($headRef -match '^agent/(codex|claude|copilot)/') { $implementer = $Matches[1].ToLowerInvariant() }
+          elseif ($headRef -match '^claude/') { $implementer = 'claude' }
+          elseif ($headRef -match '^copilot/' -or $author -eq 'Copilot') { $implementer = 'copilot' }
+          elseif ($author -match '^chatgpt-codex-connector(?:\[bot\])?$') { $implementer = 'codex' }
+          elseif ($prBody -match '(?im)^\s*Implementer:\s*human\s*$') { $implementer = 'human' }
 
           if (-not $implementer) {
-            if ($headRef -match '^agent/(codex|claude|copilot)/') { $implementer = $Matches[1].ToLowerInvariant() }
-            elseif ($headRef -match '^claude/') { $implementer = 'claude' }
-            elseif ($headRef -match '^copilot/' -or $author -eq 'Copilot') { $implementer = 'copilot' }
-            elseif ($author -match '^chatgpt-codex-connector(?:\[bot\])?$') { $implementer = 'codex' }
-            elseif ($body -match '(?im)^\s*Implementer:\s*human\s*$') { $implementer = 'human' }
-
-            if ($implementer) {
-              $attestationBody = "$marker`nImplementation provider: ``$implementer```nAttested by GitHub Actions for branch ``$headRef``. This provider is immutable for this PR; start a new PR if implementation ownership changes."
-              $post = @{ body = $attestationBody }
-              Invoke-GhJson -Method POST -Endpoint "repos/$repo/issues/$prNumber/comments" -Body $post | Out-Null
-            }
-          }
-
-          if (-not $implementer) {
-            Set-AiReviewCheck -HeadSha $headSha -Conclusion failure -Summary 'Implementation provenance is not trusted. Agent-created PRs must use agent/<provider>/... (or recognized provider branch/author); human PRs must declare Implementer: human.'
+            Set-AiReviewCheck $headSha failure 'Unknown implementation provenance. Agent PRs must use agent/<provider>/... or a recognized provider branch/author; human PRs must declare Implementer: human.'
             exit 0
           }
 
@@ -114,14 +93,14 @@ jobs:
           } | Sort-Object submitted_at)
 
           if ($current.Count -eq 0) {
-            Set-AiReviewCheck -HeadSha $headSha -Conclusion failure -Summary "No current-head independent AI review exists for $headSha (implementer: $implementer)."
+            Set-AiReviewCheck $headSha failure "No current-head independent AI review exists for $headSha (implementer: $implementer)."
             exit 0
           }
 
           $latest = $current[-1]
           if ($latest.state -eq 'CHANGES_REQUESTED') {
-            Set-AiReviewCheck -HeadSha $headSha -Conclusion failure -Summary "Latest current-head independent review by $($latest.user.login) requests changes."
+            Set-AiReviewCheck $headSha failure "Latest current-head independent review by $($latest.user.login) requests changes."
             exit 0
           }
 
-          Set-AiReviewCheck -HeadSha $headSha -Conclusion success -Summary "Current head $headSha has an independent review by $($latest.user.login); implementer attestation: $implementer. Review-thread resolution remains separately required by the branch ruleset."
+          Set-AiReviewCheck $headSha success "Current head $headSha has an independent review by $($latest.user.login); implementer: $implementer. Review-thread resolution is separately required by the branch ruleset."

--- a/.github/workflows/ai-review-reusable.yml
+++ b/.github/workflows/ai-review-reusable.yml
@@ -34,7 +34,7 @@ jobs:
             } finally { Remove-Item $tmp -Force -ErrorAction SilentlyContinue }
           }
 
-          function Get-ProviderFromReviewer([string]$Login) {
+          function Get-ProviderFromLogin([string]$Login) {
             $value = $Login.ToLowerInvariant()
             if ($value -in @('chatgpt-codex-connector','chatgpt-codex-connector[bot]')) { return 'codex' }
             if ($value -in @('copilot-pull-request-reviewer','copilot-pull-request-reviewer[bot]','copilot','copilot-swe-agent[bot]')) { return 'copilot' }
@@ -63,64 +63,74 @@ jobs:
           $headSha = [string]$pr.head.sha
           $headRef = [string]$pr.head.ref
           $author = [string]$pr.user.login
-          $prBody = [string]$pr.body
 
           if ($pr.draft) {
             Set-AiReviewCheck $headSha failure 'Draft PR: semantic review is intentionally deferred.'
             exit 0
           }
 
-          # LLM identity is accepted only from controlled branch namespaces or recognized bot authors.
-          # Editable PR prose may identify a human implementation, but cannot self-attest an LLM provider.
-          $implementer = $null
-          if ($headRef -match '^agent/(codex|claude|copilot)/') { $implementer = $Matches[1].ToLowerInvariant() }
+          # Agent provenance is mechanical. Ordinary user-authored branches are deliberately
+          # ambiguous and therefore require BOTH connected providers before automated merge.
+          $implementer = 'unknown'
+          if ($headRef -match '^agent/(chatgpt|codex|claude|copilot)/') { $implementer = $Matches[1].ToLowerInvariant() }
           elseif ($headRef -match '^claude/') { $implementer = 'claude' }
           elseif ($headRef -match '^copilot/' -or $author -eq 'Copilot') { $implementer = 'copilot' }
           elseif ($author -match '^chatgpt-codex-connector(?:\[bot\])?$') { $implementer = 'codex' }
-          elseif ($prBody -match '(?im)^\s*Implementer:\s*human\s*$') { $implementer = 'human' }
 
-          if (-not $implementer) {
-            Set-AiReviewCheck $headSha failure 'Unknown implementation provenance. Agent PRs must use agent/<provider>/... or a recognized provider branch/author; human PRs must declare Implementer: human.'
-            exit 0
+          $requiredProviders = switch ($implementer) {
+            'codex' { @('copilot') }
+            'chatgpt' { @('copilot') }
+            'copilot' { @('codex') }
+            'claude' { @('codex') }
+            default { @('codex','copilot') }
           }
 
           $reviewsRaw = & gh api "repos/$repo/pulls/$prNumber/reviews?per_page=100" 2>&1
           if ($LASTEXITCODE -ne 0) { throw ($reviewsRaw -join "`n") }
           $reviews = @(($reviewsRaw -join "`n") | ConvertFrom-Json)
-          $currentReviews = @($reviews | Where-Object {
-            $provider = Get-ProviderFromReviewer ([string]$_.user.login)
-            $_.commit_id -eq $headSha -and $_.state -notin @('DISMISSED','PENDING') -and $provider -and ($implementer -eq 'human' -or $provider -ne $implementer)
-          } | Sort-Object submitted_at)
 
-          if ($currentReviews.Count -gt 0) {
-            $latest = $currentReviews[-1]
-            if ($latest.state -eq 'CHANGES_REQUESTED') {
-              Set-AiReviewCheck $headSha failure "Latest current-head independent review by $($latest.user.login) requests changes."
-              exit 0
-            }
-            Set-AiReviewCheck $headSha success "Current head $headSha has an independent formal review by $($latest.user.login); implementer: $implementer."
-            exit 0
-          }
-
-          # Copilot coding-agent fallback: accept only a structured response from a recognized Copilot bot,
-          # containing the exact current SHA. User-authored or stale comments can never satisfy this gate.
           $commentsRaw = & gh api "repos/$repo/issues/$prNumber/comments?per_page=100" 2>&1
           if ($LASTEXITCODE -ne 0) { throw ($commentsRaw -join "`n") }
           $comments = @(($commentsRaw -join "`n") | ConvertFrom-Json)
-          $structured = @($comments | Where-Object {
-            $provider = Get-ProviderFromReviewer ([string]$_.user.login)
-            $provider -eq 'copilot' -and ($implementer -eq 'human' -or $implementer -ne 'copilot') -and
-            $_.body -match '(?im)^\s*AI-REVIEW\s+(PASS|FAIL)\b' -and $_.body -match [regex]::Escape($headSha)
-          } | Sort-Object created_at)
 
+          $passed = @{}
+          $failed = @{}
+          foreach ($provider in @('codex','copilot')) {
+            $providerReviews = @($reviews | Where-Object {
+              (Get-ProviderFromLogin ([string]$_.user.login)) -eq $provider -and
+              $_.commit_id -eq $headSha -and $_.state -notin @('DISMISSED','PENDING')
+            } | Sort-Object submitted_at)
+            if ($providerReviews.Count -gt 0) {
+              $latest = $providerReviews[-1]
+              if ($latest.state -eq 'CHANGES_REQUESTED') { $failed[$provider] = "formal review by $($latest.user.login) requests changes" }
+              else { $passed[$provider] = "formal review by $($latest.user.login)" }
+            }
+          }
+
+          # Copilot coding-agent fallback may return a structured issue comment instead of a formal review.
+          $structured = @($comments | Where-Object {
+            (Get-ProviderFromLogin ([string]$_.user.login)) -eq 'copilot' -and
+            $_.body -match '(?im)^\s*AI-REVIEW\s+(PASS|FAIL)\b' -and
+            $_.body -match [regex]::Escape($headSha)
+          } | Sort-Object created_at)
           if ($structured.Count -gt 0) {
             $latestComment = $structured[-1]
-            if ($latestComment.body -match '(?im)^\s*AI-REVIEW\s+FAIL\b') {
-              Set-AiReviewCheck $headSha failure "Structured current-head Copilot fallback review reported material findings."
+            if ($latestComment.body -match '(?im)^\s*AI-REVIEW\s+FAIL\b') { $failed['copilot'] = 'structured Copilot fallback reported material findings' }
+            elseif (-not $failed.ContainsKey('copilot')) { $passed['copilot'] = 'structured Copilot fallback' }
+          }
+
+          foreach ($provider in $requiredProviders) {
+            if ($failed.ContainsKey($provider)) {
+              Set-AiReviewCheck $headSha failure "Required $provider review failed: $($failed[$provider])."
               exit 0
             }
-            Set-AiReviewCheck $headSha success "Current head $headSha has a structured independent Copilot fallback review; implementer: $implementer."
+          }
+
+          $missing = @($requiredProviders | Where-Object { -not $passed.ContainsKey($_) })
+          if ($missing.Count -gt 0) {
+            Set-AiReviewCheck $headSha failure "Missing current-head required review provider(s): $($missing -join ', '). Implementer provenance: $implementer."
             exit 0
           }
 
-          Set-AiReviewCheck $headSha failure "No current-head independent AI review exists for $headSha (implementer: $implementer)."
+          $proof = @($requiredProviders | ForEach-Object { "$_=$($passed[$_])" }) -join '; '
+          Set-AiReviewCheck $headSha success "Current head $headSha satisfies required review providers for implementer=$implementer. $proof"

--- a/.github/workflows/ai-review-reusable.yml
+++ b/.github/workflows/ai-review-reusable.yml
@@ -37,7 +37,7 @@ jobs:
           function Get-ProviderFromReviewer([string]$Login) {
             $value = $Login.ToLowerInvariant()
             if ($value -in @('chatgpt-codex-connector','chatgpt-codex-connector[bot]')) { return 'codex' }
-            if ($value -in @('copilot-pull-request-reviewer','copilot-pull-request-reviewer[bot]')) { return 'copilot' }
+            if ($value -in @('copilot-pull-request-reviewer','copilot-pull-request-reviewer[bot]','copilot','copilot-swe-agent[bot]')) { return 'copilot' }
             return $null
           }
 
@@ -87,20 +87,40 @@ jobs:
           $reviewsRaw = & gh api "repos/$repo/pulls/$prNumber/reviews?per_page=100" 2>&1
           if ($LASTEXITCODE -ne 0) { throw ($reviewsRaw -join "`n") }
           $reviews = @(($reviewsRaw -join "`n") | ConvertFrom-Json)
-          $current = @($reviews | Where-Object {
+          $currentReviews = @($reviews | Where-Object {
             $provider = Get-ProviderFromReviewer ([string]$_.user.login)
             $_.commit_id -eq $headSha -and $_.state -notin @('DISMISSED','PENDING') -and $provider -and ($implementer -eq 'human' -or $provider -ne $implementer)
           } | Sort-Object submitted_at)
 
-          if ($current.Count -eq 0) {
-            Set-AiReviewCheck $headSha failure "No current-head independent AI review exists for $headSha (implementer: $implementer)."
+          if ($currentReviews.Count -gt 0) {
+            $latest = $currentReviews[-1]
+            if ($latest.state -eq 'CHANGES_REQUESTED') {
+              Set-AiReviewCheck $headSha failure "Latest current-head independent review by $($latest.user.login) requests changes."
+              exit 0
+            }
+            Set-AiReviewCheck $headSha success "Current head $headSha has an independent formal review by $($latest.user.login); implementer: $implementer."
             exit 0
           }
 
-          $latest = $current[-1]
-          if ($latest.state -eq 'CHANGES_REQUESTED') {
-            Set-AiReviewCheck $headSha failure "Latest current-head independent review by $($latest.user.login) requests changes."
+          # Copilot coding-agent fallback: accept only a structured response from a recognized Copilot bot,
+          # containing the exact current SHA. User-authored or stale comments can never satisfy this gate.
+          $commentsRaw = & gh api "repos/$repo/issues/$prNumber/comments?per_page=100" 2>&1
+          if ($LASTEXITCODE -ne 0) { throw ($commentsRaw -join "`n") }
+          $comments = @(($commentsRaw -join "`n") | ConvertFrom-Json)
+          $structured = @($comments | Where-Object {
+            $provider = Get-ProviderFromReviewer ([string]$_.user.login)
+            $provider -eq 'copilot' -and ($implementer -eq 'human' -or $implementer -ne 'copilot') -and
+            $_.body -match '(?im)^\s*AI-REVIEW\s+(PASS|FAIL)\b' -and $_.body -match [regex]::Escape($headSha)
+          } | Sort-Object created_at)
+
+          if ($structured.Count -gt 0) {
+            $latestComment = $structured[-1]
+            if ($latestComment.body -match '(?im)^\s*AI-REVIEW\s+FAIL\b') {
+              Set-AiReviewCheck $headSha failure "Structured current-head Copilot fallback review reported material findings."
+              exit 0
+            }
+            Set-AiReviewCheck $headSha success "Current head $headSha has a structured independent Copilot fallback review; implementer: $implementer."
             exit 0
           }
 
-          Set-AiReviewCheck $headSha success "Current head $headSha has an independent review by $($latest.user.login); implementer: $implementer. Review-thread resolution is separately required by the branch ruleset."
+          Set-AiReviewCheck $headSha failure "No current-head independent AI review exists for $headSha (implementer: $implementer)."

--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -1,0 +1,18 @@
+name: AI Review Gate
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, ready_for_review, edited]
+  pull_request_review:
+    types: [submitted, dismissed]
+
+jobs:
+  update-ai-review:
+    permissions:
+      checks: write
+      contents: read
+      issues: write
+      pull-requests: read
+    uses: ./.github/workflows/ai-review-reusable.yml
+    with:
+      pr_number: ${{ github.event.pull_request.number }}

--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -11,7 +11,6 @@ jobs:
     permissions:
       checks: write
       contents: read
-      issues: write
       pull-requests: read
     uses: ./.github/workflows/ai-review-reusable.yml
     with:

--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -8,6 +8,10 @@ on:
   issue_comment:
     types: [created, edited]
 
+concurrency:
+  group: ai-review-${{ github.repository }}-${{ github.event.pull_request.number || github.event.issue.number }}
+  cancel-in-progress: true
+
 jobs:
   update-ai-review:
     if: github.event_name != 'issue_comment' || github.event.issue.pull_request != null

--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -5,13 +5,16 @@ on:
     types: [opened, reopened, synchronize, ready_for_review, edited]
   pull_request_review:
     types: [submitted, dismissed]
+  issue_comment:
+    types: [created, edited]
 
 jobs:
   update-ai-review:
+    if: github.event_name != 'issue_comment' || github.event.issue.pull_request != null
     permissions:
       checks: write
       contents: read
       pull-requests: read
     uses: ./.github/workflows/ai-review-reusable.yml
     with:
-      pr_number: ${{ github.event.pull_request.number }}
+      pr_number: ${{ github.event.pull_request.number || github.event.issue.number }}

--- a/AGENT_RULES.md
+++ b/AGENT_RULES.md
@@ -44,26 +44,28 @@ Do not repeat the same failing strategy indefinitely. Escalate consequential amb
 
 Keep a PR draft while implementation is changing. Run fast local verification during slices, then mark the coherent PR ready.
 
-Every automated merge requires two independent GitHub integration gates on the **latest head SHA**:
+Every automated merge requires two GitHub integration gates on the **latest head SHA**:
 
 1. `PR Gate` — deterministic repo-specific evidence
-2. `AI Review` — current-head semantic review from a different implementation provider
+2. `AI Review` — required provider-specific semantic evidence for the exact head
 
-A later push creates a new head SHA and therefore invalidates the prior `AI Review` result. Auto-merge may remain armed, but GitHub cannot merge until the new head receives a successful `AI Review` check.
+A later push creates a new head SHA and invalidates the prior semantic authorization. Auto-merge may remain armed, but GitHub cannot merge until the new head receives a successful `AI Review` check.
 
-Implementation provenance is attested by GitHub Actions, not trusted from an editable PR-body claim:
+Agent provenance is mechanical, not trusted from editable PR prose:
 
-- controlled local agents use `agent/<provider>/<work>` branches
-- legacy Claude/Copilot cloud branches may use their recognized provider prefix/author
-- human work may declare `Implementer: human`
-- unknown provenance fails closed
+- ChatGPT work: `agent/chatgpt/<work>`
+- Codex work: `agent/codex/<work>`
+- Claude work: `agent/claude/<work>` or recognized legacy Claude cloud branch
+- Copilot work: `agent/copilot/<work>` or recognized Copilot branch/author
+- ordinary/user-authored branches are ambiguous for independence and therefore need both connected reviewer providers for unattended merge
 
-Default connected reviewer routing:
+Default required reviewer routing:
 
-- Claude implementation → Codex review
-- Copilot implementation → Codex review
-- Codex implementation → one Copilot review
-- human implementation → Codex by default
+- ChatGPT implementation → Copilot
+- Claude implementation → Codex
+- Copilot implementation → Codex
+- Codex implementation → Copilot
+- ambiguous/user-authored provenance → Codex + Copilot
 
 Do not claim a fresh-Claude fallback until a mechanical Claude review adapter exists.
 
@@ -74,15 +76,16 @@ The default semantic reviewer performs **one batched multi-lens pass**:
 3. business systems/operational optimization
 4. leanness/complexity/dead-code/manual-toil review
 
-A second semantic pass is justified only after substantive fixes, unresolved ambiguity, or provider fallback.
+A second semantic pass is justified only after substantive fixes, unresolved ambiguity, or when ambiguous provenance requires the second connected provider.
 
 Cost rules:
 
 - deterministic checks before LLM review
-- Codex primary; local deep review defaults to `gpt-5.4-mini`
-- max 2 Codex passes per PR: initial + one post-fix re-review
-- Copilot fallback max 1 review per PR, low effort
+- Codex primary for Claude/Copilot/ambiguous work; local deep review defaults to `gpt-5.4-mini`
+- max 2 Codex response passes per PR: initial + one post-fix re-review
+- max 1 Copilot response pass per PR, low effort
 - no default draft review or unlimited review-on-push spending
+- per-head request markers prevent duplicate requests
 - active implementation stays draft so noisy micro-pushes do not consume semantic review budget
 
 R0–R3 may auto-merge only when both required gates are enforced, review threads are resolved, and no justified manual authority gate applies. Control-plane changes remain manually merged while they can alter the evaluator that judges themselves.

--- a/AGENT_RULES.md
+++ b/AGENT_RULES.md
@@ -42,40 +42,52 @@ Do not repeat the same failing strategy indefinitely. Escalate consequential amb
 
 ## 6. Independent review and merge
 
-Keep a PR draft while implementation is still changing. Run the repo's local/fast verification during slices, then mark the coherent PR ready so the independent `PR Gate` runs.
+Keep a PR draft while implementation is changing. Run fast local verification during slices, then mark the coherent PR ready.
 
-**The implementing agent must request a different review agent after the final substantive push.** Do not leave reviewer selection as a human reminder. Use the shared review router when available; otherwise perform the equivalent bounded handoff and record the reviewer provider.
+Every automated merge requires two independent GitHub integration gates on the **latest head SHA**:
 
-Every auto-merged PR needs a current-head independent AI review. Independence means the reviewer provider did not implement the PR and the reviewer did not inherit the implementation session/context.
+1. `PR Gate` — deterministic repo-specific evidence
+2. `AI Review` — current-head semantic review from a different implementation provider
 
-Default routing:
+A later push creates a new head SHA and therefore invalidates the prior `AI Review` result. Auto-merge may remain armed, but GitHub cannot merge until the new head receives a successful `AI Review` check.
 
-- Claude implementation → Codex GitHub review
-- Copilot implementation → Codex GitHub review
-- Codex implementation → one Copilot review; use a fresh Claude session/model/context only if Copilot is unavailable
-- human/unknown implementation → Codex by default
+Implementation provenance is attested by GitHub Actions, not trusted from an editable PR-body claim:
 
-The default reviewer performs **one batched multi-lens pass** rather than spawning several paid reviewers:
+- controlled local agents use `agent/<provider>/<work>` branches
+- legacy Claude/Copilot cloud branches may use their recognized provider prefix/author
+- human work may declare `Implementer: human`
+- unknown provenance fails closed
+
+Default connected reviewer routing:
+
+- Claude implementation → Codex review
+- Copilot implementation → Codex review
+- Codex implementation → one Copilot review
+- human implementation → Codex by default
+
+Do not claim a fresh-Claude fallback until a mechanical Claude review adapter exists.
+
+The default semantic reviewer performs **one batched multi-lens pass**:
 
 1. software correctness/security
 2. business/product outcome and ROI
 3. business systems/operational optimization
 4. leanness/complexity/dead-code/manual-toil review
 
-A second semantic reviewer is justified only when the first review finds material ambiguity, the risk model requires stronger independence, or the primary reviewer is unavailable.
+A second semantic pass is justified only after substantive fixes, unresolved ambiguity, or provider fallback.
 
 Cost rules:
 
-- deterministic checks run before LLM review
-- Codex is primary; local deep review defaults to `gpt-5.4-mini`
-- at most 2 Codex reviews per PR: initial + one post-fix re-review
-- Copilot is fallback-only, low effort, at most 1 review per PR
-- do not enable Copilot review-on-push or draft review by default
-- do not repeatedly pay for a reviewer because implementation was pushed in noisy micro-commits; keep active work draft and request review after the final substantive push
+- deterministic checks before LLM review
+- Codex primary; local deep review defaults to `gpt-5.4-mini`
+- max 2 Codex passes per PR: initial + one post-fix re-review
+- Copilot fallback max 1 review per PR, low effort
+- no default draft review or unlimited review-on-push spending
+- active implementation stays draft so noisy micro-pushes do not consume semantic review budget
 
-R0–R3 may auto-merge only after the current head has an independent AI review, required `PR Gate` is live/enforced, and review threads are resolved. Control-plane changes are at least R3; they are not forced through a human approval merely because they are important.
+R0–R3 may auto-merge only when both required gates are enforced, review threads are resolved, and no justified manual authority gate applies. Control-plane changes remain manually merged while they can alter the evaluator that judges themselves.
 
-R4 never auto-merges. The manual gate is authorization for destructive/financial/privileged/irreversible consequence, not a substitute for technical review.
+R4 never auto-merges. Its manual step authorizes destructive/financial/privileged/irreversible consequence; it is not a substitute for technical review.
 
 ## 7. Manual gates must earn their existence
 
@@ -83,21 +95,19 @@ Never add or preserve a manual gate merely because work is "important", "sensiti
 
 Every manual gate must state all four:
 
-1. **failure class prevented** — the concrete bad outcome
-2. **why automation is insufficient today** — the missing signal/capability, not a vague trust claim
-3. **decision owner** — who has the authority the machine lacks
-4. **gate removal condition** — the measurable condition that lets us automate/delete the gate
+1. **failure class prevented** — concrete bad outcome
+2. **why automation is insufficient today** — missing signal/capability, not vague trust
+3. **decision owner** — who has authority the machine lacks
+4. **gate removal condition** — measurable condition that lets us automate/delete it
 
 If any field is missing, the gate is unjustified and should be removed or replaced with objective automation.
 
-Manual review is not automatically required for R3. Prefer independent AI review + deterministic controls. Use a manual gate only when a real authority/intent decision cannot yet be safely derived or bounded.
-
 ## 8. Turn manual toil into system improvement
 
-When an agent or human performs a manual workaround, ask whether the same work could recur.
+When an agent or human performs a manual workaround, ask whether it can recur.
 
-- If the automation is small, safe, and in scope: automate it now.
-- Otherwise record one concise automation/research candidate with the observed problem, evidence/frequency, current human cost, research needed, smallest experiment, expected payoff, and deletion/expiry condition.
-- Do not create idea landfill. A candidate without evidence, plausible ROI, or a next experiment is discarded.
+- If automation is small, safe, and in scope: automate it now.
+- Otherwise record one concise automation/research candidate with problem, evidence/frequency, human cost, research needed, smallest experiment, expected payoff, and deletion/expiry condition.
+- Discard candidates without evidence, plausible ROI, or a next experiment.
 
 Repeated manual work must not become normal merely because an agent can keep doing it.

--- a/DELIVERY_GITHUB.md
+++ b/DELIVERY_GITHUB.md
@@ -10,46 +10,50 @@ GitHub Issues are the durable work-item source. A PR is the smallest coherent in
 
 Prefer:
 
-`Issue → SPEC only if needed → thin local slices → draft PR while iterating → ready PR → PR Gate → auto-merge/queue → release`
+`Issue → SPEC only if needed → thin local slices → draft PR while iterating → ready PR → PR Gate + AI Review → auto-merge/queue → release`
 
 Do not make PRs artificially large to save CI minutes. Save minutes by verifying slices locally, pushing less often, canceling superseded runs, caching, and reserving expensive assurance for changes that justify it.
 
-Name short-lived branches `<type>/<issue-number>-<short-description>` so each branch traces directly to its Issue (for example `feat/42-optional-sections`, `fix/81-router-timeout`, `chore/105-ci-cache`).
+Name ordinary short-lived branches `<type>/<issue-number>-<short-description>`. Controlled local agent runs may use `agent/<provider>/<issue-or-work>` so GitHub Actions can attest implementation provenance without trusting editable PR prose.
 
-## 2. Required PR Gate
+## 2. Required integration gates
 
-Every managed repository exposes one stable required status context named **`PR Gate`**.
+Every managed repository exposes two stable required contexts on the latest PR head:
 
-Draft pushes should not consume the full required gate. If a workflow emits a skipped job for draft events, that skipped job must use a different check name; a skipped job named `PR Gate` must never be allowed to satisfy the required context.
+- **`PR Gate`** — cheapest sufficient deterministic build/test/security evidence.
+- **`AI Review`** — current-head semantic review from a provider independent of the attested implementer.
 
-`PR Gate` runs the cheapest independent evidence sufficient to block a bad merge for that repository. It should normally finish in about 10 minutes or less and may contain or aggregate repo-specific build/type/lint, unit/property/regression, changed-file/architecture, critical integration/contract/acceptance, and lightweight security/dependency evidence.
+Both contexts are bound to the GitHub Actions App. A later push creates a new SHA, so an `AI Review` success from an earlier head cannot satisfy the latest commit.
 
-Do not require every available test category on every change.
+Draft pushes should not spend semantic-review budget. Keep active work draft, request review when coherent, and allow at most the bounded re-review budget after substantive fixes.
 
-Bind the required `PR Gate` context to the GitHub Actions App integration, not only to a status name.
+`PR Gate` should normally finish in about 10 minutes or less and may contain repo-specific build/type/lint, unit/property/regression, changed-file/architecture, critical integration/contract/acceptance, and lightweight security/dependency evidence. Do not require every available test category on every change.
 
-CODEOWNERS should map the required workflow plus the small repo-specific entrypoints that determine what it executes (for example test scripts/config, coverage-gate code, or locked acceptance evaluators). Do not CODEOWN all product tests merely to satisfy this rule.
+`AI Review` uses GitHub-Actions-attested implementation provenance plus recognized review providers. Unknown provenance fails closed. Review-thread resolution remains separately required so material inline findings cannot be ignored.
 
-For today's single-developer, user-owned repositories, CODEOWNERS is **advisory**, not a required approval gate: a pull-request author cannot approve their own PR, so requiring Code Owner approval would deadlock the normal solo workflow. R3/R4/control-plane changes instead require fresh external semantic review and are excluded from automatic merge. Once repositories move to an organization with an independent reviewer/team, enable required Code Owner review and prefer an organization-required workflow sourced from this standards repo.
+For today's single-developer, user-owned repositories, CODEOWNERS is advisory and human approval count is 0. Required Code Owner review would deadlock a solo personal-repo workflow. Organization-owned repos may harden CODEOWNERS through the shared policy.
 
-Use **loose** required status checks (`strict_required_status_checks_policy: false`) by default so a PR does not rebuild merely because `main` moved. A merge queue, when available, provides the final combined-head integration check.
+Use loose required status checks (`strict_required_status_checks_policy: false`) by default so a PR does not rebuild merely because `main` moved. A merge queue, when available, provides final combined-head integration checking.
 
 ## 3. Expensive assurance
 
-Keep expensive or environment-specific checks outside the universal PR Gate unless risk makes them necessary blockers: full OS/browser matrices, mutation campaigns, extended fuzzing, load/performance, broad security scans, and slow production-like E2E.
+Keep expensive/environment-specific checks outside the universal gates unless risk makes them necessary blockers: full OS/browser matrices, mutation campaigns, extended fuzzing, load/performance, broad security scans, and slow production-like E2E.
 
-Run them through risk/path-triggered jobs, explicit escalation, main/release validation, or scheduled/manual workflows. A correctness-critical or security-critical check stays blocking even when expensive.
+Run them through risk/path triggers, explicit escalation, main/release validation, or scheduled/manual workflows. A correctness/security-critical check stays blocking even when expensive.
 
-## 4. Actions efficiency
+## 4. Actions and model efficiency
 
-- Keep PRs draft during active iteration; run fast local evidence per slice.
-- Cancel superseded ready-PR runs with workflow concurrency.
-- Prefer one setup/install per required lane when extra parallel jobs mostly duplicate setup cost.
-- Cache dependencies when safe/useful.
-- Avoid redundant push+PR execution for the same evidence.
-- Remove/demote expensive checks that rarely change a decision.
+- Keep PRs draft during active iteration.
+- Cancel superseded deterministic runs.
+- Prefer one setup/install per required lane when parallel jobs mostly duplicate setup cost.
+- Cache dependencies when useful/safe.
+- Avoid redundant push+PR execution.
+- Run deterministic checks before semantic LLM review.
+- Prefer one batched semantic review over several specialist calls.
+- Codex is the primary reviewer lane; Copilot is bounded fallback, not an every-push tax.
+- Remove/demote checks or model calls that rarely change a decision.
 
-Optimize for **fast trustworthy feedback per compute-minute**, not minimum Actions usage in isolation.
+Optimize for **fast trustworthy feedback per human minute, compute-minute, and model cost**.
 
 ## 5. Merge and protection defaults
 
@@ -57,32 +61,22 @@ For the default branch:
 
 - require a PR
 - require GitHub-Actions-produced `PR Gate`
+- require GitHub-Actions-produced exact-head `AI Review`
 - require resolution of review threads
-- require 0 human approvals by default for routine work
+- require 0 human approvals by default on personal repos
 - disallow force-push and branch deletion
-- use squash merge as the normal merge method
+- squash only
 - allow auto-merge
 - automatically delete merged head branches
-- define no silent bypass actors
+- no silent bypass actors
 
-R0–R2 may use risk-aware auto-merge after the PR is ready. R3/R4 and control-plane changes require a fresh independent semantic review after the final substantive push and must not auto-merge while a material finding is unresolved.
+R0–R3 may use auto-merge when both required gates are green and no justified authority gate applies. R4 never auto-merges.
 
-Today, repo-local workflow files are still editable by a control-plane PR, so this R3 review requirement is an extra trust boundary rather than a claim that the local evaluator is immutable. Organization-required workflows are the stronger future boundary.
+Control-plane changes remain manually merged **only** while the PR can modify the evaluator/merge authority judging itself. Remove that gate once governing enforcement lives in an immutable external or organization-required workflow the PR cannot edit.
 
 ## 6. Merge queue
 
-Use a merge queue when GitHub supports it and concurrent agent PR volume justifies it. Required-check workflows must trigger on `merge_group` or queued PRs can deadlock.
-
-Default queue posture:
-
-- squash merge
-- `HEADGREEN` grouping
-- build concurrency 3
-- merge groups up to 5 PRs
-- 1-minute maximum grouping wait
-- 10-minute required-check response timeout
-
-User-owned repositories remain queue-ready but cannot enable the queue until moved to a supported organization.
+Use a merge queue when GitHub supports it and concurrent agent PR volume justifies it. Required-check workflows must support `merge_group` before enabling the queue. User-owned repositories remain queue-ready but do not enable it until the exact-head semantic-review behavior for merge groups is explicitly implemented and verified.
 
 ## 7. Release
 
@@ -92,10 +86,12 @@ For higher-risk releases, build once, identify the immutable artifact/commit, pr
 
 ## 8. Shared control plane
 
-`policy/github-defaults.json` is the machine-readable portfolio default.
+`policy/github-defaults.json` is the machine-readable portfolio policy.
 
-- `scripts/apply-github-standard.ps1` applies repository settings, Actions, labels, and default-branch rules. After the canonical ruleset succeeds, it removes only a stale legacy required-status-check block so retired check names cannot keep a branch unmergeable; all other legacy protections remain untouched.
-- `scripts/auto-merge.ps1` is the risk-aware R0–R2 happy path and refuses R3/R4/control-plane PRs.
-- `scripts/doctor.ps1 -Remote` verifies effective remote policy, including the absence of noncanonical legacy required-check contexts, and exits nonzero on drift.
+- `scripts/apply-github-standard.ps1` applies repository settings, labels, Actions, and default-branch rules.
+- `.github/workflows/ai-review-reusable.yml` is the shared exact-head semantic-review evaluator; product repos use the thin caller template.
+- `scripts/request-independent-review.ps1` routes bounded review requests from GitHub-Actions-attested implementation provenance.
+- `scripts/auto-merge.ps1` validates the live integration plane and then arms GitHub auto-merge; it does not substitute its own call-time semantic judgment for the required `AI Review` context.
+- `scripts/doctor.ps1 -Remote` verifies effective remote policy and exits nonzero on drift.
 
-Prefer centrally maintained policy and stable check naming; keep stack-specific test commands inside each product repo.
+Prefer centrally maintained policy and stable check names; keep stack-specific deterministic commands inside each product repo.

--- a/DELIVERY_GITHUB.md
+++ b/DELIVERY_GITHUB.md
@@ -14,22 +14,24 @@ Prefer:
 
 Do not make PRs artificially large to save CI minutes. Save minutes by verifying slices locally, pushing less often, canceling superseded runs, caching, and reserving expensive assurance for changes that justify it.
 
-Name ordinary short-lived branches `<type>/<issue-number>-<short-description>`. Controlled local agent runs may use `agent/<provider>/<issue-or-work>` so GitHub Actions can attest implementation provenance without trusting editable PR prose.
+Name ordinary short-lived branches `<type>/<issue-number>-<short-description>`. Controlled agent runs use `agent/<provider>/<issue-or-work>` so review independence can be derived mechanically rather than trusted from editable PR prose.
 
 ## 2. Required integration gates
 
 Every managed repository exposes two stable required contexts on the latest PR head:
 
 - **`PR Gate`** — cheapest sufficient deterministic build/test/security evidence.
-- **`AI Review`** — current-head semantic review from a provider independent of the attested implementer.
+- **`AI Review`** — exact-head provider-specific semantic evidence required by implementation provenance.
 
 Both contexts are bound to the GitHub Actions App. A later push creates a new SHA, so an `AI Review` success from an earlier head cannot satisfy the latest commit.
 
-Draft pushes should not spend semantic-review budget. Keep active work draft, request review when coherent, and allow at most the bounded re-review budget after substantive fixes.
+Known provider routing is deliberately cheap: ChatGPT/Codex implementations require Copilot; Claude/Copilot implementations require Codex. Ordinary/user-authored branches are ambiguous for reviewer independence and require both connected providers before unattended merge.
+
+Draft pushes should not spend semantic-review budget. Keep active work draft, request review when coherent, and allow only the bounded response-pass budget after substantive fixes.
 
 `PR Gate` should normally finish in about 10 minutes or less and may contain repo-specific build/type/lint, unit/property/regression, changed-file/architecture, critical integration/contract/acceptance, and lightweight security/dependency evidence. Do not require every available test category on every change.
 
-`AI Review` uses GitHub-Actions-attested implementation provenance plus recognized review providers. Unknown provenance fails closed. Review-thread resolution remains separately required so material inline findings cannot be ignored.
+`AI Review` derives agent provenance from controlled provider branch/author metadata. It never trusts editable PR prose to self-attest an LLM provider. Review-thread resolution remains separately required so material inline findings cannot be ignored.
 
 For today's single-developer, user-owned repositories, CODEOWNERS is advisory and human approval count is 0. Required Code Owner review would deadlock a solo personal-repo workflow. Organization-owned repos may harden CODEOWNERS through the shared policy.
 
@@ -44,13 +46,14 @@ Run them through risk/path triggers, explicit escalation, main/release validatio
 ## 4. Actions and model efficiency
 
 - Keep PRs draft during active iteration.
-- Cancel superseded deterministic runs.
+- Cancel superseded deterministic and `AI Review` evaluator runs per PR.
 - Prefer one setup/install per required lane when parallel jobs mostly duplicate setup cost.
 - Cache dependencies when useful/safe.
 - Avoid redundant push+PR execution.
 - Run deterministic checks before semantic LLM review.
 - Prefer one batched semantic review over several specialist calls.
-- Codex is the primary reviewer lane; Copilot is bounded fallback, not an every-push tax.
+- Codex is the cheap default where it is cross-provider; Copilot is used when it is the required cross-provider reviewer, not as an every-push tax.
+- Review budgets count actual semantic responses; exact-head request markers prevent duplicate triggers.
 - Remove/demote checks or model calls that rarely change a decision.
 
 Optimize for **fast trustworthy feedback per human minute, compute-minute, and model cost**.
@@ -90,8 +93,8 @@ For higher-risk releases, build once, identify the immutable artifact/commit, pr
 
 - `scripts/apply-github-standard.ps1` applies repository settings, labels, Actions, and default-branch rules.
 - `.github/workflows/ai-review-reusable.yml` is the shared exact-head semantic-review evaluator; product repos use the thin caller template.
-- `scripts/request-independent-review.ps1` routes bounded review requests from GitHub-Actions-attested implementation provenance.
+- `scripts/request-independent-review.ps1` routes the next missing required provider within the configured response budget.
 - `scripts/auto-merge.ps1` validates the live integration plane and then arms GitHub auto-merge; it does not substitute its own call-time semantic judgment for the required `AI Review` context.
-- `scripts/doctor.ps1 -Remote` verifies effective remote policy and exits nonzero on drift.
+- `scripts/doctor.ps1 -Remote` verifies effective remote policy, including that the AI Review workflow itself is active, and exits nonzero on drift.
 
-Prefer centrally maintained policy and stable check names; keep stack-specific deterministic commands inside each product repo.
+Prefer centrally maintained policy and stable check naming; keep stack-specific deterministic commands inside each product repo.

--- a/README.md
+++ b/README.md
@@ -19,8 +19,9 @@ Idea
 → Risk / Authority
 → RED → Minimum GREEN
 → Verification
-→ PR / PR Gate
-→ Auto-merge / merge queue when supported
+→ PR
+→ required `PR Gate` + exact-head `AI Review`
+→ auto-merge / merge queue when supported
 → Release / Runtime Proof
 → Observe / Learn
 → next idea or slice
@@ -42,61 +43,71 @@ Every artifact, rule, gate, and CI run must reduce meaningful uncertainty, preve
 
 ## One-time portfolio setup
 
-After cloning this repo and authenticating GitHub CLI:
+After product repos contain the thin `AI Review` caller and GitHub CLI is authenticated:
 
 ```powershell
 pwsh -File scripts/setup-portfolio.ps1
 ```
 
-That applies repo settings/rules, enables Actions, creates the risk/status labels, syncs the optional `Agentic Portfolio` GitHub Project, and runs the remote doctor. If GitHub CLI lacks Project scope, run `gh auth refresh -s project` once and rerun.
+That applies repository settings/rules, enables Actions, creates the lean risk/status labels, syncs the optional `Agentic Portfolio` Project, and runs the remote doctor. Do not call the portfolio ready until the remote doctor reports READY.
 
 ## Other automation
 
 ```powershell
-# Bootstrap a brand-new GitHub repo with an immediately safe bootstrap gate.
+# Bootstrap a new repo with the shared engineering contract.
 pwsh -File scripts/bootstrap-repo.ps1 -Name my-app
 
-# Fan a newly approved standards commit out as reviewable pin-bump PRs.
+# Fan an approved standards commit out as reviewable pin PRs.
 pwsh -File scripts/upgrade-repos.ps1
 
-# Fresh independent semantic review of the current branch.
+# One cheap batched local semantic review.
 pwsh -File scripts/codex-review.ps1
 
-# Enable auto-merge only for an eligible R0-R2 PR.
+# Request a bounded cross-provider review using GitHub-Actions-attested provenance.
+pwsh -File scripts/request-independent-review.ps1 -Repo kgsmith19/my-app -Pr 12
+
+# Arm GitHub auto-merge only after live policy requires exact-head PR Gate + AI Review.
 pwsh -File scripts/auto-merge.ps1 -Repo kgsmith19/my-app -Pr 12 -Risk R2
 
-# Direct lower-level maintenance when needed.
+# Lower-level maintenance.
 pwsh -File scripts/apply-github-standard.ps1
 pwsh -File scripts/sync-agentic-project.ps1
 pwsh -File scripts/doctor.ps1 -Remote
 ```
 
-`upgrade-repos.ps1` preserves each existing `.agent/standard.lock` revision key and supports the three live schemas: `sha`, `commit`, and `standard_commit`. It refuses a missing or ambiguous revision field rather than guessing.
+`upgrade-repos.ps1` preserves each existing `.agent/standard.lock` revision key and supports `sha`, `commit`, and `standard_commit` without guessing.
 
 `policy/github-defaults.json` is the machine-readable portfolio policy.
 
 ## GitHub default
 
-Managed repos use GitHub Issues for durable work, one stable GitHub-Actions-produced required `PR Gate`, draft PRs while agents iterate, squash merge, risk-aware auto-merge, merged-branch cleanup, protected `main`, and resolved review threads.
+Managed repos use GitHub Issues for durable work, draft PRs while agents iterate, squash merge, branch cleanup, protected `main`, and resolved review threads. Integration requires two GitHub-Actions-bound contexts on the latest head:
 
-Current user-owned repos keep CODEOWNERS advisory so a solo PR author is not deadlocked by self-approval rules. R3/R4 and control-plane changes instead require fresh independent semantic review and do not use the R0-R2 auto-merge helper. Organization-owned repos can automatically harden to required Code Owner review and merge queues where the GitHub plan supports them.
+- `PR Gate` for deterministic evidence
+- `AI Review` for cross-provider semantic review freshness
+
+A new push invalidates the previous head's semantic authorization automatically. Human approval count stays 0 on personal repos. R0-R3 may auto-merge after both required gates and review-thread resolution when no justified authority gate applies. R4 never auto-merges.
+
+Control-plane PRs remain manually merged only while they can modify the evaluator/merge authority that judges them. That gate is removed when enforcement becomes immutable/external to the PR.
 
 The optional cross-repo GitHub Project is a portfolio view only; it is never a competing task database.
 
 ## Repo-specific truth
 
-Each product repo owns only what is specific to that product: PRD, active specs, important ADRs, source code, tests, commands, and deployment details. Do not copy the universal standard into every repo.
+Each product repo owns only product-specific PRD, active specs, important ADRs, source, tests, commands, and deployment details. Do not copy the universal standard into every repo.
 
 ## ACC target
 
-ACC should eventually wrap these proven scripts as:
+ACC should eventually wrap the proven scripts and run the recurring portfolio loops automatically:
 
 ```text
 acc repo init <name>
 acc standard upgrade
 acc doctor
 acc review
+acc resolve-ready
+acc cleanup
 acc merge
 ```
 
-Until then, the PowerShell scripts are the executable reference implementation.
+Until those adapters are proven, the scripts are the executable reference implementation.

--- a/docs/adr/0001-independent-review-routing.md
+++ b/docs/adr/0001-independent-review-routing.md
@@ -1,25 +1,32 @@
 # ADR 0001: Cost-aware independent AI review
 
-Status: accepted for implementation in Issue #17
+Status: accepted; hardened by Issue #21
 
 ## Decision
 
-Use one cheap, current-head, cross-provider semantic review before automated merge.
+Use one cheap, cross-provider semantic review **per mergeable head SHA**, enforced as the required GitHub `AI Review` check.
 
-- Deterministic evidence runs first.
+- Deterministic `PR Gate` runs independently.
+- GitHub Actions attests implementation provenance from recognized provider author/branch metadata instead of trusting editable PR-body LLM claims.
 - Claude/Copilot implementations prefer Codex review.
-- Codex implementations prefer one Copilot review; a fresh Claude session/model/context is the fallback when available.
-- The default semantic pass batches software/security, business/product, systems/optimization, and leanness lenses into one call.
-- Default budget: at most two Codex passes (initial + one re-review) and one Copilot fallback per PR.
-- Draft churn and every-push Copilot re-review are disabled by default.
-- R0-R3 may auto-merge after current-head independent review plus required GitHub evidence when live policy permits.
-- R4 remains an authorization gate for destructive/financial/privileged/irreversible consequence.
-- A manual gate is invalid unless it states the failure class, why automation is insufficient, decision owner, and removal condition.
+- Codex implementations use one Copilot review. No Claude fallback is claimed until a mechanical Claude review adapter exists.
+- Human implementation uses Codex by default.
+- One semantic pass batches software/security, business/product, systems/optimization, and leanness lenses.
+- Budget: at most two Codex passes (initial + one re-review) and one Copilot fallback per PR.
+- Draft churn does not consume semantic-review budget.
+- A push after review creates a new SHA; the previous `AI Review` result cannot authorize that new head.
+- R0-R3 may auto-merge only after latest-head `PR Gate` + `AI Review` and resolved review threads.
+- R4 remains an explicit authorization gate for destructive/financial/privileged/irreversible consequence.
+- Manual gates require failure class, automation insufficiency, decision owner, and removal condition.
 
 ## Why
 
-Independent semantic review has value, but multiple paid reviewers on every PR waste time and budget. One batched cross-provider review catches implementation, product, business-system, and complexity problems without multiplying calls. Provider separation reduces correlated implementation/review blind spots.
+A call-time script check is insufficient: auto-merge can remain armed after a later push. A required exact-head check makes GitHub itself enforce semantic-review freshness. Provider separation reduces correlated blind spots, and batching business/system/lean lenses into one review avoids multiplying model calls.
 
-## Removal / evolution
+## Trust boundary
 
-Change provider/model/budget only from measured quality, latency, and cost evidence. Eliminate remaining manual control-plane review once the governing evaluator and merge authority are external/immutable to the PR being judged.
+For product repos, the thin `AI Review` caller uses the shared evaluator in `agent-engineering-standard`. Control-plane changes to the standard remain manually merged while they can alter the evaluator that judges themselves.
+
+## Evolution
+
+Change model/provider/budget only from measured quality, latency, and cost. Eliminate the remaining control-plane manual gate when the evaluator/merge authority is immutable or organization-required and cannot be modified by the PR under judgment.

--- a/docs/adr/0001-independent-review-routing.md
+++ b/docs/adr/0001-independent-review-routing.md
@@ -4,29 +4,32 @@ Status: accepted; hardened by Issue #21
 
 ## Decision
 
-Use one cheap, cross-provider semantic review **per mergeable head SHA**, enforced as the required GitHub `AI Review` check.
+Use the smallest provider-specific semantic review set **per mergeable head SHA**, enforced as the required GitHub `AI Review` check.
 
 - Deterministic `PR Gate` runs independently.
-- GitHub Actions attests implementation provenance from recognized provider author/branch metadata instead of trusting editable PR-body LLM claims.
-- Claude/Copilot implementations prefer Codex review.
-- Codex implementations use one Copilot review. No Claude fallback is claimed until a mechanical Claude review adapter exists.
-- Human implementation uses Codex by default.
-- One semantic pass batches software/security, business/product, systems/optimization, and leanness lenses.
-- Budget: at most two Codex passes (initial + one re-review) and one Copilot fallback per PR.
-- Draft churn does not consume semantic-review budget.
+- Agent provenance comes from controlled provider branch/author metadata, not editable PR prose.
+- ChatGPT implementations require Copilot review.
+- Claude/Copilot implementations require Codex review.
+- Codex implementations require Copilot review.
+- Ordinary/user-authored provenance is ambiguous for independence and therefore requires both Codex + Copilot for unattended merge.
+- No Claude fallback is claimed until a mechanical Claude review adapter exists.
+- One semantic response batches software/security, business/product, systems/optimization, and leanness lenses.
+- Budget: at most two Codex response passes (initial + one re-review) and one Copilot response pass per PR.
+- Draft churn does not consume semantic-review budget; exact-head request markers prevent duplicate triggers.
 - A push after review creates a new SHA; the previous `AI Review` result cannot authorize that new head.
+- `AI Review` evaluator runs are serialized per PR so stale concurrent runs cannot overwrite newer evidence.
 - R0-R3 may auto-merge only after latest-head `PR Gate` + `AI Review` and resolved review threads.
 - R4 remains an explicit authorization gate for destructive/financial/privileged/irreversible consequence.
 - Manual gates require failure class, automation insufficiency, decision owner, and removal condition.
 
 ## Why
 
-A call-time script check is insufficient: auto-merge can remain armed after a later push. A required exact-head check makes GitHub itself enforce semantic-review freshness. Provider separation reduces correlated blind spots, and batching business/system/lean lenses into one review avoids multiplying model calls.
+A call-time script check is insufficient because auto-merge can remain armed after a later push. A required exact-head check makes GitHub itself enforce semantic-review freshness. Known provider provenance allows one truly cross-provider review, while ambiguous provenance pays for both connected providers rather than trusting a self-attested implementer identity. Batching business/system/lean lenses avoids multiplying calls.
 
 ## Trust boundary
 
-For product repos, the thin `AI Review` caller uses the shared evaluator in `agent-engineering-standard`. Control-plane changes to the standard remain manually merged while they can alter the evaluator that judges themselves.
+Product repos use a thin `AI Review` caller backed by the shared evaluator in `agent-engineering-standard`. Control-plane changes to the standard remain manually merged while they can alter the evaluator that judges themselves.
 
 ## Evolution
 
-Change model/provider/budget only from measured quality, latency, and cost. Eliminate the remaining control-plane manual gate when the evaluator/merge authority is immutable or organization-required and cannot be modified by the PR under judgment.
+Change provider/model/budget only from measured quality, latency, and cost. Eliminate the remaining control-plane manual gate when evaluator/merge authority is immutable or organization-required and cannot be modified by the PR under judgment.

--- a/policy/github-defaults.json
+++ b/policy/github-defaults.json
@@ -3,6 +3,7 @@
   "project_title": "Agentic Portfolio",
   "ruleset_name": "Lean PR Gate",
   "required_status_context": "PR Gate",
+  "required_ai_review_context": "AI Review",
   "strict_required_status_checks_policy": false,
   "required_approving_review_count": 0,
   "require_code_owner_review": false,
@@ -33,13 +34,17 @@
   "manual_gates": {
     "control_plane": {
       "required": true,
-      "reason": "A control-plane PR can modify the evaluator or authority that judges its own merge.",
-      "removal_condition": "Move the governing evaluator and merge authority to an immutable external or organization-required workflow that the PR cannot modify."
+      "failure_class_prevented": "A pull request changes the evaluator or merge authority and then uses that changed control to approve itself.",
+      "why_automation_is_insufficient": "The standard repository still contains the governing policy and evaluator code, so a control-plane PR is not independent of its own enforcement.",
+      "decision_owner": "repository owner",
+      "gate_removal_condition": "Move the governing evaluator and merge authority to an immutable external or organization-required workflow that the PR cannot modify."
     },
     "R4": {
       "required": true,
-      "reason": "The decision authorizes destructive, financial, privileged, or irreversible consequence; review quality alone cannot grant that authority.",
-      "removal_condition": "Replace the irreversible action with a bounded reversible mechanism whose blast radius and rollback are mechanically enforced and reclassify the operation below R4."
+      "failure_class_prevented": "An automated action causes destructive, financial, privileged, or practically irreversible real-world consequence without explicit authority.",
+      "why_automation_is_insufficient": "Repository evidence can validate implementation quality but cannot infer the human intent or authority to accept an irreversible consequence.",
+      "decision_owner": "authorized human owner",
+      "gate_removal_condition": "Replace the irreversible action with a mechanically bounded reversible mechanism with independently verified rollback, then reclassify it below R4."
     }
   },
   "org_hardening": {

--- a/scripts/apply-github-standard.ps1
+++ b/scripts/apply-github-standard.ps1
@@ -7,19 +7,14 @@ $ErrorActionPreference = "Stop"
 . (Join-Path $PSScriptRoot 'lib/legacy-protection.ps1')
 
 function Invoke-GhJson {
-  param(
-    [Parameter(Mandatory)][string]$Method,
-    [Parameter(Mandatory)][string]$Endpoint,
-    [Parameter(Mandatory)]$Body
-  )
+  param([Parameter(Mandatory)][string]$Method,[Parameter(Mandatory)][string]$Endpoint,[Parameter(Mandatory)]$Body)
   $tmp = [System.IO.Path]::GetTempFileName()
   try {
     $Body | ConvertTo-Json -Depth 20 | Set-Content -Path $tmp -Encoding utf8 -NoNewline
     $output = & gh api --method $Method $Endpoint --input $tmp 2>&1
     if ($LASTEXITCODE -ne 0) { throw ($output -join "`n") }
     return ($output -join "`n")
-  }
-  finally { Remove-Item $tmp -Force -ErrorAction SilentlyContinue }
+  } finally { Remove-Item $tmp -Force -ErrorAction SilentlyContinue }
 }
 
 if (-not (Get-Command gh -ErrorAction SilentlyContinue)) { throw "GitHub CLI (gh) is required. Install it, then run gh auth login." }
@@ -29,10 +24,8 @@ if ($LASTEXITCODE -ne 0) { throw "gh is not authenticated." }
 $config = Get-Content $ConfigPath -Raw | ConvertFrom-Json
 $owner = $config.owner
 $targets = if ($Repositories -and $Repositories.Count -gt 0) { $Repositories } else { @($config.repositories) }
-
-# Bind the required check to GitHub Actions, not just a spoofable context name.
 $actionsAppRaw = & gh api /apps/github-actions 2>&1
-if ($LASTEXITCODE -ne 0) { throw "Could not resolve the GitHub Actions App identity; refusing to create an unbound required check." }
+if ($LASTEXITCODE -ne 0) { throw "Could not resolve the GitHub Actions App identity; refusing to create unbound required checks." }
 $actionsAppId = [int]((($actionsAppRaw -join "`n") | ConvertFrom-Json).id)
 
 $labels = @(
@@ -48,76 +41,70 @@ $labels = @(
 foreach ($name in $targets) {
   $repo = if ($name -match "/") { $name } else { "$owner/$name" }
   Write-Host "`n=== $repo ===" -ForegroundColor Cyan
-
   $metaRaw = & gh api "repos/$repo" 2>&1
   if ($LASTEXITCODE -ne 0) { Write-Warning "Cannot read $repo; skipping. $($metaRaw -join ' ')"; continue }
   $meta = ($metaRaw -join "`n") | ConvertFrom-Json
   $isOrgOwned = $meta.owner.type -eq 'Organization'
   $requireCodeOwnerReview = [bool]$config.require_code_owner_review
-  if ($isOrgOwned -and $config.org_hardening -and [bool]$config.org_hardening.require_code_owner_review) {
-    $requireCodeOwnerReview = $true
-  }
+  if ($isOrgOwned -and $config.org_hardening -and [bool]$config.org_hardening.require_code_owner_review) { $requireCodeOwnerReview = $true }
 
   $settings = @{
-    has_issues               = $true
-    allow_auto_merge         = [bool]$config.allow_auto_merge
-    allow_update_branch      = [bool]$config.allow_update_branch
-    delete_branch_on_merge   = [bool]$config.delete_branch_on_merge
-    allow_merge_commit       = [bool]$config.allow_merge_commit
-    allow_rebase_merge       = [bool]$config.allow_rebase_merge
-    allow_squash_merge       = [bool]$config.allow_squash_merge
+    has_issues = $true
+    allow_auto_merge = [bool]$config.allow_auto_merge
+    allow_update_branch = [bool]$config.allow_update_branch
+    delete_branch_on_merge = [bool]$config.delete_branch_on_merge
+    allow_merge_commit = [bool]$config.allow_merge_commit
+    allow_rebase_merge = [bool]$config.allow_rebase_merge
+    allow_squash_merge = [bool]$config.allow_squash_merge
   }
   Invoke-GhJson -Method PATCH -Endpoint "repos/$repo" -Body $settings | Out-Null
   Write-Host "repo settings: Issues/auto-merge/update-branch/squash/delete-branch configured"
 
-  $actionsSettings = @{ enabled = $true; allowed_actions = "all"; sha_pinning_required = $false }
-  Invoke-GhJson -Method PUT -Endpoint "repos/$repo/actions/permissions" -Body $actionsSettings | Out-Null
-  Write-Host "actions: enabled"
-
+  Invoke-GhJson -Method PUT -Endpoint "repos/$repo/actions/permissions" -Body @{ enabled = $true; allowed_actions = 'all'; sha_pinning_required = $false } | Out-Null
   foreach ($label in $labels) {
     & gh label create $label.name --repo $repo --color $label.color --description $label.description --force 2>&1 | Out-Null
     if ($LASTEXITCODE -ne 0) { Write-Warning "Could not create/update label $($label.name) in $repo" }
   }
-  Write-Host "labels: risk/status baseline configured"
 
+  $requiredChecks = @(
+    @{ context = $config.required_status_context; integration_id = $actionsAppId },
+    @{ context = $config.required_ai_review_context; integration_id = $actionsAppId }
+  )
   $rules = @(
-    @{ type = "deletion" },
-    @{ type = "non_fast_forward" },
+    @{ type = 'deletion' },
+    @{ type = 'non_fast_forward' },
     @{
-      type = "pull_request"
+      type = 'pull_request'
       parameters = @{
-        allowed_merge_methods             = @("squash")
-        dismiss_stale_reviews_on_push     = $false
-        require_code_owner_review         = $requireCodeOwnerReview
-        require_last_push_approval        = $false
-        required_approving_review_count   = [int]$config.required_approving_review_count
+        allowed_merge_methods = @('squash')
+        dismiss_stale_reviews_on_push = $false
+        require_code_owner_review = $requireCodeOwnerReview
+        require_last_push_approval = $false
+        required_approving_review_count = [int]$config.required_approving_review_count
         required_review_thread_resolution = [bool]$config.required_review_thread_resolution
       }
     },
     @{
-      type = "required_status_checks"
+      type = 'required_status_checks'
       parameters = @{
-        do_not_enforce_on_create             = $true
+        do_not_enforce_on_create = $true
         strict_required_status_checks_policy = [bool]$config.strict_required_status_checks_policy
-        required_status_checks = @(
-          @{ context = $config.required_status_context; integration_id = $actionsAppId }
-        )
+        required_status_checks = $requiredChecks
       }
     }
   )
 
   $queueWanted = [bool]$config.merge_queue.desired
-  $queueEligibleOwner = $isOrgOwned
-  if ($queueWanted -and $queueEligibleOwner) {
+  if ($queueWanted -and $isOrgOwned) {
     $rules += @{
-      type = "merge_queue"
+      type = 'merge_queue'
       parameters = @{
-        check_response_timeout_minutes    = [int]$config.merge_queue.check_response_timeout_minutes
-        grouping_strategy                 = $config.merge_queue.grouping_strategy
-        max_entries_to_build              = [int]$config.merge_queue.max_entries_to_build
-        max_entries_to_merge              = [int]$config.merge_queue.max_entries_to_merge
-        merge_method                      = "SQUASH"
-        min_entries_to_merge              = [int]$config.merge_queue.min_entries_to_merge
+        check_response_timeout_minutes = [int]$config.merge_queue.check_response_timeout_minutes
+        grouping_strategy = $config.merge_queue.grouping_strategy
+        max_entries_to_build = [int]$config.merge_queue.max_entries_to_build
+        max_entries_to_merge = [int]$config.merge_queue.max_entries_to_merge
+        merge_method = 'SQUASH'
+        min_entries_to_merge = [int]$config.merge_queue.min_entries_to_merge
         min_entries_to_merge_wait_minutes = [int]$config.merge_queue.min_entries_to_merge_wait_minutes
       }
     }
@@ -125,69 +112,49 @@ foreach ($name in $targets) {
 
   $payload = @{
     name = $config.ruleset_name
-    target = "branch"
-    enforcement = "active"
+    target = 'branch'
+    enforcement = 'active'
     bypass_actors = @()
-    conditions = @{ ref_name = @{ include = @("~DEFAULT_BRANCH"); exclude = @() } }
+    conditions = @{ ref_name = @{ include = @('~DEFAULT_BRANCH'); exclude = @() } }
     rules = $rules
   }
-
   $existingRaw = & gh api "repos/$repo/rulesets" 2>&1
-  if ($LASTEXITCODE -ne 0) { Write-Warning "Cannot inspect rulesets for $repo; repo settings and Actions were still applied."; continue }
+  if ($LASTEXITCODE -ne 0) { Write-Warning "Cannot inspect rulesets for $repo; settings/Actions/labels were still applied."; continue }
   $existing = (($existingRaw -join "`n") | ConvertFrom-Json) | Where-Object { $_.name -eq $config.ruleset_name } | Select-Object -First 1
 
   try {
-    if ($existing) {
-      Invoke-GhJson -Method PUT -Endpoint "repos/$repo/rulesets/$($existing.id)" -Body $payload | Out-Null
-      Write-Host "ruleset: updated $($config.ruleset_name)"
-    }
-    else {
-      Invoke-GhJson -Method POST -Endpoint "repos/$repo/rulesets" -Body $payload | Out-Null
-      Write-Host "ruleset: created $($config.ruleset_name)"
-    }
-    if ($requireCodeOwnerReview) { Write-Host "CODEOWNERS approval: enforced" }
-    else { Write-Host "CODEOWNERS approval: advisory (solo personal-account safe)" }
-    if ($queueWanted -and $queueEligibleOwner) { Write-Host "merge queue: requested" }
-    elseif ($queueWanted) { Write-Host "merge queue: queue-ready only; GitHub does not support merge queues on user-owned repos" -ForegroundColor Yellow }
+    if ($existing) { Invoke-GhJson -Method PUT -Endpoint "repos/$repo/rulesets/$($existing.id)" -Body $payload | Out-Null }
+    else { Invoke-GhJson -Method POST -Endpoint "repos/$repo/rulesets" -Body $payload | Out-Null }
+    Write-Host "ruleset: $($config.ruleset_name) requires PR Gate + AI Review"
+    if ($requireCodeOwnerReview) { Write-Host 'CODEOWNERS approval: enforced' } else { Write-Host 'CODEOWNERS approval: advisory (solo personal-account safe)' }
+    if ($queueWanted -and $isOrgOwned) { Write-Host 'merge queue: requested' }
+    elseif ($queueWanted) { Write-Host 'merge queue: deferred on user-owned repo' -ForegroundColor Yellow }
   }
   catch {
-    if ($queueWanted -and $queueEligibleOwner) {
-      Write-Warning "Merge-queue ruleset application failed; retrying without merge_queue. Reason: $($_.Exception.Message)"
-      $payload.rules = @($payload.rules | Where-Object { $_.type -ne "merge_queue" })
+    if ($queueWanted -and $isOrgOwned) {
+      Write-Warning "Merge-queue ruleset failed; retrying without queue. $($_.Exception.Message)"
+      $payload.rules = @($payload.rules | Where-Object { $_.type -ne 'merge_queue' })
       if ($existing) { Invoke-GhJson -Method PUT -Endpoint "repos/$repo/rulesets/$($existing.id)" -Body $payload | Out-Null }
       else { Invoke-GhJson -Method POST -Endpoint "repos/$repo/rulesets" -Body $payload | Out-Null }
-      Write-Host "ruleset: applied without queue; retry after organization transfer/plan eligibility" -ForegroundColor Yellow
-    }
-    else { throw }
+    } else { throw }
   }
 
-  # The canonical ruleset is now active. Remove only a stale legacy required-check
-  # block so retired contexts cannot silently keep the default branch unmergeable.
-  # Other legacy protections (reviews, force-push, deletion, etc.) are untouched.
+  # Canonical ruleset owns required statuses. Remove only a stale legacy status block;
+  # preserve unrelated legacy protections.
   $legacyRaw = & gh api "repos/$repo/branches/$($meta.default_branch)/protection" 2>&1
   if ($LASTEXITCODE -eq 0) {
     $legacy = ($legacyRaw -join "`n") | ConvertFrom-Json
     $staleContexts = @(Get-StaleLegacyRequiredCheckContexts -Protection $legacy -RequiredContext $config.required_status_context)
     if ($staleContexts.Count -gt 0) {
       $deleteRaw = & gh api --method DELETE "repos/$repo/branches/$($meta.default_branch)/protection/required_status_checks" 2>&1
-      if ($LASTEXITCODE -ne 0) {
-        throw "Could not remove stale legacy required checks from ${repo}: $($deleteRaw -join ' ')"
-      }
+      if ($LASTEXITCODE -ne 0) { throw "Could not remove stale legacy required checks from ${repo}: $($deleteRaw -join ' ')" }
       Write-Host "legacy required checks: removed $($staleContexts -join ', ')" -ForegroundColor Yellow
-    }
-    else {
-      Write-Host "legacy required checks: clean"
-    }
-  }
-  else {
+    } else { Write-Host 'legacy required checks: clean' }
+  } else {
     $legacyError = $legacyRaw -join "`n"
-    if (Test-GitHubBranchProtectionAbsent -ErrorText $legacyError) {
-      Write-Host "legacy branch protection: absent"
-    }
-    else {
-      throw "Could not inspect legacy branch protection for ${repo}: $legacyError"
-    }
+    if (Test-GitHubBranchProtectionAbsent -ErrorText $legacyError) { Write-Host 'legacy branch protection: absent' }
+    else { throw "Could not inspect legacy branch protection for ${repo}: $legacyError" }
   }
 }
 
-Write-Host "`nDone. Re-run after moving eligible repos into a supported GitHub organization to add merge queues and stronger review enforcement automatically." -ForegroundColor Green
+Write-Host "`nDone. Run doctor.ps1 -Remote; do not claim the control plane ready until every repo reports READY." -ForegroundColor Green

--- a/scripts/auto-merge.ps1
+++ b/scripts/auto-merge.ps1
@@ -1,55 +1,48 @@
 param(
   [Parameter(Mandatory)][string]$Repo,
   [Parameter(Mandatory)][int]$Pr,
-  [ValidateSet('R0','R1','R2','R3','R4')][string]$Risk = 'R2',
-  [ValidateSet('claude','copilot','codex','human','unknown')][string]$Implementer = 'unknown'
+  [ValidateSet('R0','R1','R2','R3','R4')][string]$Risk = 'R2'
 )
 
 $ErrorActionPreference = 'Stop'
-. (Join-Path $PSScriptRoot 'lib/review-policy.ps1')
-
 if (-not (Get-Command gh -ErrorAction SilentlyContinue)) { throw 'GitHub CLI (gh) is required.' }
 & gh auth status | Out-Host
 if ($LASTEXITCODE -ne 0) { throw 'gh is not authenticated.' }
 
 $config = Get-Content (Join-Path $PSScriptRoot '..\policy\github-defaults.json') -Raw | ConvertFrom-Json
-
-$prRaw = & gh pr view $Pr --repo $Repo --json isDraft,state,headRefOid,body,labels 2>&1
+$prRaw = & gh pr view $Pr --repo $Repo --json isDraft,state,labels 2>&1
 if ($LASTEXITCODE -ne 0) { throw ($prRaw -join "`n") }
-$prInfo = ($prRaw -join "`n") | ConvertFrom-Json
-if ($prInfo.state -ne 'OPEN') { throw "PR #$Pr is not open." }
-if ($prInfo.isDraft) { throw "PR #$Pr is still draft. Finish implementation and mark it ready first." }
-if (@($prInfo.labels | ForEach-Object { $_.name }) -contains 'status:blocked') { throw "Auto-merge refused: PR #$Pr is status:blocked." }
-
-if ($Implementer -eq 'unknown' -and $prInfo.body -match '(?im)^\s*Implementer:\s*(claude|copilot|codex|human)\s*$') { $Implementer = $Matches[1].ToLowerInvariant() }
-if ($Implementer -eq 'unknown') { throw "Auto-merge requires an Implementer: claude|copilot|codex|human line in the PR body (or -Implementer explicitly)." }
+$pr = ($prRaw -join "`n") | ConvertFrom-Json
+if ($pr.state -ne 'OPEN') { throw "PR #$Pr is not open." }
+if ($pr.isDraft) { throw "PR #$Pr is draft." }
+if (@($pr.labels | ForEach-Object { $_.name }) -contains 'status:blocked') { throw "PR #$Pr is status:blocked." }
 
 $riskNumber = [int]$Risk.Substring(1)
 $maxRisk = [int]([string]$config.auto_merge_max_risk).Substring(1)
-if ($riskNumber -gt $maxRisk) { throw "Auto-merge refused: $Risk exceeds configured auto_merge_max_risk $($config.auto_merge_max_risk)." }
-if ($Risk -eq 'R4') { throw "Auto-merge refused: R4 requires explicit authority for destructive/financial/privileged/irreversible consequence." }
+if ($riskNumber -gt $maxRisk -or $Risk -eq 'R4') { throw "Auto-merge refused for $Risk; configured maximum is $($config.auto_merge_max_risk)." }
 
 $filesRaw = & gh api --paginate "repos/$Repo/pulls/$Pr/files?per_page=100" --jq '.[].filename' 2>&1
 if ($LASTEXITCODE -ne 0) { throw ($filesRaw -join "`n") }
-$files = @($filesRaw)
 $controlPlanePatterns = @(
   '^\.github/workflows/', '^\.agent/', '^AGENTS\.md$', '^policy/', '^scripts/lib/',
   '^scripts/(apply-github-standard|doctor|auto-merge|request-independent-review|upgrade-repos|bootstrap-repo|codex-review|sync-agentic-project)\.ps1$',
   '^(AGENT_RULES|QUALITY_RULES|SECURITY_RISK_AUTONOMY|DELIVERY_GITHUB|EVIDENCE_LEARNING)\.md$'
 )
 $controlPlane = $Repo -match '/agent-engineering-standard$'
-foreach ($file in $files) { if ($controlPlanePatterns | Where-Object { $file -match $_ }) { $controlPlane = $true; break } }
-if ($controlPlane -and $riskNumber -lt 3) { throw "Auto-merge refused: control-plane changes must declare at least R3." }
-if ($controlPlane -and [bool]$config.manual_gates.control_plane.required) { throw "Auto-merge refused: control-plane gate remains justified. Removal condition: $($config.manual_gates.control_plane.removal_condition)" }
+foreach ($file in @($filesRaw)) { if ($controlPlanePatterns | Where-Object { $file -match $_ }) { $controlPlane = $true; break } }
+if ($controlPlane -and $riskNumber -lt 3) { throw 'Control-plane changes must declare at least R3.' }
+if ($controlPlane -and [bool]$config.manual_gates.control_plane.required) {
+  throw "Auto-merge refused by justified control-plane gate. Removal condition: $($config.manual_gates.control_plane.gate_removal_condition)"
+}
 
 $metaRaw = & gh api "repos/$Repo" 2>&1
 if ($LASTEXITCODE -ne 0) { throw "Cannot inspect live repository settings for $Repo." }
 $meta = ($metaRaw -join "`n") | ConvertFrom-Json
-if (-not $meta.allow_auto_merge) { throw "Live GitHub setting drift: auto-merge is off. Run setup-portfolio.ps1." }
-if (-not $meta.allow_squash_merge -or $meta.allow_merge_commit -or $meta.allow_rebase_merge) { throw "Live GitHub merge-method drift: repository is not squash-only. Run setup-portfolio.ps1." }
+if (-not $meta.allow_auto_merge) { throw 'Live GitHub setting drift: auto-merge is off.' }
+if (-not $meta.allow_squash_merge -or $meta.allow_merge_commit -or $meta.allow_rebase_merge) { throw 'Live GitHub merge policy is not squash-only.' }
 $isOrgOwned = $meta.owner.type -eq 'Organization'
 $expectedCodeOwnerReview = [bool]$config.require_code_owner_review
-if ($isOrgOwned -and $config.org_hardening -and [bool]$config.org_hardening.require_code_owner_review) { $expectedCodeOwnerReview = $true }
+if ($isOrgOwned -and [bool]$config.org_hardening.require_code_owner_review) { $expectedCodeOwnerReview = $true }
 
 $actionsAppRaw = & gh api /apps/github-actions 2>&1
 if ($LASTEXITCODE -ne 0) { throw 'Cannot resolve GitHub Actions App identity.' }
@@ -58,39 +51,30 @@ $actionsAppId = [int]((($actionsAppRaw -join "`n") | ConvertFrom-Json).id)
 $rulesetsRaw = & gh api "repos/$Repo/rulesets" 2>&1
 if ($LASTEXITCODE -ne 0) { throw "Cannot inspect live rulesets for $Repo." }
 $summary = ((($rulesetsRaw -join "`n") | ConvertFrom-Json) | Where-Object { $_.name -eq $config.ruleset_name } | Select-Object -First 1)
-if (-not $summary) { throw "Live ruleset '$($config.ruleset_name)' is missing. Run setup-portfolio.ps1." }
+if (-not $summary) { throw "Live ruleset '$($config.ruleset_name)' is missing." }
 $detailRaw = & gh api "repos/$Repo/rulesets/$($summary.id)" 2>&1
-if ($LASTEXITCODE -ne 0) { throw "Cannot inspect live ruleset '$($config.ruleset_name)'." }
+if ($LASTEXITCODE -ne 0) { throw 'Cannot inspect live ruleset details.' }
 $detail = ($detailRaw -join "`n") | ConvertFrom-Json
 if ($detail.enforcement -ne 'active') { throw 'Live ruleset is not active.' }
-if ($detail.bypass_actors -and @($detail.bypass_actors).Count -gt 0) { throw 'Live ruleset has bypass actors; refusing auto-merge.' }
+if ($detail.bypass_actors -and @($detail.bypass_actors).Count -gt 0) { throw 'Live ruleset has bypass actors.' }
+if (-not (@($detail.conditions.ref_name.include) -contains '~DEFAULT_BRANCH')) { throw 'Live ruleset does not protect the default branch.' }
 
 $prRule = $detail.rules | Where-Object { $_.type -eq 'pull_request' } | Select-Object -First 1
 if (-not $prRule) { throw 'Live ruleset does not require pull requests.' }
-if ([int]$prRule.parameters.required_approving_review_count -ne 0) { throw 'Human approval requirement detected; portfolio default must be 0.' }
+if ([int]$prRule.parameters.required_approving_review_count -ne 0) { throw 'Human approval requirement is not zero.' }
 if ([bool]$prRule.parameters.require_code_owner_review -ne $expectedCodeOwnerReview) { throw 'Code Owner review policy drift detected.' }
-if (-not [bool]$prRule.parameters.required_review_thread_resolution) { throw 'Review-thread resolution is not required; refusing auto-merge.' }
+if (-not [bool]$prRule.parameters.required_review_thread_resolution) { throw 'Review-thread resolution is not required.' }
 $methods = @($prRule.parameters.allowed_merge_methods)
 if ($methods.Count -ne 1 -or $methods[0] -ne 'squash') { throw 'Ruleset is not squash-only.' }
 
 $statusRule = $detail.rules | Where-Object { $_.type -eq 'required_status_checks' } | Select-Object -First 1
 if (-not $statusRule) { throw 'Live ruleset has no required-status-check rule.' }
-$requiredCheck = @($statusRule.parameters.required_status_checks) | Where-Object { $_.context -eq $config.required_status_context } | Select-Object -First 1
-if (-not $requiredCheck) { throw "Live ruleset does not require '$($config.required_status_context)'." }
-if ([int]$requiredCheck.integration_id -ne $actionsAppId) { throw "Required '$($config.required_status_context)' is not bound to GitHub Actions." }
+foreach ($context in @($config.required_status_context, $config.required_ai_review_context)) {
+  $required = @($statusRule.parameters.required_status_checks) | Where-Object { $_.context -eq $context } | Select-Object -First 1
+  if (-not $required) { throw "Live ruleset does not require '$context'." }
+  if ([int]$required.integration_id -ne $actionsAppId) { throw "Required '$context' is not bound to GitHub Actions." }
+}
 
-$reviewsRaw = & gh api --paginate --slurp "repos/$Repo/pulls/$Pr/reviews?per_page=100" 2>&1
-if ($LASTEXITCODE -ne 0) { throw ($reviewsRaw -join "`n") }
-$reviewPages = ($reviewsRaw -join "`n") | ConvertFrom-Json
-$currentIndependent = @($reviewPages | ForEach-Object { $_ } | Where-Object {
-  $provider = Get-ReviewProviderFromLogin -Login $_.user.login
-  $_.commit_id -eq $prInfo.headRefOid -and $_.state -notin @('DISMISSED','PENDING') -and $provider -and (Test-IndependentReview -Implementer $Implementer -ReviewerProvider $provider)
-} | Sort-Object submitted_at)
-if ($currentIndependent.Count -eq 0) { throw "No independent AI review exists on current head $($prInfo.headRefOid). Run request-independent-review.ps1 after the final substantive push." }
-$latestReview = $currentIndependent[-1]
-if ($latestReview.state -eq 'CHANGES_REQUESTED') { throw "Latest independent review by $($latestReview.user.login) requests changes; refusing auto-merge." }
-
-$reviewer = $latestReview.user.login
 & gh pr merge $Pr --repo $Repo --auto --squash
 if ($LASTEXITCODE -ne 0) { throw "Could not enable auto-merge for $Repo PR #$Pr." }
-Write-Host "AUTO-MERGE ARMED: $Repo PR #$Pr ($Risk), independent reviewer $reviewer. GitHub remains the authority: required PR Gate + resolved threads must pass before merge." -ForegroundColor Green
+Write-Host "AUTO-MERGE ARMED: $Repo PR #$Pr ($Risk). GitHub now requires exact-head PR Gate + AI Review and resolved review threads before merge." -ForegroundColor Green

--- a/scripts/auto-merge.ps1
+++ b/scripts/auto-merge.ps1
@@ -10,7 +10,7 @@ if (-not (Get-Command gh -ErrorAction SilentlyContinue)) { throw 'GitHub CLI (gh
 if ($LASTEXITCODE -ne 0) { throw 'gh is not authenticated.' }
 
 $config = Get-Content (Join-Path $PSScriptRoot '..\policy\github-defaults.json') -Raw | ConvertFrom-Json
-$prRaw = & gh pr view $Pr --repo $Repo --json isDraft,state,labels 2>&1
+$prRaw = & gh pr view $Pr --repo $Repo --json isDraft,state,labels,baseRefName 2>&1
 if ($LASTEXITCODE -ne 0) { throw ($prRaw -join "`n") }
 $pr = ($prRaw -join "`n") | ConvertFrom-Json
 if ($pr.state -ne 'OPEN') { throw "PR #$Pr is not open." }
@@ -38,6 +38,7 @@ if ($controlPlane -and [bool]$config.manual_gates.control_plane.required) {
 $metaRaw = & gh api "repos/$Repo" 2>&1
 if ($LASTEXITCODE -ne 0) { throw "Cannot inspect live repository settings for $Repo." }
 $meta = ($metaRaw -join "`n") | ConvertFrom-Json
+if ($pr.baseRefName -ne $meta.default_branch) { throw "Auto-merge refused: PR #$Pr targets '$($pr.baseRefName)', not protected default branch '$($meta.default_branch)'." }
 if (-not $meta.allow_auto_merge) { throw 'Live GitHub setting drift: auto-merge is off.' }
 if (-not $meta.allow_squash_merge -or $meta.allow_merge_commit -or $meta.allow_rebase_merge) { throw 'Live GitHub merge policy is not squash-only.' }
 $isOrgOwned = $meta.owner.type -eq 'Organization'

--- a/scripts/bootstrap-repo.ps1
+++ b/scripts/bootstrap-repo.ps1
@@ -45,6 +45,7 @@ Copy-Item (Join-Path $standardRoot 'templates/PRD.md') (Join-Path $target 'PRD.m
 Copy-Item (Join-Path $standardRoot 'templates/ISSUE.md') (Join-Path $target '.github/ISSUE_TEMPLATE/work-item.md') -Force
 Copy-Item (Join-Path $standardRoot 'templates/PULL_REQUEST.md') (Join-Path $target '.github/PULL_REQUEST_TEMPLATE.md') -Force
 Copy-Item (Join-Path $standardRoot 'templates/PR_GATE.yml') (Join-Path $target '.github/workflows/pr-gate.yml') -Force
+Copy-Item (Join-Path $standardRoot 'templates/AI_REVIEW.yml') (Join-Path $target '.github/workflows/ai-review.yml') -Force
 Copy-Item (Join-Path $standardRoot 'templates/CODEOWNERS') (Join-Path $target '.github/CODEOWNERS') -Force
 
 @"
@@ -67,11 +68,12 @@ work_tracking:
 
 ci:
   required_check: "PR Gate"
+  ai_review_check: "AI Review"
   gate_profile: bootstrap-only
 
-# Before product code lands, replace the bootstrap-only gate with the cheapest
+# Before product code lands, replace the bootstrap-only PR Gate with the cheapest
 # repo-specific objective build/test/acceptance evidence for the detected stack.
-# Add only commands and risk paths that have actually been verified.
+# Keep the shared AI Review caller intact unless the control-plane design changes.
 "@ | Set-Content (Join-Path $target '.agent/project.yaml') -Encoding utf8
 
 '@AGENTS.md' | Set-Content (Join-Path $target 'CLAUDE.md') -Encoding utf8
@@ -95,6 +97,7 @@ Replace the bootstrap-only PR Gate with the smallest objective gate appropriate 
 ## Acceptance
 - Detect and record verified build/test/type/lint/E2E commands in `.agent/project.yaml`.
 - Replace `.github/workflows/pr-gate.yml` so `PR Gate` executes the cheapest sufficient independent evidence.
+- Preserve `.github/workflows/ai-review.yml` so the required exact-head `AI Review` context continues to run.
 - Extend `.github/CODEOWNERS` with the small repo-specific gate entrypoints whose weakening could make `PR Gate` falsely green; keep the canonical control-plane ownership rules as the final non-comment rules.
 - Keep draft iteration local; ready PR and `merge_group` must produce the real `PR Gate`.
 - Add only tests/tools justified by actual product risk; do not invent a framework just for conformity.

--- a/scripts/doctor.ps1
+++ b/scripts/doctor.ps1
@@ -121,8 +121,12 @@ foreach ($name in $config.repositories) {
         if ($detail.enforcement -ne 'active') { $problems.Add('ruleset not active') }
         if ($detail.bypass_actors -and @($detail.bypass_actors).Count -gt 0) { $problems.Add('ruleset has bypass actors') }
         if (-not (@($detail.conditions.ref_name.include) -contains '~DEFAULT_BRANCH')) { $problems.Add('ruleset does not target default branch') }
+        $types = @($detail.rules | ForEach-Object { $_.type })
+        foreach ($requiredType in @('deletion','non_fast_forward','pull_request','required_status_checks')) {
+          if ($types -notcontains $requiredType) { $problems.Add("missing rule: $requiredType") }
+        }
         $prRule = $detail.rules | Where-Object { $_.type -eq 'pull_request' } | Select-Object -First 1
-        if (-not $prRule) { $problems.Add('pull-request rule missing') } else {
+        if ($prRule) {
           if ([int]$prRule.parameters.required_approving_review_count -ne 0) { $problems.Add('human approval requirement is not zero') }
           if ([bool]$prRule.parameters.require_code_owner_review -ne $expectedCodeOwnerReview) { $problems.Add('CODEOWNERS review policy drift') }
           if (-not $prRule.parameters.required_review_thread_resolution) { $problems.Add('review-thread resolution not required') }
@@ -130,7 +134,7 @@ foreach ($name in $config.repositories) {
           if ($allowed.Count -ne 1 -or $allowed[0] -ne 'squash') { $problems.Add('ruleset not squash-only') }
         }
         $statusRule = $detail.rules | Where-Object { $_.type -eq 'required_status_checks' } | Select-Object -First 1
-        if (-not $statusRule) { $problems.Add('required-status rule missing') } else {
+        if ($statusRule) {
           foreach ($context in @($config.required_status_context,$config.required_ai_review_context)) {
             $check = @($statusRule.parameters.required_status_checks) | Where-Object { $_.context -eq $context } | Select-Object -First 1
             if (-not $check) { $problems.Add("required context missing: $context") }

--- a/scripts/doctor.ps1
+++ b/scripts/doctor.ps1
@@ -95,6 +95,13 @@ foreach ($name in $config.repositories) {
   if ($meta.allow_merge_commit) { $problems.Add('merge commits enabled') }
   if ($meta.allow_rebase_merge) { $problems.Add('rebase enabled') }
 
+  $actionsRaw = & gh api "repos/$repo/actions/permissions" 2>&1
+  if ($LASTEXITCODE -ne 0) { $problems.Add('cannot read Actions permissions') }
+  else {
+    $actions = ($actionsRaw -join "`n") | ConvertFrom-Json
+    if (-not [bool]$actions.enabled) { $problems.Add('Actions disabled') }
+  }
+
   $codeownersRaw = & gh api -H 'Accept: application/vnd.github.raw+json' "repos/$repo/contents/.github/CODEOWNERS?ref=$($meta.default_branch)" 2>&1
   if ($LASTEXITCODE -ne 0) { $problems.Add('CODEOWNERS missing') } else {
     $expectedTail = if ($name -eq 'agent-engineering-standard') { $standardTail } else { $appTail }

--- a/scripts/doctor.ps1
+++ b/scripts/doctor.ps1
@@ -110,6 +110,14 @@ foreach ($name in $config.repositories) {
 
   $aiWorkflowRaw = & gh api "repos/$repo/contents/.github/workflows/ai-review.yml?ref=$($meta.default_branch)" 2>&1
   if ($LASTEXITCODE -ne 0) { $problems.Add('AI Review caller workflow missing') }
+  else {
+    $workflowStateRaw = & gh api "repos/$repo/actions/workflows/ai-review.yml" 2>&1
+    if ($LASTEXITCODE -ne 0) { $problems.Add('cannot read AI Review workflow state') }
+    else {
+      $workflowState = ($workflowStateRaw -join "`n") | ConvertFrom-Json
+      if ($workflowState.state -ne 'active') { $problems.Add("AI Review workflow not active: $($workflowState.state)") }
+    }
+  }
 
   $rulesetsRaw = & gh api "repos/$repo/rulesets" 2>&1
   if ($LASTEXITCODE -ne 0) { $problems.Add('cannot read rulesets') } else {

--- a/scripts/doctor.ps1
+++ b/scripts/doctor.ps1
@@ -3,9 +3,10 @@ param(
   [string]$ConfigPath = (Join-Path $PSScriptRoot "..\policy\github-defaults.json")
 )
 
-$ErrorActionPreference = "Stop"
-$root = (Resolve-Path (Join-Path $PSScriptRoot "..")).Path
+$ErrorActionPreference = 'Stop'
+$root = (Resolve-Path (Join-Path $PSScriptRoot '..')).Path
 . (Join-Path $PSScriptRoot 'lib/legacy-protection.ps1')
+. (Join-Path $PSScriptRoot 'lib/review-policy.ps1')
 
 function Test-CodeownersTail {
   param([Parameter(Mandatory)][string]$Content,[Parameter(Mandatory)][string[]]$ExpectedTail)
@@ -17,66 +18,63 @@ function Test-CodeownersTail {
 }
 
 $required = @(
-  "README.md", "LIFECYCLE.md", "AGENT_RULES.md", "QUALITY_RULES.md", "SECURITY_RISK_AUTONOMY.md", "DELIVERY_GITHUB.md", "EVIDENCE_LEARNING.md",
-  "AGENTS.md", ".github/CODEOWNERS", "policy/github-defaults.json",
-  "scripts/setup-portfolio.ps1", "scripts/apply-github-standard.ps1", "scripts/sync-agentic-project.ps1", "scripts/codex-review.ps1", "scripts/request-independent-review.ps1", "scripts/auto-merge.ps1",
-  "scripts/bootstrap-repo.ps1", "scripts/upgrade-repos.ps1", "scripts/lib/legacy-protection.ps1", "scripts/lib/standard-lock.ps1", "scripts/lib/review-policy.ps1",
-  "tests/legacy-protection.tests.ps1", "tests/standard-lock.tests.ps1", "tests/review-policy.tests.ps1",
-  ".github/workflows/ci.yml", "templates/AGENTS.md", "templates/CODEOWNERS", "templates/PR_GATE.yml", "templates/PRD.md", "templates/SPEC.md", "templates/ADR.md", "templates/ISSUE.md", "templates/PULL_REQUEST.md"
+  'README.md','LIFECYCLE.md','AGENT_RULES.md','QUALITY_RULES.md','SECURITY_RISK_AUTONOMY.md','DELIVERY_GITHUB.md','EVIDENCE_LEARNING.md','AGENTS.md',
+  '.github/CODEOWNERS','.github/workflows/ci.yml','.github/workflows/ai-review.yml','.github/workflows/ai-review-reusable.yml','policy/github-defaults.json',
+  'scripts/setup-portfolio.ps1','scripts/apply-github-standard.ps1','scripts/sync-agentic-project.ps1','scripts/codex-review.ps1','scripts/request-independent-review.ps1','scripts/auto-merge.ps1','scripts/bootstrap-repo.ps1','scripts/upgrade-repos.ps1',
+  'scripts/lib/legacy-protection.ps1','scripts/lib/standard-lock.ps1','scripts/lib/review-policy.ps1',
+  'tests/legacy-protection.tests.ps1','tests/standard-lock.tests.ps1','tests/review-policy.tests.ps1',
+  'templates/AGENTS.md','templates/CODEOWNERS','templates/PR_GATE.yml','templates/AI_REVIEW.yml','templates/PRD.md','templates/SPEC.md','templates/ADR.md','templates/ISSUE.md','templates/PULL_REQUEST.md'
 )
 foreach ($relative in $required) { if (-not (Test-Path (Join-Path $root $relative))) { throw "Missing required file: $relative" } }
 
-$config = Get-Content (Join-Path $root "policy/github-defaults.json") -Raw | ConvertFrom-Json
-if ($config.required_status_context -ne "PR Gate") { throw "required_status_context must be 'PR Gate'" }
-if ($config.required_approving_review_count -ne 0) { throw "Default human approval count must remain 0." }
-if ($config.require_code_owner_review) { throw "Personal-account default must not require Code Owner approval." }
-if (-not $config.org_hardening -or -not [bool]$config.org_hardening.require_code_owner_review) { throw "Organization hardening must retain Code Owner review." }
-if (-not [bool]$config.allow_auto_merge) { throw "allow_auto_merge must remain true for the reviewed R0-R3 lane." }
-if (-not [bool]$config.allow_update_branch) { throw "allow_update_branch must remain true." }
-if ([bool]$config.allow_merge_commit -or [bool]$config.allow_rebase_merge -or -not [bool]$config.allow_squash_merge) { throw "Repository merge policy must remain squash-only." }
-if ($config.merge_method -ne 'squash') { throw "merge_method must remain squash." }
-if ($config.auto_merge_max_risk -ne 'R3') { throw "auto_merge_max_risk must remain R3; R4 requires explicit authority." }
-if (-not $config.control_plane_requires_fresh_external_review) { throw "Control-plane changes must require fresh independent review." }
+$config = Get-Content (Join-Path $root 'policy/github-defaults.json') -Raw | ConvertFrom-Json
+if ($config.required_status_context -ne 'PR Gate') { throw "required_status_context must be 'PR Gate'" }
+if ($config.required_ai_review_context -ne 'AI Review') { throw "required_ai_review_context must be 'AI Review'" }
+if ($config.required_approving_review_count -ne 0) { throw 'Default human approval count must remain 0.' }
+if ($config.require_code_owner_review) { throw 'Personal-account default must not require Code Owner approval.' }
+if (-not [bool]$config.org_hardening.require_code_owner_review) { throw 'Organization hardening must retain Code Owner review.' }
+if (-not [bool]$config.allow_auto_merge -or -not [bool]$config.allow_update_branch) { throw 'Safe automated lane requires auto-merge + update-branch enabled.' }
+if ([bool]$config.allow_merge_commit -or [bool]$config.allow_rebase_merge -or -not [bool]$config.allow_squash_merge -or $config.merge_method -ne 'squash') { throw 'Repository merge policy must remain squash-only.' }
+if ($config.auto_merge_max_risk -ne 'R3') { throw 'auto_merge_max_risk must remain R3; R4 requires explicit authority.' }
 
 $review = $config.independent_review
-if (-not $review -or -not [bool]$review.required_for_auto_merge) { throw "Independent AI review must be required before auto-merge." }
-if ($review.preferred_provider -ne 'codex') { throw "Codex must remain the preferred independent reviewer unless evidence changes." }
-if ($review.local_codex_model -ne 'gpt-5.4-mini') { throw "Local Codex review must default to gpt-5.4-mini." }
-if ([int]$review.max_codex_reviews_per_pr -ne 2) { throw "Codex review budget must remain capped at 2 per PR." }
-if (-not [bool]$review.copilot_fallback) { throw "Copilot must remain a bounded fallback reviewer." }
-if ([int]$review.max_copilot_reviews_per_pr -ne 1) { throw "Copilot review budget must remain capped at 1 per PR." }
-if ([bool]$review.copilot_review_on_push -or [bool]$review.copilot_review_drafts) { throw "Copilot draft/push re-review must remain off by default." }
-if ($review.copilot_effort -ne 'low') { throw "Copilot fallback effort must remain low." }
-if ([bool]$review.same_provider_counts_as_independent) { throw "The implementation provider cannot count as its own independent reviewer." }
+if (-not [bool]$review.required_for_auto_merge) { throw 'Independent AI review must be required before auto-merge.' }
+if ($review.preferred_provider -ne 'codex' -or $review.local_codex_model -ne 'gpt-5.4-mini') { throw 'Current low-cost default must remain Codex + gpt-5.4-mini unless evidence changes.' }
+if ([int]$review.max_codex_reviews_per_pr -ne 2 -or [int]$review.max_copilot_reviews_per_pr -ne 1) { throw 'Review budgets drifted.' }
+if ([bool]$review.copilot_review_on_push -or [bool]$review.copilot_review_drafts) { throw 'Unbounded Copilot draft/push review must remain off.' }
+if ($review.copilot_effort -ne 'low' -or [bool]$review.same_provider_counts_as_independent) { throw 'Copilot/independence policy drifted.' }
 
-$requiredGateFields = @('failure_class_prevented','why_automation_is_insufficient','decision_owner','gate_removal_condition')
-foreach ($field in $requiredGateFields) { if (@($config.manual_gate_required_fields) -notcontains $field) { throw "manual_gate_required_fields is missing '$field'." } }
+foreach ($field in @('failure_class_prevented','why_automation_is_insufficient','decision_owner','gate_removal_condition')) {
+  if (@($config.manual_gate_required_fields) -notcontains $field) { throw "manual_gate_required_fields missing '$field'." }
+}
 foreach ($gateName in @('control_plane','R4')) {
   $gate = $config.manual_gates.PSObject.Properties[$gateName].Value
-  if (-not $gate -or -not [bool]$gate.required) { throw "Manual gate '$gateName' must be explicitly configured." }
-  if ([string]::IsNullOrWhiteSpace([string]$gate.reason)) { throw "Manual gate '$gateName' lacks a concrete reason." }
-  if ([string]::IsNullOrWhiteSpace([string]$gate.removal_condition)) { throw "Manual gate '$gateName' lacks a removal condition." }
+  if (-not $gate -or -not [bool]$gate.required) { throw "Manual gate '$gateName' is not explicitly configured." }
+  Assert-ManualGateJustification -Justification $gate | Out-Null
 }
 
 $ownerToken = "@$($config.owner)"
-$appCodeownersTail = @("/.github/workflows/ $ownerToken","/.github/CODEOWNERS $ownerToken","/.agent/ $ownerToken","/AGENTS.md $ownerToken")
-$standardCodeownersTail = @("/.github/workflows/ $ownerToken","/.github/CODEOWNERS $ownerToken","/policy/ $ownerToken","/scripts/ $ownerToken","/AGENTS.md $ownerToken","/AGENT_RULES.md $ownerToken","/QUALITY_RULES.md $ownerToken","/SECURITY_RISK_AUTONOMY.md $ownerToken","/DELIVERY_GITHUB.md $ownerToken")
-if (-not (Test-CodeownersTail -Content (Get-Content (Join-Path $root '.github/CODEOWNERS') -Raw) -ExpectedTail $standardCodeownersTail)) { throw "Local .github/CODEOWNERS does not match canonical ownership map." }
-if (-not (Test-CodeownersTail -Content (Get-Content (Join-Path $root 'templates/CODEOWNERS') -Raw) -ExpectedTail $appCodeownersTail)) { throw "templates/CODEOWNERS does not match canonical app ownership map." }
+$appTail = @("/.github/workflows/ $ownerToken","/.github/CODEOWNERS $ownerToken","/.agent/ $ownerToken","/AGENTS.md $ownerToken")
+$standardTail = @("/.github/workflows/ $ownerToken","/.github/CODEOWNERS $ownerToken","/policy/ $ownerToken","/scripts/ $ownerToken","/AGENTS.md $ownerToken","/AGENT_RULES.md $ownerToken","/QUALITY_RULES.md $ownerToken","/SECURITY_RISK_AUTONOMY.md $ownerToken","/DELIVERY_GITHUB.md $ownerToken")
+if (-not (Test-CodeownersTail -Content (Get-Content (Join-Path $root '.github/CODEOWNERS') -Raw) -ExpectedTail $standardTail)) { throw 'Local CODEOWNERS drifted.' }
+if (-not (Test-CodeownersTail -Content (Get-Content (Join-Path $root 'templates/CODEOWNERS') -Raw) -ExpectedTail $appTail)) { throw 'Template CODEOWNERS drifted.' }
 
-$psScripts = @("scripts/setup-portfolio.ps1","scripts/apply-github-standard.ps1","scripts/sync-agentic-project.ps1","scripts/codex-review.ps1","scripts/request-independent-review.ps1","scripts/auto-merge.ps1","scripts/bootstrap-repo.ps1","scripts/upgrade-repos.ps1","scripts/doctor.ps1","scripts/lib/legacy-protection.ps1","scripts/lib/standard-lock.ps1","scripts/lib/review-policy.ps1","tests/legacy-protection.tests.ps1","tests/standard-lock.tests.ps1","tests/review-policy.tests.ps1")
+$psScripts = @(
+  'scripts/setup-portfolio.ps1','scripts/apply-github-standard.ps1','scripts/sync-agentic-project.ps1','scripts/codex-review.ps1','scripts/request-independent-review.ps1','scripts/auto-merge.ps1','scripts/bootstrap-repo.ps1','scripts/upgrade-repos.ps1','scripts/doctor.ps1',
+  'scripts/lib/legacy-protection.ps1','scripts/lib/standard-lock.ps1','scripts/lib/review-policy.ps1','tests/legacy-protection.tests.ps1','tests/standard-lock.tests.ps1','tests/review-policy.tests.ps1'
+)
 foreach ($relative in $psScripts) {
   $tokens = $null; $errors = $null
   [System.Management.Automation.Language.Parser]::ParseFile((Join-Path $root $relative), [ref]$tokens, [ref]$errors) | Out-Null
   if ($errors.Count -gt 0) { throw "PowerShell parse failed: $relative :: $($errors[0].Message)" }
 }
 
-Write-Host "LOCAL: READY" -ForegroundColor Green
+Write-Host 'LOCAL: READY' -ForegroundColor Green
 if (-not $Remote) { exit 0 }
-if (-not (Get-Command gh -ErrorAction SilentlyContinue)) { throw "gh is required for -Remote." }
+if (-not (Get-Command gh -ErrorAction SilentlyContinue)) { throw 'gh is required for -Remote.' }
 
 $actionsAppRaw = & gh api /apps/github-actions 2>&1
-if ($LASTEXITCODE -ne 0) { throw "Could not resolve GitHub Actions App identity." }
+if ($LASTEXITCODE -ne 0) { throw 'Could not resolve GitHub Actions App identity.' }
 $actionsAppId = [int]((($actionsAppRaw -join "`n") | ConvertFrom-Json).id)
 $remoteFailures = New-Object System.Collections.Generic.List[string]
 
@@ -87,52 +85,51 @@ foreach ($name in $config.repositories) {
   $meta = ($metaRaw -join "`n") | ConvertFrom-Json
   $isOrgOwned = $meta.owner.type -eq 'Organization'
   $expectedCodeOwnerReview = [bool]$config.require_code_owner_review
-  if ($isOrgOwned -and $config.org_hardening -and [bool]$config.org_hardening.require_code_owner_review) { $expectedCodeOwnerReview = $true }
+  if ($isOrgOwned -and [bool]$config.org_hardening.require_code_owner_review) { $expectedCodeOwnerReview = $true }
 
-  if (-not $meta.has_issues) { $problems.Add("Issues disabled") }
-  if (-not $meta.allow_auto_merge) { $problems.Add("auto-merge off") }
-  if (-not $meta.allow_update_branch) { $problems.Add("update-branch off") }
-  if (-not $meta.delete_branch_on_merge) { $problems.Add("delete-branch off") }
-  if (-not $meta.allow_squash_merge) { $problems.Add("squash off") }
-  if ($meta.allow_merge_commit) { $problems.Add("merge commits enabled") }
-  if ($meta.allow_rebase_merge) { $problems.Add("rebase enabled") }
+  if (-not $meta.has_issues) { $problems.Add('Issues disabled') }
+  if (-not $meta.allow_auto_merge) { $problems.Add('auto-merge off') }
+  if (-not $meta.allow_update_branch) { $problems.Add('update-branch off') }
+  if (-not $meta.delete_branch_on_merge) { $problems.Add('delete-branch off') }
+  if (-not $meta.allow_squash_merge) { $problems.Add('squash off') }
+  if ($meta.allow_merge_commit) { $problems.Add('merge commits enabled') }
+  if ($meta.allow_rebase_merge) { $problems.Add('rebase enabled') }
 
-  $actionsRaw = & gh api "repos/$repo/actions/permissions" 2>&1
-  if ($LASTEXITCODE -ne 0) { $problems.Add("cannot read Actions permissions") } else { if (-not ((($actionsRaw -join "`n") | ConvertFrom-Json).enabled)) { $problems.Add("Actions disabled") } }
-
-  $codeownersRaw = & gh api -H "Accept: application/vnd.github.raw+json" "repos/$repo/contents/.github/CODEOWNERS?ref=$($meta.default_branch)" 2>&1
-  if ($LASTEXITCODE -ne 0) { $problems.Add("CODEOWNERS missing on default branch") } else {
-    $expectedTail = if ($name -eq 'agent-engineering-standard') { $standardCodeownersTail } else { $appCodeownersTail }
-    if (-not (Test-CodeownersTail -Content ($codeownersRaw -join "`n") -ExpectedTail $expectedTail)) { $problems.Add("CODEOWNERS effective tail does not match canonical ownership map") }
+  $codeownersRaw = & gh api -H 'Accept: application/vnd.github.raw+json' "repos/$repo/contents/.github/CODEOWNERS?ref=$($meta.default_branch)" 2>&1
+  if ($LASTEXITCODE -ne 0) { $problems.Add('CODEOWNERS missing') } else {
+    $expectedTail = if ($name -eq 'agent-engineering-standard') { $standardTail } else { $appTail }
+    if (-not (Test-CodeownersTail -Content ($codeownersRaw -join "`n") -ExpectedTail $expectedTail)) { $problems.Add('CODEOWNERS ownership map drift') }
   }
 
+  $aiWorkflowRaw = & gh api "repos/$repo/contents/.github/workflows/ai-review.yml?ref=$($meta.default_branch)" 2>&1
+  if ($LASTEXITCODE -ne 0) { $problems.Add('AI Review caller workflow missing') }
+
   $rulesetsRaw = & gh api "repos/$repo/rulesets" 2>&1
-  if ($LASTEXITCODE -ne 0) { $problems.Add("cannot read rulesets") } else {
+  if ($LASTEXITCODE -ne 0) { $problems.Add('cannot read rulesets') } else {
     $summary = ((($rulesetsRaw -join "`n") | ConvertFrom-Json) | Where-Object { $_.name -eq $config.ruleset_name } | Select-Object -First 1)
-    if (-not $summary) { $problems.Add("ruleset missing") } else {
+    if (-not $summary) { $problems.Add('ruleset missing') } else {
       $detailRaw = & gh api "repos/$repo/rulesets/$($summary.id)" 2>&1
-      if ($LASTEXITCODE -ne 0) { $problems.Add("cannot read ruleset details") } else {
+      if ($LASTEXITCODE -ne 0) { $problems.Add('cannot read ruleset details') } else {
         $detail = ($detailRaw -join "`n") | ConvertFrom-Json
-        if ($detail.enforcement -ne 'active') { $problems.Add("ruleset not active") }
-        if ($detail.bypass_actors -and @($detail.bypass_actors).Count -gt 0) { $problems.Add("ruleset has bypass actors") }
-        if (-not (@($detail.conditions.ref_name.include) -contains '~DEFAULT_BRANCH')) { $problems.Add("ruleset does not target default branch") }
-        $types = @($detail.rules | ForEach-Object { $_.type })
-        foreach ($requiredType in @('deletion','non_fast_forward','pull_request','required_status_checks')) { if ($types -notcontains $requiredType) { $problems.Add("missing rule: $requiredType") } }
+        if ($detail.enforcement -ne 'active') { $problems.Add('ruleset not active') }
+        if ($detail.bypass_actors -and @($detail.bypass_actors).Count -gt 0) { $problems.Add('ruleset has bypass actors') }
+        if (-not (@($detail.conditions.ref_name.include) -contains '~DEFAULT_BRANCH')) { $problems.Add('ruleset does not target default branch') }
         $prRule = $detail.rules | Where-Object { $_.type -eq 'pull_request' } | Select-Object -First 1
-        if ($prRule) {
-          if ([int]$prRule.parameters.required_approving_review_count -ne 0) { $problems.Add("human approval requirement is not zero") }
-          if ([bool]$prRule.parameters.require_code_owner_review -ne $expectedCodeOwnerReview) { $problems.Add("CODEOWNERS review policy drift") }
-          if (-not $prRule.parameters.required_review_thread_resolution) { $problems.Add("review-thread resolution not required") }
-          $allowedMethods = @($prRule.parameters.allowed_merge_methods)
-          if ($allowedMethods.Count -ne 1 -or $allowedMethods[0] -ne 'squash') { $problems.Add("ruleset merge methods not squash-only") }
+        if (-not $prRule) { $problems.Add('pull-request rule missing') } else {
+          if ([int]$prRule.parameters.required_approving_review_count -ne 0) { $problems.Add('human approval requirement is not zero') }
+          if ([bool]$prRule.parameters.require_code_owner_review -ne $expectedCodeOwnerReview) { $problems.Add('CODEOWNERS review policy drift') }
+          if (-not $prRule.parameters.required_review_thread_resolution) { $problems.Add('review-thread resolution not required') }
+          $allowed = @($prRule.parameters.allowed_merge_methods)
+          if ($allowed.Count -ne 1 -or $allowed[0] -ne 'squash') { $problems.Add('ruleset not squash-only') }
         }
         $statusRule = $detail.rules | Where-Object { $_.type -eq 'required_status_checks' } | Select-Object -First 1
-        if ($statusRule) {
-          if ([bool]$statusRule.parameters.strict_required_status_checks_policy -ne [bool]$config.strict_required_status_checks_policy) { $problems.Add("strict-status policy drift") }
-          $requiredCheck = @($statusRule.parameters.required_status_checks) | Where-Object { $_.context -eq $config.required_status_context } | Select-Object -First 1
-          if (-not $requiredCheck) { $problems.Add("required PR Gate context missing") } elseif ([int]$requiredCheck.integration_id -ne $actionsAppId) { $problems.Add("PR Gate not bound to GitHub Actions") }
+        if (-not $statusRule) { $problems.Add('required-status rule missing') } else {
+          foreach ($context in @($config.required_status_context,$config.required_ai_review_context)) {
+            $check = @($statusRule.parameters.required_status_checks) | Where-Object { $_.context -eq $context } | Select-Object -First 1
+            if (-not $check) { $problems.Add("required context missing: $context") }
+            elseif ([int]$check.integration_id -ne $actionsAppId) { $problems.Add("$context not bound to GitHub Actions") }
+          }
         }
-        if ($config.merge_queue.desired -and $isOrgOwned -and $types -notcontains 'merge_queue') { $problems.Add("merge queue missing on eligible repo") }
       }
     }
   }
@@ -140,17 +137,14 @@ foreach ($name in $config.repositories) {
   $legacyRaw = & gh api "repos/$repo/branches/$($meta.default_branch)/protection" 2>&1
   if ($LASTEXITCODE -eq 0) {
     foreach ($context in @(Get-StaleLegacyRequiredCheckContexts -Protection (($legacyRaw -join "`n") | ConvertFrom-Json) -RequiredContext $config.required_status_context)) { $problems.Add("stale legacy required check: $context") }
-  } else {
-    $legacyError = $legacyRaw -join "`n"
-    if (-not (Test-GitHubBranchProtectionAbsent -ErrorText $legacyError)) { $problems.Add("cannot read legacy branch protection") }
-  }
+  } elseif (-not (Test-GitHubBranchProtectionAbsent -ErrorText ($legacyRaw -join "`n"))) { $problems.Add('cannot read legacy branch protection') }
 
-  if ($problems.Count -eq 0) { Write-Host "${repo} : READY" -ForegroundColor Green } else {
+  if ($problems.Count -eq 0) { Write-Host "${repo} : READY" -ForegroundColor Green }
+  else {
     Write-Host "${repo} : $($problems -join ', ')" -ForegroundColor Yellow
     foreach ($problem in $problems) { $remoteFailures.Add("${repo}: $problem") }
   }
-  if ($config.merge_queue.desired -and -not $isOrgOwned) { Write-Host "  merge queue: waiting on transfer to a supported GitHub organization" -ForegroundColor DarkYellow }
 }
 
 if ($remoteFailures.Count -gt 0) { throw "REMOTE: DRIFT DETECTED`n$($remoteFailures -join "`n")" }
-Write-Host "REMOTE: READY" -ForegroundColor Green
+Write-Host 'REMOTE: READY' -ForegroundColor Green

--- a/scripts/lib/review-policy.ps1
+++ b/scripts/lib/review-policy.ps1
@@ -12,7 +12,7 @@ function Get-RequiredReviewProviders {
 
   switch ($Implementer) {
     'codex' { return @('copilot') }
-    'chatgpt' { return @('copilot') }
+    'chatgpt' { return @('codex') }
     'copilot' { return @('codex') }
     'claude' { return @('codex') }
     default { return @('codex','copilot') }

--- a/scripts/lib/review-policy.ps1
+++ b/scripts/lib/review-policy.ps1
@@ -9,39 +9,30 @@ function Get-ReviewProviderFromLogin {
 
 function Get-PreferredIndependentReviewer {
   param(
-    [ValidateSet('claude','copilot','codex','human','unknown')][string]$Implementer = 'unknown',
+    [ValidateSet('claude','copilot','codex','human')][string]$Implementer,
     [bool]$CodexAvailable = $true,
-    [bool]$CopilotAvailable = $true,
-    [bool]$ClaudeAvailable = $true
+    [bool]$CopilotAvailable = $true
   )
 
   if ($Implementer -ne 'codex' -and $CodexAvailable) { return 'codex' }
   if ($Implementer -ne 'copilot' -and $CopilotAvailable) { return 'copilot' }
-  if ($Implementer -ne 'claude' -and $ClaudeAvailable) { return 'claude' }
-  throw "No independent AI reviewer is available for implementer '$Implementer'."
+  throw "No mechanically connected independent reviewer is available for implementer '$Implementer'."
 }
 
 function Test-IndependentReview {
   param(
-    [Parameter(Mandatory)][string]$Implementer,
-    [Parameter(Mandatory)][string]$ReviewerProvider
+    [Parameter(Mandatory)][ValidateSet('claude','copilot','codex','human')][string]$Implementer,
+    [Parameter(Mandatory)][ValidateSet('copilot','codex')][string]$ReviewerProvider
   )
 
-  if ($Implementer -in @('human','unknown')) { return $true }
+  if ($Implementer -eq 'human') { return $true }
   return $Implementer -ne $ReviewerProvider
 }
 
 function Assert-ManualGateJustification {
   param([Parameter(Mandatory)]$Justification)
 
-  $required = @(
-    'failure_class_prevented',
-    'why_automation_is_insufficient',
-    'decision_owner',
-    'gate_removal_condition'
-  )
-
-  foreach ($field in $required) {
+  foreach ($field in @('failure_class_prevented','why_automation_is_insufficient','decision_owner','gate_removal_condition')) {
     $property = $Justification.PSObject.Properties[$field]
     if (-not $property -or [string]::IsNullOrWhiteSpace([string]$property.Value)) {
       throw "Manual gate is not justified: missing '$field'."

--- a/scripts/lib/review-policy.ps1
+++ b/scripts/lib/review-policy.ps1
@@ -7,25 +7,38 @@ function Get-ReviewProviderFromLogin {
   return $null
 }
 
+function Get-RequiredReviewProviders {
+  param([Parameter(Mandatory)][ValidateSet('claude','copilot','codex','human','unknown')][string]$Implementer)
+
+  switch ($Implementer) {
+    'codex' { return @('copilot') }
+    'copilot' { return @('codex') }
+    'claude' { return @('codex') }
+    default { return @('codex','copilot') }
+  }
+}
+
 function Get-PreferredIndependentReviewer {
   param(
-    [Parameter(Mandatory)][ValidateSet('claude','copilot','codex','human')][string]$Implementer,
+    [Parameter(Mandatory)][ValidateSet('claude','copilot','codex','human','unknown')][string]$Implementer,
     [bool]$CodexAvailable = $true,
     [bool]$CopilotAvailable = $true
   )
 
-  if ($Implementer -ne 'codex' -and $CodexAvailable) { return 'codex' }
-  if ($Implementer -ne 'copilot' -and $CopilotAvailable) { return 'copilot' }
-  throw "No mechanically connected independent reviewer is available for implementer '$Implementer'."
+  foreach ($provider in @(Get-RequiredReviewProviders -Implementer $Implementer)) {
+    if ($provider -eq 'codex' -and $CodexAvailable) { return 'codex' }
+    if ($provider -eq 'copilot' -and $CopilotAvailable) { return 'copilot' }
+  }
+  throw "No required connected reviewer is available for implementer '$Implementer'."
 }
 
 function Test-IndependentReview {
   param(
-    [Parameter(Mandatory)][ValidateSet('claude','copilot','codex','human')][string]$Implementer,
+    [Parameter(Mandatory)][ValidateSet('claude','copilot','codex','human','unknown')][string]$Implementer,
     [Parameter(Mandatory)][ValidateSet('copilot','codex')][string]$ReviewerProvider
   )
 
-  if ($Implementer -eq 'human') { return $true }
+  if ($Implementer -in @('human','unknown')) { return $false }
   return $Implementer -ne $ReviewerProvider
 }
 

--- a/scripts/lib/review-policy.ps1
+++ b/scripts/lib/review-policy.ps1
@@ -3,13 +3,13 @@ function Get-ReviewProviderFromLogin {
 
   $normalized = $Login.ToLowerInvariant()
   if ($normalized -in @('chatgpt-codex-connector', 'chatgpt-codex-connector[bot]')) { return 'codex' }
-  if ($normalized -in @('copilot-pull-request-reviewer', 'copilot-pull-request-reviewer[bot]')) { return 'copilot' }
+  if ($normalized -in @('copilot-pull-request-reviewer', 'copilot-pull-request-reviewer[bot]', 'copilot', 'copilot-swe-agent[bot]')) { return 'copilot' }
   return $null
 }
 
 function Get-PreferredIndependentReviewer {
   param(
-    [ValidateSet('claude','copilot','codex','human')][string]$Implementer,
+    [Parameter(Mandatory)][ValidateSet('claude','copilot','codex','human')][string]$Implementer,
     [bool]$CodexAvailable = $true,
     [bool]$CopilotAvailable = $true
   )

--- a/scripts/lib/review-policy.ps1
+++ b/scripts/lib/review-policy.ps1
@@ -8,10 +8,11 @@ function Get-ReviewProviderFromLogin {
 }
 
 function Get-RequiredReviewProviders {
-  param([Parameter(Mandatory)][ValidateSet('claude','copilot','codex','human','unknown')][string]$Implementer)
+  param([Parameter(Mandatory)][ValidateSet('chatgpt','claude','copilot','codex','human','unknown')][string]$Implementer)
 
   switch ($Implementer) {
     'codex' { return @('copilot') }
+    'chatgpt' { return @('copilot') }
     'copilot' { return @('codex') }
     'claude' { return @('codex') }
     default { return @('codex','copilot') }
@@ -20,7 +21,7 @@ function Get-RequiredReviewProviders {
 
 function Get-PreferredIndependentReviewer {
   param(
-    [Parameter(Mandatory)][ValidateSet('claude','copilot','codex','human','unknown')][string]$Implementer,
+    [Parameter(Mandatory)][ValidateSet('chatgpt','claude','copilot','codex','human','unknown')][string]$Implementer,
     [bool]$CodexAvailable = $true,
     [bool]$CopilotAvailable = $true
   )
@@ -34,12 +35,11 @@ function Get-PreferredIndependentReviewer {
 
 function Test-IndependentReview {
   param(
-    [Parameter(Mandatory)][ValidateSet('claude','copilot','codex','human','unknown')][string]$Implementer,
+    [Parameter(Mandatory)][ValidateSet('chatgpt','claude','copilot','codex','human','unknown')][string]$Implementer,
     [Parameter(Mandatory)][ValidateSet('copilot','codex')][string]$ReviewerProvider
   )
 
-  if ($Implementer -in @('human','unknown')) { return $false }
-  return $Implementer -ne $ReviewerProvider
+  return @((Get-RequiredReviewProviders -Implementer $Implementer)) -contains $ReviewerProvider
 }
 
 function Assert-ManualGateJustification {

--- a/scripts/request-independent-review.ps1
+++ b/scripts/request-independent-review.ps1
@@ -21,6 +21,7 @@ if ($pr.state -ne 'open') { throw "PR #$Pr is not open." }
 if ($pr.draft) { throw "PR #$Pr is draft. Keep implementation churn in draft; request semantic review only when ready." }
 
 $headRef = [string]$pr.head.ref
+$headSha = [string]$pr.head.sha
 $author = [string]$pr.user.login
 $prBody = [string]$pr.body
 $implementer = $null
@@ -36,7 +37,7 @@ if ($LASTEXITCODE -ne 0) { throw ($reviewsRaw -join "`n") }
 $reviews = @(($reviewsRaw -join "`n") | ConvertFrom-Json)
 $currentIndependent = @($reviews | Where-Object {
   $reviewerProvider = Get-ReviewProviderFromLogin -Login $_.user.login
-  $_.commit_id -eq $pr.head.sha -and $_.state -notin @('DISMISSED','PENDING') -and $reviewerProvider -and (Test-IndependentReview -Implementer $implementer -ReviewerProvider $reviewerProvider)
+  $_.commit_id -eq $headSha -and $_.state -notin @('DISMISSED','PENDING') -and $reviewerProvider -and (Test-IndependentReview -Implementer $implementer -ReviewerProvider $reviewerProvider)
 })
 if ($currentIndependent.Count -gt 0) {
   Write-Host "CURRENT-HEAD INDEPENDENT REVIEW ALREADY EXISTS: $($currentIndependent[-1].user.login)" -ForegroundColor Green
@@ -48,29 +49,33 @@ if ($LASTEXITCODE -ne 0) { throw ($commentsRaw -join "`n") }
 $comments = @(($commentsRaw -join "`n") | ConvertFrom-Json)
 $codexReviews = @($reviews | Where-Object { (Get-ReviewProviderFromLogin -Login $_.user.login) -eq 'codex' }).Count
 $copilotReviews = @($reviews | Where-Object { (Get-ReviewProviderFromLogin -Login $_.user.login) -eq 'copilot' }).Count
-$codexRequests = @($comments | Where-Object { $_.body -match '(?i)^\s*@codex\s+review\b' }).Count
-$copilotRequests = @($comments | Where-Object { $_.body -match '(?i)^\s*@copilot\b.*\breview\b' }).Count
+$codexMarker = "<!-- ai-review-request:codex:$headSha -->"
+$copilotMarker = "<!-- ai-review-request:copilot:$headSha -->"
+$codexOutstanding = @($comments | Where-Object { $_.body -like "*$codexMarker*" }).Count -gt 0
+$copilotOutstanding = @($comments | Where-Object { $_.body -like "*$copilotMarker*" }).Count -gt 0
 
 if ($Provider -eq 'auto') {
   $Provider = Get-PreferredIndependentReviewer `
     -Implementer $implementer `
-    -CodexAvailable (($codexReviews -lt [int]$reviewPolicy.max_codex_reviews_per_pr) -and ($codexRequests -lt [int]$reviewPolicy.max_codex_reviews_per_pr)) `
-    -CopilotAvailable ([bool]$reviewPolicy.copilot_fallback -and $copilotReviews -lt [int]$reviewPolicy.max_copilot_reviews_per_pr -and $copilotRequests -lt [int]$reviewPolicy.max_copilot_reviews_per_pr)
+    -CodexAvailable ($codexReviews -lt [int]$reviewPolicy.max_codex_reviews_per_pr -and -not $codexOutstanding) `
+    -CopilotAvailable ([bool]$reviewPolicy.copilot_fallback -and $copilotReviews -lt [int]$reviewPolicy.max_copilot_reviews_per_pr -and -not $copilotOutstanding)
 }
 if (-not (Test-IndependentReview -Implementer $implementer -ReviewerProvider $Provider)) { throw "Reviewer '$Provider' is not independent from implementer '$implementer'." }
 
 switch ($Provider) {
   'codex' {
-    if ($codexRequests -ge [int]$reviewPolicy.max_codex_reviews_per_pr) { throw "Codex review-request budget exhausted for PR #$Pr." }
-    & gh pr comment $Pr --repo $Repo --body '@codex review' | Out-Host
+    if ($codexReviews -ge [int]$reviewPolicy.max_codex_reviews_per_pr) { throw "Codex review-pass budget exhausted for PR #$Pr." }
+    if ($codexOutstanding) { throw "Codex review already requested for current head $headSha." }
+    & gh pr comment $Pr --repo $Repo --body "@codex review`n`n$codexMarker" | Out-Host
     if ($LASTEXITCODE -ne 0) { throw "Could not request Codex review for $Repo PR #$Pr." }
-    Write-Host "REVIEW REQUESTED: Codex ($($codexRequests + 1)/$($reviewPolicy.max_codex_reviews_per_pr)); implementer=$implementer." -ForegroundColor Green
+    Write-Host "REVIEW REQUESTED: Codex pass $($codexReviews + 1)/$($reviewPolicy.max_codex_reviews_per_pr); head=$headSha; implementer=$implementer." -ForegroundColor Green
   }
   'copilot' {
-    if ($copilotRequests -ge [int]$reviewPolicy.max_copilot_reviews_per_pr) { throw "Copilot fallback budget exhausted for PR #$Pr." }
-    $prompt = "@copilot Independently review the CURRENT PR head only. Do not modify files or push commits. Report only material P0-P2 findings. Start with AI-REVIEW PASS or AI-REVIEW FAIL and include the exact head SHA reviewed."
+    if ($copilotReviews -ge [int]$reviewPolicy.max_copilot_reviews_per_pr) { throw "Copilot fallback review-pass budget exhausted for PR #$Pr." }
+    if ($copilotOutstanding) { throw "Copilot fallback already requested for current head $headSha." }
+    $prompt = "@copilot Independently review the CURRENT PR head only. Do not modify files or push commits. Apply software/security, business/product ROI, systems/optimization, and strict leanness lenses. Report only material P0-P2 findings. Start with AI-REVIEW PASS or AI-REVIEW FAIL and include exact SHA $headSha.`n`n$copilotMarker"
     & gh pr comment $Pr --repo $Repo --body $prompt | Out-Host
     if ($LASTEXITCODE -ne 0) { throw "Could not request Copilot fallback review for $Repo PR #$Pr." }
-    Write-Host "REVIEW REQUESTED: Copilot coding-agent fallback ($($copilotRequests + 1)/$($reviewPolicy.max_copilot_reviews_per_pr)); implementer=$implementer." -ForegroundColor Yellow
+    Write-Host "REVIEW REQUESTED: Copilot fallback pass $($copilotReviews + 1)/$($reviewPolicy.max_copilot_reviews_per_pr); head=$headSha; implementer=$implementer." -ForegroundColor Yellow
   }
 }

--- a/scripts/request-independent-review.ps1
+++ b/scripts/request-independent-review.ps1
@@ -23,59 +23,85 @@ if ($pr.draft) { throw "PR #$Pr is draft. Keep implementation churn in draft; re
 $headRef = [string]$pr.head.ref
 $headSha = [string]$pr.head.sha
 $author = [string]$pr.user.login
-$prBody = [string]$pr.body
-$implementer = $null
-if ($headRef -match '^agent/(codex|claude|copilot)/') { $implementer = $Matches[1].ToLowerInvariant() }
+$implementer = 'unknown'
+if ($headRef -match '^agent/(chatgpt|codex|claude|copilot)/') { $implementer = $Matches[1].ToLowerInvariant() }
 elseif ($headRef -match '^claude/') { $implementer = 'claude' }
 elseif ($headRef -match '^copilot/' -or $author -eq 'Copilot') { $implementer = 'copilot' }
 elseif ($author -match '^chatgpt-codex-connector(?:\[bot\])?$') { $implementer = 'codex' }
-elseif ($prBody -match '(?im)^\s*Implementer:\s*human\s*$') { $implementer = 'human' }
-if (-not $implementer) { throw 'Implementation provenance is unknown; use a controlled agent/<provider>/ branch or declare Implementer: human for human-authored work.' }
+
+$requiredProviders = @(Get-RequiredReviewProviders -Implementer $implementer)
 
 $reviewsRaw = & gh api "repos/$Repo/pulls/$Pr/reviews?per_page=100" 2>&1
 if ($LASTEXITCODE -ne 0) { throw ($reviewsRaw -join "`n") }
 $reviews = @(($reviewsRaw -join "`n") | ConvertFrom-Json)
-$currentIndependent = @($reviews | Where-Object {
-  $reviewerProvider = Get-ReviewProviderFromLogin -Login $_.user.login
-  $_.commit_id -eq $headSha -and $_.state -notin @('DISMISSED','PENDING') -and $reviewerProvider -and (Test-IndependentReview -Implementer $implementer -ReviewerProvider $reviewerProvider)
-})
-if ($currentIndependent.Count -gt 0) {
-  Write-Host "CURRENT-HEAD INDEPENDENT REVIEW ALREADY EXISTS: $($currentIndependent[-1].user.login)" -ForegroundColor Green
-  exit 0
-}
-
 $commentsRaw = & gh api "repos/$Repo/issues/$Pr/comments?per_page=100" 2>&1
 if ($LASTEXITCODE -ne 0) { throw ($commentsRaw -join "`n") }
 $comments = @(($commentsRaw -join "`n") | ConvertFrom-Json)
-$codexReviews = @($reviews | Where-Object { (Get-ReviewProviderFromLogin -Login $_.user.login) -eq 'codex' }).Count
-$copilotReviews = @($reviews | Where-Object { (Get-ReviewProviderFromLogin -Login $_.user.login) -eq 'copilot' }).Count
+
+$passedCurrent = @{}
+foreach ($provider in @('codex','copilot')) {
+  $providerReviews = @($reviews | Where-Object {
+    (Get-ReviewProviderFromLogin -Login $_.user.login) -eq $provider -and
+    $_.commit_id -eq $headSha -and $_.state -notin @('DISMISSED','PENDING')
+  } | Sort-Object submitted_at)
+  if ($providerReviews.Count -gt 0 -and $providerReviews[-1].state -ne 'CHANGES_REQUESTED') {
+    $passedCurrent[$provider] = $true
+  }
+}
+
+$structuredCopilotResponses = @($comments | Where-Object {
+  (Get-ReviewProviderFromLogin -Login $_.user.login) -eq 'copilot' -and
+  $_.body -match '(?im)^\s*AI-REVIEW\s+(PASS|FAIL)\b'
+})
+$currentStructuredCopilot = @($structuredCopilotResponses | Where-Object { $_.body -match [regex]::Escape($headSha) } | Sort-Object created_at)
+if ($currentStructuredCopilot.Count -gt 0 -and $currentStructuredCopilot[-1].body -match '(?im)^\s*AI-REVIEW\s+PASS\b') {
+  $passedCurrent['copilot'] = $true
+}
+
+$missing = @($requiredProviders | Where-Object { -not $passedCurrent.ContainsKey($_) })
+if ($missing.Count -eq 0) {
+  Write-Host "CURRENT-HEAD REQUIRED REVIEWS ALREADY SATISFIED: $($requiredProviders -join ', ')" -ForegroundColor Green
+  exit 0
+}
+
+# Budgets count actual semantic responses, not duplicate trigger comments.
+$codexPassCount = @($reviews | Where-Object { (Get-ReviewProviderFromLogin -Login $_.user.login) -eq 'codex' }).Count
+$copilotFormalCount = @($reviews | Where-Object { (Get-ReviewProviderFromLogin -Login $_.user.login) -eq 'copilot' }).Count
+$copilotStructuredCount = $structuredCopilotResponses.Count
+$copilotPassCount = $copilotFormalCount + $copilotStructuredCount
+
 $codexMarker = "<!-- ai-review-request:codex:$headSha -->"
 $copilotMarker = "<!-- ai-review-request:copilot:$headSha -->"
 $codexOutstanding = @($comments | Where-Object { $_.body -like "*$codexMarker*" }).Count -gt 0
 $copilotOutstanding = @($comments | Where-Object { $_.body -like "*$copilotMarker*" }).Count -gt 0
 
+$codexAvailable = ($codexPassCount -lt [int]$reviewPolicy.max_codex_reviews_per_pr) -and -not $codexOutstanding
+$copilotAvailable = [bool]$reviewPolicy.copilot_fallback -and ($copilotPassCount -lt [int]$reviewPolicy.max_copilot_reviews_per_pr) -and -not $copilotOutstanding
+
 if ($Provider -eq 'auto') {
-  $Provider = Get-PreferredIndependentReviewer `
-    -Implementer $implementer `
-    -CodexAvailable ($codexReviews -lt [int]$reviewPolicy.max_codex_reviews_per_pr -and -not $codexOutstanding) `
-    -CopilotAvailable ([bool]$reviewPolicy.copilot_fallback -and $copilotReviews -lt [int]$reviewPolicy.max_copilot_reviews_per_pr -and -not $copilotOutstanding)
+  $Provider = $null
+  foreach ($candidate in $missing) {
+    if ($candidate -eq 'codex' -and $codexAvailable) { $Provider = 'codex'; break }
+    if ($candidate -eq 'copilot' -and $copilotAvailable) { $Provider = 'copilot'; break }
+  }
+  if (-not $Provider) {
+    throw "No budgeted required reviewer is available for current head $headSha. Missing: $($missing -join ', '). Codex passes=$codexPassCount/$($reviewPolicy.max_codex_reviews_per_pr), Copilot passes=$copilotPassCount/$($reviewPolicy.max_copilot_reviews_per_pr)."
+  }
 }
-if (-not (Test-IndependentReview -Implementer $implementer -ReviewerProvider $Provider)) { throw "Reviewer '$Provider' is not independent from implementer '$implementer'." }
+if ($missing -notcontains $Provider) { throw "Reviewer '$Provider' is not a missing required provider for implementer '$implementer'. Missing: $($missing -join ', ')." }
 
 switch ($Provider) {
   'codex' {
-    if ($codexReviews -ge [int]$reviewPolicy.max_codex_reviews_per_pr) { throw "Codex review-pass budget exhausted for PR #$Pr." }
-    if ($codexOutstanding) { throw "Codex review already requested for current head $headSha." }
+    if (-not $codexAvailable) { throw "Codex is unavailable or already requested for current head $headSha." }
     & gh pr comment $Pr --repo $Repo --body "@codex review`n`n$codexMarker" | Out-Host
     if ($LASTEXITCODE -ne 0) { throw "Could not request Codex review for $Repo PR #$Pr." }
-    Write-Host "REVIEW REQUESTED: Codex pass $($codexReviews + 1)/$($reviewPolicy.max_codex_reviews_per_pr); head=$headSha; implementer=$implementer." -ForegroundColor Green
+    Write-Host "REVIEW REQUESTED: Codex response budget $($codexPassCount + 1)/$($reviewPolicy.max_codex_reviews_per_pr); head=$headSha; implementer=$implementer." -ForegroundColor Green
   }
   'copilot' {
-    if ($copilotReviews -ge [int]$reviewPolicy.max_copilot_reviews_per_pr) { throw "Copilot fallback review-pass budget exhausted for PR #$Pr." }
-    if ($copilotOutstanding) { throw "Copilot fallback already requested for current head $headSha." }
+    if (-not $copilotAvailable) { throw "Copilot is unavailable or already requested for current head $headSha." }
     $prompt = "@copilot Independently review the CURRENT PR head only. Do not modify files or push commits. Apply software/security, business/product ROI, systems/optimization, and strict leanness lenses. Report only material P0-P2 findings. Start with AI-REVIEW PASS or AI-REVIEW FAIL and include exact SHA $headSha.`n`n$copilotMarker"
     & gh pr comment $Pr --repo $Repo --body $prompt | Out-Host
     if ($LASTEXITCODE -ne 0) { throw "Could not request Copilot fallback review for $Repo PR #$Pr." }
-    Write-Host "REVIEW REQUESTED: Copilot fallback pass $($copilotReviews + 1)/$($reviewPolicy.max_copilot_reviews_per_pr); head=$headSha; implementer=$implementer." -ForegroundColor Yellow
+    Write-Host "REVIEW REQUESTED: Copilot response budget $($copilotPassCount + 1)/$($reviewPolicy.max_copilot_reviews_per_pr); head=$headSha; implementer=$implementer." -ForegroundColor Yellow
   }
 }

--- a/scripts/request-independent-review.ps1
+++ b/scripts/request-independent-review.ps1
@@ -13,57 +13,64 @@ if ($LASTEXITCODE -ne 0) { throw 'gh is not authenticated.' }
 
 $config = Get-Content (Join-Path $PSScriptRoot '..\policy\github-defaults.json') -Raw | ConvertFrom-Json
 $reviewPolicy = $config.independent_review
-$prRaw = & gh pr view $Pr --repo $Repo --json isDraft,state,headRefOid 2>&1
+
+$prRaw = & gh api "repos/$Repo/pulls/$Pr" 2>&1
 if ($LASTEXITCODE -ne 0) { throw ($prRaw -join "`n") }
 $pr = ($prRaw -join "`n") | ConvertFrom-Json
-if ($pr.state -ne 'OPEN') { throw "PR #$Pr is not open." }
-if ($pr.isDraft) { throw "PR #$Pr is draft; semantic review is intentionally deferred." }
+if ($pr.state -ne 'open') { throw "PR #$Pr is not open." }
+if ($pr.draft) { throw "PR #$Pr is draft. Keep implementation churn in draft; request semantic review only when ready." }
 
-$commentsRaw = & gh api "repos/$Repo/issues/$Pr/comments?per_page=100" 2>&1
-if ($LASTEXITCODE -ne 0) { throw ($commentsRaw -join "`n") }
-$comments = @(($commentsRaw -join "`n") | ConvertFrom-Json)
-$marker = '<!-- agent-engineering:implementer-attestation -->'
-$attestation = $comments | Where-Object { $_.user.login -eq 'github-actions[bot]' -and $_.body -like "*$marker*" } | Select-Object -First 1
-if (-not $attestation -or $attestation.body -notmatch '(?im)^Implementation provider:\s*`(claude|copilot|codex|human)`\s*$') {
-  throw "No trusted GitHub Actions implementer attestation exists yet. Let the AI Review Gate run first."
-}
-$implementer = $Matches[1].ToLowerInvariant()
+$headRef = [string]$pr.head.ref
+$author = [string]$pr.user.login
+$prBody = [string]$pr.body
+$implementer = $null
+if ($headRef -match '^agent/(codex|claude|copilot)/') { $implementer = $Matches[1].ToLowerInvariant() }
+elseif ($headRef -match '^claude/') { $implementer = 'claude' }
+elseif ($headRef -match '^copilot/' -or $author -eq 'Copilot') { $implementer = 'copilot' }
+elseif ($author -match '^chatgpt-codex-connector(?:\[bot\])?$') { $implementer = 'codex' }
+elseif ($prBody -match '(?im)^\s*Implementer:\s*human\s*$') { $implementer = 'human' }
+if (-not $implementer) { throw 'Implementation provenance is unknown; use a controlled agent/<provider>/ branch or declare Implementer: human for human-authored work.' }
 
 $reviewsRaw = & gh api "repos/$Repo/pulls/$Pr/reviews?per_page=100" 2>&1
 if ($LASTEXITCODE -ne 0) { throw ($reviewsRaw -join "`n") }
 $reviews = @(($reviewsRaw -join "`n") | ConvertFrom-Json)
 $currentIndependent = @($reviews | Where-Object {
   $reviewerProvider = Get-ReviewProviderFromLogin -Login $_.user.login
-  $_.commit_id -eq $pr.headRefOid -and $_.state -notin @('DISMISSED','PENDING') -and $reviewerProvider -and (Test-IndependentReview -Implementer $implementer -ReviewerProvider $reviewerProvider)
+  $_.commit_id -eq $pr.head.sha -and $_.state -notin @('DISMISSED','PENDING') -and $reviewerProvider -and (Test-IndependentReview -Implementer $implementer -ReviewerProvider $reviewerProvider)
 })
 if ($currentIndependent.Count -gt 0) {
   Write-Host "CURRENT-HEAD INDEPENDENT REVIEW ALREADY EXISTS: $($currentIndependent[-1].user.login)" -ForegroundColor Green
   exit 0
 }
 
+$commentsRaw = & gh api "repos/$Repo/issues/$Pr/comments?per_page=100" 2>&1
+if ($LASTEXITCODE -ne 0) { throw ($commentsRaw -join "`n") }
+$comments = @(($commentsRaw -join "`n") | ConvertFrom-Json)
 $codexReviews = @($reviews | Where-Object { (Get-ReviewProviderFromLogin -Login $_.user.login) -eq 'codex' }).Count
 $copilotReviews = @($reviews | Where-Object { (Get-ReviewProviderFromLogin -Login $_.user.login) -eq 'copilot' }).Count
-$codexRequests = @($comments | Where-Object { $_.body -match '(?i)@codex\s+review' }).Count
+$codexRequests = @($comments | Where-Object { $_.body -match '(?i)^\s*@codex\s+review\b' }).Count
+$copilotRequests = @($comments | Where-Object { $_.body -match '(?i)^\s*@copilot\b.*\breview\b' }).Count
 
 if ($Provider -eq 'auto') {
   $Provider = Get-PreferredIndependentReviewer `
     -Implementer $implementer `
     -CodexAvailable (($codexReviews -lt [int]$reviewPolicy.max_codex_reviews_per_pr) -and ($codexRequests -lt [int]$reviewPolicy.max_codex_reviews_per_pr)) `
-    -CopilotAvailable ([bool]$reviewPolicy.copilot_fallback -and $copilotReviews -lt [int]$reviewPolicy.max_copilot_reviews_per_pr)
+    -CopilotAvailable ([bool]$reviewPolicy.copilot_fallback -and $copilotReviews -lt [int]$reviewPolicy.max_copilot_reviews_per_pr -and $copilotRequests -lt [int]$reviewPolicy.max_copilot_reviews_per_pr)
 }
-if (-not (Test-IndependentReview -Implementer $implementer -ReviewerProvider $Provider)) { throw "Reviewer '$Provider' is not independent from attested implementer '$implementer'." }
+if (-not (Test-IndependentReview -Implementer $implementer -ReviewerProvider $Provider)) { throw "Reviewer '$Provider' is not independent from implementer '$implementer'." }
 
 switch ($Provider) {
   'codex' {
-    if ($codexReviews -ge [int]$reviewPolicy.max_codex_reviews_per_pr -or $codexRequests -ge [int]$reviewPolicy.max_codex_reviews_per_pr) { throw "Codex review budget exhausted for PR #$Pr." }
+    if ($codexRequests -ge [int]$reviewPolicy.max_codex_reviews_per_pr) { throw "Codex review-request budget exhausted for PR #$Pr." }
     & gh pr comment $Pr --repo $Repo --body '@codex review' | Out-Host
     if ($LASTEXITCODE -ne 0) { throw "Could not request Codex review for $Repo PR #$Pr." }
-    Write-Host "REVIEW REQUESTED: Codex ($($codexRequests + 1)/$($reviewPolicy.max_codex_reviews_per_pr)); attested implementer=$implementer." -ForegroundColor Green
+    Write-Host "REVIEW REQUESTED: Codex ($($codexRequests + 1)/$($reviewPolicy.max_codex_reviews_per_pr)); implementer=$implementer." -ForegroundColor Green
   }
   'copilot' {
-    if ($copilotReviews -ge [int]$reviewPolicy.max_copilot_reviews_per_pr) { throw "Copilot review budget exhausted for PR #$Pr." }
-    & gh pr edit $Pr --repo $Repo --add-reviewer '@copilot' | Out-Host
-    if ($LASTEXITCODE -ne 0) { throw "Could not request Copilot review for $Repo PR #$Pr." }
-    Write-Host "REVIEW REQUESTED: Copilot fallback ($($copilotReviews + 1)/$($reviewPolicy.max_copilot_reviews_per_pr)); attested implementer=$implementer." -ForegroundColor Yellow
+    if ($copilotRequests -ge [int]$reviewPolicy.max_copilot_reviews_per_pr) { throw "Copilot fallback budget exhausted for PR #$Pr." }
+    $prompt = "@copilot Independently review the CURRENT PR head only. Do not modify files or push commits. Report only material P0-P2 findings. Start with AI-REVIEW PASS or AI-REVIEW FAIL and include the exact head SHA reviewed."
+    & gh pr comment $Pr --repo $Repo --body $prompt | Out-Host
+    if ($LASTEXITCODE -ne 0) { throw "Could not request Copilot fallback review for $Repo PR #$Pr." }
+    Write-Host "REVIEW REQUESTED: Copilot coding-agent fallback ($($copilotRequests + 1)/$($reviewPolicy.max_copilot_reviews_per_pr)); implementer=$implementer." -ForegroundColor Yellow
   }
 }

--- a/scripts/request-independent-review.ps1
+++ b/scripts/request-independent-review.ps1
@@ -1,7 +1,6 @@
 param(
   [Parameter(Mandatory)][string]$Repo,
   [Parameter(Mandatory)][int]$Pr,
-  [ValidateSet('auto','claude','copilot','codex','human','unknown')][string]$Implementer = 'auto',
   [ValidateSet('auto','codex','copilot')][string]$Provider = 'auto'
 )
 
@@ -14,27 +13,28 @@ if ($LASTEXITCODE -ne 0) { throw 'gh is not authenticated.' }
 
 $config = Get-Content (Join-Path $PSScriptRoot '..\policy\github-defaults.json') -Raw | ConvertFrom-Json
 $reviewPolicy = $config.independent_review
-
-$prRaw = & gh pr view $Pr --repo $Repo --json isDraft,state,headRefOid,body 2>&1
+$prRaw = & gh pr view $Pr --repo $Repo --json isDraft,state,headRefOid 2>&1
 if ($LASTEXITCODE -ne 0) { throw ($prRaw -join "`n") }
-$prInfo = ($prRaw -join "`n") | ConvertFrom-Json
-if ($prInfo.state -ne 'OPEN') { throw "PR #$Pr is not open." }
-if ($prInfo.isDraft) { throw "PR #$Pr is draft. Keep implementation churn in draft; request independent review only when ready." }
+$pr = ($prRaw -join "`n") | ConvertFrom-Json
+if ($pr.state -ne 'OPEN') { throw "PR #$Pr is not open." }
+if ($pr.isDraft) { throw "PR #$Pr is draft; semantic review is intentionally deferred." }
 
-if ($Implementer -eq 'auto') {
-  $match = [regex]::Match([string]$prInfo.body, '(?im)^\s*Implementer:\s*(claude|copilot|codex|human)\s*$')
-  $Implementer = if ($match.Success) { $match.Groups[1].Value.ToLowerInvariant() } else { 'unknown' }
+$commentsRaw = & gh api "repos/$Repo/issues/$Pr/comments?per_page=100" 2>&1
+if ($LASTEXITCODE -ne 0) { throw ($commentsRaw -join "`n") }
+$comments = @(($commentsRaw -join "`n") | ConvertFrom-Json)
+$marker = '<!-- agent-engineering:implementer-attestation -->'
+$attestation = $comments | Where-Object { $_.user.login -eq 'github-actions[bot]' -and $_.body -like "*$marker*" } | Select-Object -First 1
+if (-not $attestation -or $attestation.body -notmatch '(?im)^Implementation provider:\s*`(claude|copilot|codex|human)`\s*$') {
+  throw "No trusted GitHub Actions implementer attestation exists yet. Let the AI Review Gate run first."
 }
-if ($Implementer -eq 'unknown') { throw "Independent review routing requires a concrete Implementer: claude|copilot|codex|human line in the PR body (or -Implementer explicitly)." }
+$implementer = $Matches[1].ToLowerInvariant()
 
-$reviewsRaw = & gh api --paginate --slurp "repos/$Repo/pulls/$Pr/reviews?per_page=100" 2>&1
+$reviewsRaw = & gh api "repos/$Repo/pulls/$Pr/reviews?per_page=100" 2>&1
 if ($LASTEXITCODE -ne 0) { throw ($reviewsRaw -join "`n") }
-$reviewPages = ($reviewsRaw -join "`n") | ConvertFrom-Json
-$reviews = @($reviewPages | ForEach-Object { $_ })
-
+$reviews = @(($reviewsRaw -join "`n") | ConvertFrom-Json)
 $currentIndependent = @($reviews | Where-Object {
-  $provider = Get-ReviewProviderFromLogin -Login $_.user.login
-  $_.commit_id -eq $prInfo.headRefOid -and $_.state -ne 'DISMISSED' -and $provider -and (Test-IndependentReview -Implementer $Implementer -ReviewerProvider $provider)
+  $reviewerProvider = Get-ReviewProviderFromLogin -Login $_.user.login
+  $_.commit_id -eq $pr.headRefOid -and $_.state -notin @('DISMISSED','PENDING') -and $reviewerProvider -and (Test-IndependentReview -Implementer $implementer -ReviewerProvider $reviewerProvider)
 })
 if ($currentIndependent.Count -gt 0) {
   Write-Host "CURRENT-HEAD INDEPENDENT REVIEW ALREADY EXISTS: $($currentIndependent[-1].user.login)" -ForegroundColor Green
@@ -43,35 +43,27 @@ if ($currentIndependent.Count -gt 0) {
 
 $codexReviews = @($reviews | Where-Object { (Get-ReviewProviderFromLogin -Login $_.user.login) -eq 'codex' }).Count
 $copilotReviews = @($reviews | Where-Object { (Get-ReviewProviderFromLogin -Login $_.user.login) -eq 'copilot' }).Count
-
-$commentsRaw = & gh api --paginate --slurp "repos/$Repo/issues/$Pr/comments?per_page=100" 2>&1
-if ($LASTEXITCODE -ne 0) { throw ($commentsRaw -join "`n") }
-$commentPages = ($commentsRaw -join "`n") | ConvertFrom-Json
-$comments = @($commentPages | ForEach-Object { $_ })
 $codexRequests = @($comments | Where-Object { $_.body -match '(?i)@codex\s+review' }).Count
 
 if ($Provider -eq 'auto') {
   $Provider = Get-PreferredIndependentReviewer `
-    -Implementer $Implementer `
+    -Implementer $implementer `
     -CodexAvailable (($codexReviews -lt [int]$reviewPolicy.max_codex_reviews_per_pr) -and ($codexRequests -lt [int]$reviewPolicy.max_codex_reviews_per_pr)) `
-    -CopilotAvailable ([bool]$reviewPolicy.copilot_fallback -and $copilotReviews -lt [int]$reviewPolicy.max_copilot_reviews_per_pr) `
-    -ClaudeAvailable $false
+    -CopilotAvailable ([bool]$reviewPolicy.copilot_fallback -and $copilotReviews -lt [int]$reviewPolicy.max_copilot_reviews_per_pr)
 }
-
-if (-not (Test-IndependentReview -Implementer $Implementer -ReviewerProvider $Provider)) { throw "Reviewer '$Provider' is not independent from implementer '$Implementer'." }
+if (-not (Test-IndependentReview -Implementer $implementer -ReviewerProvider $Provider)) { throw "Reviewer '$Provider' is not independent from attested implementer '$implementer'." }
 
 switch ($Provider) {
   'codex' {
     if ($codexReviews -ge [int]$reviewPolicy.max_codex_reviews_per_pr -or $codexRequests -ge [int]$reviewPolicy.max_codex_reviews_per_pr) { throw "Codex review budget exhausted for PR #$Pr." }
     & gh pr comment $Pr --repo $Repo --body '@codex review' | Out-Host
     if ($LASTEXITCODE -ne 0) { throw "Could not request Codex review for $Repo PR #$Pr." }
-    Write-Host "REVIEW REQUESTED: Codex GitHub ($($codexRequests + 1)/$($reviewPolicy.max_codex_reviews_per_pr)); implementer=$Implementer." -ForegroundColor Green
+    Write-Host "REVIEW REQUESTED: Codex ($($codexRequests + 1)/$($reviewPolicy.max_codex_reviews_per_pr)); attested implementer=$implementer." -ForegroundColor Green
   }
   'copilot' {
     if ($copilotReviews -ge [int]$reviewPolicy.max_copilot_reviews_per_pr) { throw "Copilot review budget exhausted for PR #$Pr." }
-    # @copilot is GitHub's documented reviewer alias; the submitted review is authored by copilot-pull-request-reviewer[bot].
     & gh pr edit $Pr --repo $Repo --add-reviewer '@copilot' | Out-Host
     if ($LASTEXITCODE -ne 0) { throw "Could not request Copilot review for $Repo PR #$Pr." }
-    Write-Host "REVIEW REQUESTED: Copilot fallback ($($copilotReviews + 1)/$($reviewPolicy.max_copilot_reviews_per_pr)); implementer=$Implementer; review-on-push remains disabled." -ForegroundColor Yellow
+    Write-Host "REVIEW REQUESTED: Copilot fallback ($($copilotReviews + 1)/$($reviewPolicy.max_copilot_reviews_per_pr)); attested implementer=$implementer." -ForegroundColor Yellow
   }
 }

--- a/templates/AI_REVIEW.yml
+++ b/templates/AI_REVIEW.yml
@@ -5,13 +5,16 @@ on:
     types: [opened, reopened, synchronize, ready_for_review, edited]
   pull_request_review:
     types: [submitted, dismissed]
+  issue_comment:
+    types: [created, edited]
 
 jobs:
   update-ai-review:
+    if: github.event_name != 'issue_comment' || github.event.issue.pull_request != null
     permissions:
       checks: write
       contents: read
       pull-requests: read
     uses: kgsmith19/agent-engineering-standard/.github/workflows/ai-review-reusable.yml@main
     with:
-      pr_number: ${{ github.event.pull_request.number }}
+      pr_number: ${{ github.event.pull_request.number || github.event.issue.number }}

--- a/templates/AI_REVIEW.yml
+++ b/templates/AI_REVIEW.yml
@@ -11,7 +11,6 @@ jobs:
     permissions:
       checks: write
       contents: read
-      issues: write
       pull-requests: read
     uses: kgsmith19/agent-engineering-standard/.github/workflows/ai-review-reusable.yml@main
     with:

--- a/templates/AI_REVIEW.yml
+++ b/templates/AI_REVIEW.yml
@@ -8,6 +8,10 @@ on:
   issue_comment:
     types: [created, edited]
 
+concurrency:
+  group: ai-review-${{ github.repository }}-${{ github.event.pull_request.number || github.event.issue.number }}
+  cancel-in-progress: true
+
 jobs:
   update-ai-review:
     if: github.event_name != 'issue_comment' || github.event.issue.pull_request != null

--- a/templates/AI_REVIEW.yml
+++ b/templates/AI_REVIEW.yml
@@ -1,0 +1,18 @@
+name: AI Review Gate
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, ready_for_review, edited]
+  pull_request_review:
+    types: [submitted, dismissed]
+
+jobs:
+  update-ai-review:
+    permissions:
+      checks: write
+      contents: read
+      issues: write
+      pull-requests: read
+    uses: kgsmith19/agent-engineering-standard/.github/workflows/ai-review-reusable.yml@main
+    with:
+      pr_number: ${{ github.event.pull_request.number }}

--- a/templates/PULL_REQUEST.md
+++ b/templates/PULL_REQUEST.md
@@ -4,9 +4,9 @@
 Issue:
 Spec:
 Slice(s):
-Implementer: claude / copilot / codex / human
+Implementer: chatgpt / claude / copilot / codex / human
 
-> Agent-created PRs must use a recognized provider author/prefix or `agent/<provider>/...`; `AI Review` fails closed on unknown implementation provenance.
+> The Implementer line is descriptive, not trusted agent identity. Controlled agent work should use `agent/<provider>/...` (for example `agent/chatgpt/42-fix`). Ordinary/user-authored branches are treated as ambiguous and require both Codex + Copilot for unattended merge.
 
 ## What Changed
 -

--- a/templates/PULL_REQUEST.md
+++ b/templates/PULL_REQUEST.md
@@ -4,17 +4,18 @@
 Issue:
 Spec:
 Slice(s):
-Implementer: claude / copilot / codex / human / unknown
+Implementer: claude / copilot / codex / human
+
+> Agent-created PRs must use a recognized provider author/prefix or `agent/<provider>/...`; `AI Review` fails closed on unknown implementation provenance.
 
 ## What Changed
 -
 
 ## Evidence
-- [ ] Required checks pass
+- [ ] Required `PR Gate` passes on the latest head
+- [ ] Required `AI Review` passes on the latest head
 - [ ] Acceptance satisfied
-- [ ] Protected evaluator passes when applicable
-- [ ] Risk/security checks pass when applicable
-- [ ] Current-head independent review requested from a different provider/agent
+- [ ] Risk/security evidence passes when applicable
 
 ## Risk
 R0 / R1 / R2 / R3 / R4
@@ -25,7 +26,7 @@ R0 / R1 / R2 / R3 / R4
 ## Integrity
 - [ ] Tests/policies were not weakened
 - [ ] Scope was not unnecessarily widened
-- [ ] Repeated manual work discovered here was automated in-scope or logged as one bounded automation/research candidate
+- [ ] Repeated manual work was automated in-scope or logged as one bounded automation/research candidate
 
 ## Manual Gate (only when actually required)
 None, or state all four:

--- a/tests/review-policy.tests.ps1
+++ b/tests/review-policy.tests.ps1
@@ -14,27 +14,28 @@ function Assert-Throws {
 }
 
 Assert-Throws 'review routing requires an explicit implementer' { Get-PreferredIndependentReviewer }
+Assert-Equal 'ChatGPT implementation routes to Copilot' (Get-PreferredIndependentReviewer -Implementer chatgpt) 'copilot'
 Assert-Equal 'Claude implementation routes to Codex' (Get-PreferredIndependentReviewer -Implementer claude) 'codex'
 Assert-Equal 'Copilot implementation routes to Codex' (Get-PreferredIndependentReviewer -Implementer copilot) 'codex'
 Assert-Equal 'Codex implementation routes to Copilot' (Get-PreferredIndependentReviewer -Implementer codex) 'copilot'
 Assert-Equal 'Unknown provenance starts with Codex' (Get-PreferredIndependentReviewer -Implementer unknown) 'codex'
 Assert-Equal 'Human/user-authored provenance starts with Codex' (Get-PreferredIndependentReviewer -Implementer human) 'codex'
 Assert-Throws 'Codex without Copilot is blocked instead of pretending Claude is connected' { Get-PreferredIndependentReviewer -Implementer codex -CopilotAvailable $false }
-Assert-Throws 'Codex cannot review Codex when it is the only provider' { Get-PreferredIndependentReviewer -Implementer codex -CopilotAvailable $false -CodexAvailable $true }
 
 $unknownProviders = @(Get-RequiredReviewProviders -Implementer unknown)
 Assert-Equal 'Unknown provenance requires two providers' $unknownProviders.Count 2
-Assert-Equal 'Unknown first required provider is Codex' $unknownProviders[0] 'codex'
-Assert-Equal 'Unknown second required provider is Copilot' $unknownProviders[1] 'copilot'
+Assert-Equal 'Unknown first provider is Codex' $unknownProviders[0] 'codex'
+Assert-Equal 'Unknown second provider is Copilot' $unknownProviders[1] 'copilot'
+Assert-Equal 'ChatGPT requires Copilot specifically' (@(Get-RequiredReviewProviders -Implementer chatgpt)[0]) 'copilot'
 
 Assert-Equal 'Codex bot login recognized' (Get-ReviewProviderFromLogin -Login 'chatgpt-codex-connector[bot]') 'codex'
 Assert-Equal 'Copilot bot login recognized' (Get-ReviewProviderFromLogin -Login 'copilot-pull-request-reviewer[bot]') 'copilot'
 Assert-Equal 'Copilot coding-agent login recognized' (Get-ReviewProviderFromLogin -Login 'copilot-swe-agent[bot]') 'copilot'
 Assert-Equal 'unknown reviewer ignored' (Get-ReviewProviderFromLogin -Login 'random-bot[bot]') $null
-Assert-Equal 'different known provider is independent' (Test-IndependentReview -Implementer claude -ReviewerProvider codex) $true
-Assert-Equal 'same provider is not independent' (Test-IndependentReview -Implementer codex -ReviewerProvider codex) $false
-Assert-Equal 'single provider cannot prove ambiguous human provenance' (Test-IndependentReview -Implementer human -ReviewerProvider codex) $false
-Assert-Equal 'single provider cannot prove unknown provenance' (Test-IndependentReview -Implementer unknown -ReviewerProvider codex) $false
+Assert-Equal 'Claude-Codex pair is valid' (Test-IndependentReview -Implementer claude -ReviewerProvider codex) $true
+Assert-Equal 'Codex-Codex pair is invalid' (Test-IndependentReview -Implementer codex -ReviewerProvider codex) $false
+Assert-Equal 'ChatGPT-Codex is not accepted as cross-provider' (Test-IndependentReview -Implementer chatgpt -ReviewerProvider codex) $false
+Assert-Equal 'ChatGPT-Copilot is cross-provider' (Test-IndependentReview -Implementer chatgpt -ReviewerProvider copilot) $true
 
 $validGate = [pscustomobject]@{
   failure_class_prevented = 'irreversible production data loss'

--- a/tests/review-policy.tests.ps1
+++ b/tests/review-policy.tests.ps1
@@ -12,6 +12,9 @@ function Assert-Throws {
   throw "$Name failed: expected an exception."
 }
 
+Assert-Throws 'review routing requires an explicit implementer' {
+  Get-PreferredIndependentReviewer
+}
 Assert-Equal 'Claude implementation routes to Codex' (Get-PreferredIndependentReviewer -Implementer claude) 'codex'
 Assert-Equal 'Copilot implementation routes to Codex' (Get-PreferredIndependentReviewer -Implementer copilot) 'codex'
 Assert-Equal 'Codex implementation routes to Copilot' (Get-PreferredIndependentReviewer -Implementer codex) 'copilot'
@@ -24,6 +27,7 @@ Assert-Throws 'Codex cannot review Codex when it is the only provider' {
 
 Assert-Equal 'Codex bot login recognized' (Get-ReviewProviderFromLogin -Login 'chatgpt-codex-connector[bot]') 'codex'
 Assert-Equal 'Copilot bot login recognized' (Get-ReviewProviderFromLogin -Login 'copilot-pull-request-reviewer[bot]') 'copilot'
+Assert-Equal 'Copilot coding-agent login recognized' (Get-ReviewProviderFromLogin -Login 'copilot-swe-agent[bot]') 'copilot'
 Assert-Equal 'unknown reviewer ignored' (Get-ReviewProviderFromLogin -Login 'random-bot[bot]') $null
 Assert-Equal 'different provider is independent' (Test-IndependentReview -Implementer claude -ReviewerProvider codex) $true
 Assert-Equal 'same provider is not independent' (Test-IndependentReview -Implementer codex -ReviewerProvider codex) $false

--- a/tests/review-policy.tests.ps1
+++ b/tests/review-policy.tests.ps1
@@ -15,9 +15,11 @@ function Assert-Throws {
 Assert-Equal 'Claude implementation routes to Codex' (Get-PreferredIndependentReviewer -Implementer claude) 'codex'
 Assert-Equal 'Copilot implementation routes to Codex' (Get-PreferredIndependentReviewer -Implementer copilot) 'codex'
 Assert-Equal 'Codex implementation routes to Copilot' (Get-PreferredIndependentReviewer -Implementer codex) 'copilot'
-Assert-Equal 'Codex falls back to Claude when Copilot unavailable' (Get-PreferredIndependentReviewer -Implementer codex -CopilotAvailable $false) 'claude'
-Assert-Throws 'same-provider-only availability is refused' {
-  Get-PreferredIndependentReviewer -Implementer codex -CopilotAvailable $false -ClaudeAvailable $false
+Assert-Throws 'Codex without Copilot is blocked instead of pretending Claude is connected' {
+  Get-PreferredIndependentReviewer -Implementer codex -CopilotAvailable $false
+}
+Assert-Throws 'Codex cannot review Codex when it is the only provider' {
+  Get-PreferredIndependentReviewer -Implementer codex -CopilotAvailable $false -CodexAvailable $true
 }
 
 Assert-Equal 'Codex bot login recognized' (Get-ReviewProviderFromLogin -Login 'chatgpt-codex-connector[bot]') 'codex'
@@ -25,11 +27,12 @@ Assert-Equal 'Copilot bot login recognized' (Get-ReviewProviderFromLogin -Login 
 Assert-Equal 'unknown reviewer ignored' (Get-ReviewProviderFromLogin -Login 'random-bot[bot]') $null
 Assert-Equal 'different provider is independent' (Test-IndependentReview -Implementer claude -ReviewerProvider codex) $true
 Assert-Equal 'same provider is not independent' (Test-IndependentReview -Implementer codex -ReviewerProvider codex) $false
+Assert-Equal 'human implementation accepts an AI reviewer' (Test-IndependentReview -Implementer human -ReviewerProvider codex) $true
 
 $validGate = [pscustomobject]@{
   failure_class_prevented = 'irreversible production data loss'
   why_automation_is_insufficient = 'the intent to destroy cannot be inferred from repository state'
-  decision_owner = 'Kyle'
+  decision_owner = 'authorized human owner'
   gate_removal_condition = 'operation becomes reversible with independently verified restore'
 }
 Assert-Equal 'complete manual gate justification accepted' (Assert-ManualGateJustification -Justification $validGate) $true

--- a/tests/review-policy.tests.ps1
+++ b/tests/review-policy.tests.ps1
@@ -17,16 +17,24 @@ Assert-Throws 'review routing requires an explicit implementer' { Get-PreferredI
 Assert-Equal 'Claude implementation routes to Codex' (Get-PreferredIndependentReviewer -Implementer claude) 'codex'
 Assert-Equal 'Copilot implementation routes to Codex' (Get-PreferredIndependentReviewer -Implementer copilot) 'codex'
 Assert-Equal 'Codex implementation routes to Copilot' (Get-PreferredIndependentReviewer -Implementer codex) 'copilot'
+Assert-Equal 'Unknown provenance starts with Codex' (Get-PreferredIndependentReviewer -Implementer unknown) 'codex'
+Assert-Equal 'Human/user-authored provenance starts with Codex' (Get-PreferredIndependentReviewer -Implementer human) 'codex'
 Assert-Throws 'Codex without Copilot is blocked instead of pretending Claude is connected' { Get-PreferredIndependentReviewer -Implementer codex -CopilotAvailable $false }
 Assert-Throws 'Codex cannot review Codex when it is the only provider' { Get-PreferredIndependentReviewer -Implementer codex -CopilotAvailable $false -CodexAvailable $true }
+
+$unknownProviders = @(Get-RequiredReviewProviders -Implementer unknown)
+Assert-Equal 'Unknown provenance requires two providers' $unknownProviders.Count 2
+Assert-Equal 'Unknown first required provider is Codex' $unknownProviders[0] 'codex'
+Assert-Equal 'Unknown second required provider is Copilot' $unknownProviders[1] 'copilot'
 
 Assert-Equal 'Codex bot login recognized' (Get-ReviewProviderFromLogin -Login 'chatgpt-codex-connector[bot]') 'codex'
 Assert-Equal 'Copilot bot login recognized' (Get-ReviewProviderFromLogin -Login 'copilot-pull-request-reviewer[bot]') 'copilot'
 Assert-Equal 'Copilot coding-agent login recognized' (Get-ReviewProviderFromLogin -Login 'copilot-swe-agent[bot]') 'copilot'
 Assert-Equal 'unknown reviewer ignored' (Get-ReviewProviderFromLogin -Login 'random-bot[bot]') $null
-Assert-Equal 'different provider is independent' (Test-IndependentReview -Implementer claude -ReviewerProvider codex) $true
+Assert-Equal 'different known provider is independent' (Test-IndependentReview -Implementer claude -ReviewerProvider codex) $true
 Assert-Equal 'same provider is not independent' (Test-IndependentReview -Implementer codex -ReviewerProvider codex) $false
-Assert-Equal 'human implementation accepts an AI reviewer' (Test-IndependentReview -Implementer human -ReviewerProvider codex) $true
+Assert-Equal 'single provider cannot prove ambiguous human provenance' (Test-IndependentReview -Implementer human -ReviewerProvider codex) $false
+Assert-Equal 'single provider cannot prove unknown provenance' (Test-IndependentReview -Implementer unknown -ReviewerProvider codex) $false
 
 $validGate = [pscustomobject]@{
   failure_class_prevented = 'irreversible production data loss'

--- a/tests/review-policy.tests.ps1
+++ b/tests/review-policy.tests.ps1
@@ -1,5 +1,6 @@
 $ErrorActionPreference = 'Stop'
-. (Join-Path $PSScriptRoot '..\scripts\lib\review-policy.ps1')
+$root = (Resolve-Path (Join-Path $PSScriptRoot '..')).Path
+. (Join-Path $root 'scripts/lib/review-policy.ps1')
 
 function Assert-Equal {
   param([string]$Name, $Actual, $Expected)
@@ -12,18 +13,12 @@ function Assert-Throws {
   throw "$Name failed: expected an exception."
 }
 
-Assert-Throws 'review routing requires an explicit implementer' {
-  Get-PreferredIndependentReviewer
-}
+Assert-Throws 'review routing requires an explicit implementer' { Get-PreferredIndependentReviewer }
 Assert-Equal 'Claude implementation routes to Codex' (Get-PreferredIndependentReviewer -Implementer claude) 'codex'
 Assert-Equal 'Copilot implementation routes to Codex' (Get-PreferredIndependentReviewer -Implementer copilot) 'codex'
 Assert-Equal 'Codex implementation routes to Copilot' (Get-PreferredIndependentReviewer -Implementer codex) 'copilot'
-Assert-Throws 'Codex without Copilot is blocked instead of pretending Claude is connected' {
-  Get-PreferredIndependentReviewer -Implementer codex -CopilotAvailable $false
-}
-Assert-Throws 'Codex cannot review Codex when it is the only provider' {
-  Get-PreferredIndependentReviewer -Implementer codex -CopilotAvailable $false -CodexAvailable $true
-}
+Assert-Throws 'Codex without Copilot is blocked instead of pretending Claude is connected' { Get-PreferredIndependentReviewer -Implementer codex -CopilotAvailable $false }
+Assert-Throws 'Codex cannot review Codex when it is the only provider' { Get-PreferredIndependentReviewer -Implementer codex -CopilotAvailable $false -CodexAvailable $true }
 
 Assert-Equal 'Codex bot login recognized' (Get-ReviewProviderFromLogin -Login 'chatgpt-codex-connector[bot]') 'codex'
 Assert-Equal 'Copilot bot login recognized' (Get-ReviewProviderFromLogin -Login 'copilot-pull-request-reviewer[bot]') 'copilot'
@@ -47,5 +42,9 @@ Assert-Throws 'manual gate missing removal condition is refused' {
     decision_owner = 'z'
   })
 }
+
+$bootstrap = Get-Content (Join-Path $root 'scripts/bootstrap-repo.ps1') -Raw
+if ($bootstrap -notmatch "templates/AI_REVIEW\.yml") { throw 'bootstrap-repo.ps1 must source templates/AI_REVIEW.yml.' }
+if ($bootstrap -notmatch "\.github/workflows/ai-review\.yml") { throw 'bootstrap-repo.ps1 must install .github/workflows/ai-review.yml before applying the ruleset.' }
 
 Write-Host 'review-policy tests: PASS' -ForegroundColor Green


### PR DESCRIPTION
Superseded by a clean provider-provenance recut. The implementation is preserved exactly on `agent/chatgpt/21-exact-head-ai-review`, based on verified final source head `ff7a67e11d593b2add57c30999725332a68595e8` (CI green). Closing this PR resets the noisy reviewer/debug history and lets the final integration prove the intended rule mechanically: ChatGPT implementation → Copilot current-head review. No intended Issue #21 change is being discarded.