### PR TITLE
fix: consolidate current automation work onto a clean main

### DIFF
--- a/.github/workflows/ai-review-reusable.yml
+++ b/.github/workflows/ai-review-reusable.yml
@@ -34,17 +34,10 @@ jobs:
             } finally { Remove-Item $tmp -Force -ErrorAction SilentlyContinue }
           }
 
-<<<<<<< HEAD
-          function Get-ProviderFromReviewer([string]$Login) {
-            $value = $Login.ToLowerInvariant()
-            if ($value -in @('chatgpt-codex-connector','chatgpt-codex-connector[bot]')) { return 'codex' }
-            if ($value -in @('copilot-pull-request-reviewer','copilot-pull-request-reviewer[bot]')) { return 'copilot' }
-=======
           function Get-ProviderFromLogin([string]$Login) {
             $value = $Login.ToLowerInvariant()
             if ($value -in @('chatgpt-codex-connector','chatgpt-codex-connector[bot]')) { return 'codex' }
             if ($value -in @('copilot-pull-request-reviewer','copilot-pull-request-reviewer[bot]','copilot','copilot-swe-agent[bot]')) { return 'copilot' }
->>>>>>> origin/main
             return $null
           }
 
@@ -70,30 +63,12 @@ jobs:
           $headSha = [string]$pr.head.sha
           $headRef = [string]$pr.head.ref
           $author = [string]$pr.user.login
-<<<<<<< HEAD
-          $prBody = [string]$pr.body
-=======
->>>>>>> origin/main
 
           if ($pr.draft) {
             Set-AiReviewCheck $headSha failure 'Draft PR: semantic review is intentionally deferred.'
             exit 0
           }
 
-<<<<<<< HEAD
-          # LLM identity is accepted only from controlled branch namespaces or recognized bot authors.
-          # Editable PR prose may identify a human implementation, but cannot self-attest an LLM provider.
-          $implementer = $null
-          if ($headRef -match '^agent/(codex|claude|copilot)/') { $implementer = $Matches[1].ToLowerInvariant() }
-          elseif ($headRef -match '^claude/') { $implementer = 'claude' }
-          elseif ($headRef -match '^copilot/' -or $author -eq 'Copilot') { $implementer = 'copilot' }
-          elseif ($author -match '^chatgpt-codex-connector(?:\[bot\])?$') { $implementer = 'codex' }
-          elseif ($prBody -match '(?im)^\s*Implementer:\s*human\s*$') { $implementer = 'human' }
-
-          if (-not $implementer) {
-            Set-AiReviewCheck $headSha failure 'Unknown implementation provenance. Agent PRs must use agent/<provider>/... or a recognized provider branch/author; human PRs must declare Implementer: human.'
-            exit 0
-=======
           # Agent provenance is mechanical. Ordinary user-authored branches are deliberately
           # ambiguous and therefore require BOTH connected providers before automated merge.
           $implementer = 'unknown'
@@ -108,31 +83,11 @@ jobs:
             'copilot' { @('codex') }
             'claude' { @('codex') }
             default { @('codex','copilot') }
->>>>>>> origin/main
           }
 
           $reviewsRaw = & gh api "repos/$repo/pulls/$prNumber/reviews?per_page=100" 2>&1
           if ($LASTEXITCODE -ne 0) { throw ($reviewsRaw -join "`n") }
           $reviews = @(($reviewsRaw -join "`n") | ConvertFrom-Json)
-<<<<<<< HEAD
-          $current = @($reviews | Where-Object {
-            $provider = Get-ProviderFromReviewer ([string]$_.user.login)
-            $_.commit_id -eq $headSha -and $_.state -notin @('DISMISSED','PENDING') -and $provider -and ($implementer -eq 'human' -or $provider -ne $implementer)
-          } | Sort-Object submitted_at)
-
-          if ($current.Count -eq 0) {
-            Set-AiReviewCheck $headSha failure "No current-head independent AI review exists for $headSha (implementer: $implementer)."
-            exit 0
-          }
-
-          $latest = $current[-1]
-          if ($latest.state -eq 'CHANGES_REQUESTED') {
-            Set-AiReviewCheck $headSha failure "Latest current-head independent review by $($latest.user.login) requests changes."
-            exit 0
-          }
-
-          Set-AiReviewCheck $headSha success "Current head $headSha has an independent review by $($latest.user.login); implementer: $implementer. Review-thread resolution is separately required by the branch ruleset."
-=======
 
           $commentsRaw = & gh api "repos/$repo/issues/$prNumber/comments?per_page=100" 2>&1
           if ($LASTEXITCODE -ne 0) { throw ($commentsRaw -join "`n") }
@@ -179,4 +134,3 @@ jobs:
 
           $proof = @($requiredProviders | ForEach-Object { "$_=$($passed[$_])" }) -join '; '
           Set-AiReviewCheck $headSha success "Current head $headSha satisfies required review providers for implementer=$implementer. $proof"
->>>>>>> origin/main

--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -5,11 +5,6 @@ on:
     types: [opened, reopened, synchronize, ready_for_review, edited]
   pull_request_review:
     types: [submitted, dismissed]
-<<<<<<< HEAD
-
-jobs:
-  update-ai-review:
-=======
   issue_comment:
     types: [created, edited]
 
@@ -20,15 +15,10 @@ concurrency:
 jobs:
   update-ai-review:
     if: github.event_name != 'issue_comment' || github.event.issue.pull_request != null
->>>>>>> origin/main
     permissions:
       checks: write
       contents: read
       pull-requests: read
     uses: ./.github/workflows/ai-review-reusable.yml
     with:
-<<<<<<< HEAD
-      pr_number: ${{ github.event.pull_request.number }}
-=======
       pr_number: ${{ github.event.pull_request.number || github.event.issue.number }}
->>>>>>> origin/main

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,9 @@ jobs:
       - name: Test independent review policy
         shell: pwsh
         run: ./tests/review-policy.tests.ps1
+      - name: Test standard hygiene
+        shell: pwsh
+        run: ./tests/standard-hygiene.tests.ps1
       - name: Validate standard
         shell: pwsh
         run: ./scripts/doctor.ps1

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+# Local agent scratch state — never commit
+.worktrees/
+.superpowers/

--- a/AGENT_RULES.md
+++ b/AGENT_RULES.md
@@ -114,3 +114,15 @@ When an agent or human performs a manual workaround, ask whether it can recur.
 - Discard candidates without evidence, plausible ROI, or a next experiment.
 
 Repeated manual work must not become normal merely because an agent can keep doing it.
+
+## 9. Isolated worktrees and parallel subagents
+
+Every write-capable task runs in one isolated worktree tied to its Issue or slice.
+
+- Prefer a harness-native worktree when available; otherwise use `.worktrees/<branch>`.
+- Never share a worktree or working directory between concurrent write agents.
+- Read-only investigations/reviews may fan out in parallel with isolated context.
+- Parallel write agents require provably disjoint file scopes and separate worktrees/branches.
+- One coordinator integrates results and runs the final verification.
+- Default parallelism is 3; exceed it only with evidence that added concurrency reduces wall-clock time without increasing rework.
+- Remove merged/abandoned worktrees and branches. Dirty or unique work is reported, never destroyed automatically.

--- a/AGENT_RULES.md
+++ b/AGENT_RULES.md
@@ -44,28 +44,6 @@ Do not repeat the same failing strategy indefinitely. Escalate consequential amb
 
 Keep a PR draft while implementation is changing. Run fast local verification during slices, then mark the coherent PR ready.
 
-<<<<<<< HEAD
-Every automated merge requires two independent GitHub integration gates on the **latest head SHA**:
-
-1. `PR Gate` — deterministic repo-specific evidence
-2. `AI Review` — current-head semantic review from a different implementation provider
-
-A later push creates a new head SHA and therefore invalidates the prior `AI Review` result. Auto-merge may remain armed, but GitHub cannot merge until the new head receives a successful `AI Review` check.
-
-Implementation provenance is attested by GitHub Actions, not trusted from an editable PR-body claim:
-
-- controlled local agents use `agent/<provider>/<work>` branches
-- legacy Claude/Copilot cloud branches may use their recognized provider prefix/author
-- human work may declare `Implementer: human`
-- unknown provenance fails closed
-
-Default connected reviewer routing:
-
-- Claude implementation → Codex review
-- Copilot implementation → Codex review
-- Codex implementation → one Copilot review
-- human implementation → Codex by default
-=======
 Every automated merge requires two GitHub integration gates on the **latest head SHA**:
 
 1. `PR Gate` — deterministic repo-specific evidence
@@ -88,7 +66,6 @@ Default required reviewer routing:
 - Copilot implementation → Codex
 - Codex implementation → Copilot
 - ambiguous/user-authored provenance → Codex + Copilot
->>>>>>> origin/main
 
 Do not claim a fresh-Claude fallback until a mechanical Claude review adapter exists.
 
@@ -99,27 +76,16 @@ The default semantic reviewer performs **one batched multi-lens pass**:
 3. business systems/operational optimization
 4. leanness/complexity/dead-code/manual-toil review
 
-<<<<<<< HEAD
-A second semantic pass is justified only after substantive fixes, unresolved ambiguity, or provider fallback.
-=======
 A second semantic pass is justified only after substantive fixes, unresolved ambiguity, or when ambiguous provenance requires the second connected provider.
->>>>>>> origin/main
 
 Cost rules:
 
 - deterministic checks before LLM review
-<<<<<<< HEAD
-- Codex primary; local deep review defaults to `gpt-5.4-mini`
-- max 2 Codex passes per PR: initial + one post-fix re-review
-- Copilot fallback max 1 review per PR, low effort
-- no default draft review or unlimited review-on-push spending
-=======
 - Codex primary for Claude/Copilot/ambiguous work; local deep review defaults to `gpt-5.4-mini`
 - max 2 Codex response passes per PR: initial + one post-fix re-review
 - max 1 Copilot response pass per PR, low effort
 - no default draft review or unlimited review-on-push spending
 - per-head request markers prevent duplicate requests
->>>>>>> origin/main
 - active implementation stays draft so noisy micro-pushes do not consume semantic review budget
 
 R0–R3 may auto-merge only when both required gates are enforced, review threads are resolved, and no justified manual authority gate applies. Control-plane changes remain manually merged while they can alter the evaluator that judges themselves.

--- a/DELIVERY_GITHUB.md
+++ b/DELIVERY_GITHUB.md
@@ -14,31 +14,13 @@ Prefer:
 
 Do not make PRs artificially large to save CI minutes. Save minutes by verifying slices locally, pushing less often, canceling superseded runs, caching, and reserving expensive assurance for changes that justify it.
 
-<<<<<<< HEAD
-Name ordinary short-lived branches `<type>/<issue-number>-<short-description>`. Controlled local agent runs may use `agent/<provider>/<issue-or-work>` so GitHub Actions can attest implementation provenance without trusting editable PR prose.
-=======
 Name ordinary short-lived branches `<type>/<issue-number>-<short-description>`. Controlled agent runs use `agent/<provider>/<issue-or-work>` so review independence can be derived mechanically rather than trusted from editable PR prose.
->>>>>>> origin/main
 
 ## 2. Required integration gates
 
 Every managed repository exposes two stable required contexts on the latest PR head:
 
 - **`PR Gate`** — cheapest sufficient deterministic build/test/security evidence.
-<<<<<<< HEAD
-- **`AI Review`** — current-head semantic review from a provider independent of the attested implementer.
-
-Both contexts are bound to the GitHub Actions App. A later push creates a new SHA, so an `AI Review` success from an earlier head cannot satisfy the latest commit.
-
-Draft pushes should not spend semantic-review budget. Keep active work draft, request review when coherent, and allow at most the bounded re-review budget after substantive fixes.
-
-`PR Gate` should normally finish in about 10 minutes or less and may contain repo-specific build/type/lint, unit/property/regression, changed-file/architecture, critical integration/contract/acceptance, and lightweight security/dependency evidence. Do not require every available test category on every change.
-
-`AI Review` uses GitHub-Actions-attested implementation provenance plus recognized review providers. Unknown provenance fails closed. Review-thread resolution remains separately required so material inline findings cannot be ignored.
-
-For today's single-developer, user-owned repositories, CODEOWNERS is advisory and human approval count is 0. Required Code Owner review would deadlock a solo personal-repo workflow. Organization-owned repos may harden CODEOWNERS through the shared policy.
-
-=======
 - **`AI Review`** — exact-head provider-specific semantic evidence required by implementation provenance.
 
 Both contexts are bound to the GitHub Actions App. A later push creates a new SHA, so an `AI Review` success from an earlier head cannot satisfy the latest commit.
@@ -53,7 +35,6 @@ Draft pushes should not spend semantic-review budget. Keep active work draft, re
 
 For today's single-developer, user-owned repositories, CODEOWNERS is advisory and human approval count is 0. Required Code Owner review would deadlock a solo personal-repo workflow. Organization-owned repos may harden CODEOWNERS through the shared policy.
 
->>>>>>> origin/main
 Use loose required status checks (`strict_required_status_checks_policy: false`) by default so a PR does not rebuild merely because `main` moved. A merge queue, when available, provides final combined-head integration checking.
 
 ## 3. Expensive assurance
@@ -65,22 +46,14 @@ Run them through risk/path triggers, explicit escalation, main/release validatio
 ## 4. Actions and model efficiency
 
 - Keep PRs draft during active iteration.
-<<<<<<< HEAD
-- Cancel superseded deterministic runs.
-=======
 - Cancel superseded deterministic and `AI Review` evaluator runs per PR.
->>>>>>> origin/main
 - Prefer one setup/install per required lane when parallel jobs mostly duplicate setup cost.
 - Cache dependencies when useful/safe.
 - Avoid redundant push+PR execution.
 - Run deterministic checks before semantic LLM review.
 - Prefer one batched semantic review over several specialist calls.
-<<<<<<< HEAD
-- Codex is the primary reviewer lane; Copilot is bounded fallback, not an every-push tax.
-=======
 - Codex is the cheap default where it is cross-provider; Copilot is used when it is the required cross-provider reviewer, not as an every-push tax.
 - Review budgets count actual semantic responses; exact-head request markers prevent duplicate triggers.
->>>>>>> origin/main
 - Remove/demote checks or model calls that rarely change a decision.
 
 Optimize for **fast trustworthy feedback per human minute, compute-minute, and model cost**.
@@ -120,16 +93,8 @@ For higher-risk releases, build once, identify the immutable artifact/commit, pr
 
 - `scripts/apply-github-standard.ps1` applies repository settings, labels, Actions, and default-branch rules.
 - `.github/workflows/ai-review-reusable.yml` is the shared exact-head semantic-review evaluator; product repos use the thin caller template.
-<<<<<<< HEAD
-- `scripts/request-independent-review.ps1` routes bounded review requests from GitHub-Actions-attested implementation provenance.
-- `scripts/auto-merge.ps1` validates the live integration plane and then arms GitHub auto-merge; it does not substitute its own call-time semantic judgment for the required `AI Review` context.
-- `scripts/doctor.ps1 -Remote` verifies effective remote policy and exits nonzero on drift.
-
-Prefer centrally maintained policy and stable check names; keep stack-specific deterministic commands inside each product repo.
-=======
 - `scripts/request-independent-review.ps1` routes the next missing required provider within the configured response budget.
 - `scripts/auto-merge.ps1` validates the live integration plane and then arms GitHub auto-merge; it does not substitute its own call-time semantic judgment for the required `AI Review` context.
 - `scripts/doctor.ps1 -Remote` verifies effective remote policy, including that the AI Review workflow itself is active, and exits nonzero on drift.
 
 Prefer centrally maintained policy and stable check naming; keep stack-specific deterministic commands inside each product repo.
->>>>>>> origin/main

--- a/docs/adr/0001-independent-review-routing.md
+++ b/docs/adr/0001-independent-review-routing.md
@@ -4,19 +4,6 @@ Status: accepted; hardened by Issue #21
 
 ## Decision
 
-<<<<<<< HEAD
-Use one cheap, cross-provider semantic review **per mergeable head SHA**, enforced as the required GitHub `AI Review` check.
-
-- Deterministic `PR Gate` runs independently.
-- GitHub Actions attests implementation provenance from recognized provider author/branch metadata instead of trusting editable PR-body LLM claims.
-- Claude/Copilot implementations prefer Codex review.
-- Codex implementations use one Copilot review. No Claude fallback is claimed until a mechanical Claude review adapter exists.
-- Human implementation uses Codex by default.
-- One semantic pass batches software/security, business/product, systems/optimization, and leanness lenses.
-- Budget: at most two Codex passes (initial + one re-review) and one Copilot fallback per PR.
-- Draft churn does not consume semantic-review budget.
-- A push after review creates a new SHA; the previous `AI Review` result cannot authorize that new head.
-=======
 Use the smallest provider-specific semantic review set **per mergeable head SHA**, enforced as the required GitHub `AI Review` check.
 
 - Deterministic `PR Gate` runs independently.
@@ -31,24 +18,12 @@ Use the smallest provider-specific semantic review set **per mergeable head SHA*
 - Draft churn does not consume semantic-review budget; exact-head request markers prevent duplicate triggers.
 - A push after review creates a new SHA; the previous `AI Review` result cannot authorize that new head.
 - `AI Review` evaluator runs are serialized per PR so stale concurrent runs cannot overwrite newer evidence.
->>>>>>> origin/main
 - R0-R3 may auto-merge only after latest-head `PR Gate` + `AI Review` and resolved review threads.
 - R4 remains an explicit authorization gate for destructive/financial/privileged/irreversible consequence.
 - Manual gates require failure class, automation insufficiency, decision owner, and removal condition.
 
 ## Why
 
-<<<<<<< HEAD
-A call-time script check is insufficient: auto-merge can remain armed after a later push. A required exact-head check makes GitHub itself enforce semantic-review freshness. Provider separation reduces correlated blind spots, and batching business/system/lean lenses into one review avoids multiplying model calls.
-
-## Trust boundary
-
-For product repos, the thin `AI Review` caller uses the shared evaluator in `agent-engineering-standard`. Control-plane changes to the standard remain manually merged while they can alter the evaluator that judges themselves.
-
-## Evolution
-
-Change model/provider/budget only from measured quality, latency, and cost. Eliminate the remaining control-plane manual gate when the evaluator/merge authority is immutable or organization-required and cannot be modified by the PR under judgment.
-=======
 A call-time script check is insufficient because auto-merge can remain armed after a later push. A required exact-head check makes GitHub itself enforce semantic-review freshness. Known provider provenance allows one truly cross-provider review, while ambiguous provenance pays for both connected providers rather than trusting a self-attested implementer identity. Batching business/system/lean lenses avoids multiplying calls.
 
 ## Trust boundary
@@ -58,4 +33,3 @@ Product repos use a thin `AI Review` caller backed by the shared evaluator in `a
 ## Evolution
 
 Change provider/model/budget only from measured quality, latency, and cost. Eliminate the remaining control-plane manual gate when evaluator/merge authority is immutable or organization-required and cannot be modified by the PR under judgment.
->>>>>>> origin/main

--- a/scripts/auto-merge.ps1
+++ b/scripts/auto-merge.ps1
@@ -10,11 +10,7 @@ if (-not (Get-Command gh -ErrorAction SilentlyContinue)) { throw 'GitHub CLI (gh
 if ($LASTEXITCODE -ne 0) { throw 'gh is not authenticated.' }
 
 $config = Get-Content (Join-Path $PSScriptRoot '..\policy\github-defaults.json') -Raw | ConvertFrom-Json
-<<<<<<< HEAD
-$prRaw = & gh pr view $Pr --repo $Repo --json isDraft,state,labels 2>&1
-=======
 $prRaw = & gh pr view $Pr --repo $Repo --json isDraft,state,labels,baseRefName 2>&1
->>>>>>> origin/main
 if ($LASTEXITCODE -ne 0) { throw ($prRaw -join "`n") }
 $pr = ($prRaw -join "`n") | ConvertFrom-Json
 if ($pr.state -ne 'OPEN') { throw "PR #$Pr is not open." }
@@ -42,10 +38,7 @@ if ($controlPlane -and [bool]$config.manual_gates.control_plane.required) {
 $metaRaw = & gh api "repos/$Repo" 2>&1
 if ($LASTEXITCODE -ne 0) { throw "Cannot inspect live repository settings for $Repo." }
 $meta = ($metaRaw -join "`n") | ConvertFrom-Json
-<<<<<<< HEAD
-=======
 if ($pr.baseRefName -ne $meta.default_branch) { throw "Auto-merge refused: PR #$Pr targets '$($pr.baseRefName)', not protected default branch '$($meta.default_branch)'." }
->>>>>>> origin/main
 if (-not $meta.allow_auto_merge) { throw 'Live GitHub setting drift: auto-merge is off.' }
 if (-not $meta.allow_squash_merge -or $meta.allow_merge_commit -or $meta.allow_rebase_merge) { throw 'Live GitHub merge policy is not squash-only.' }
 $isOrgOwned = $meta.owner.type -eq 'Organization'

--- a/scripts/bootstrap-repo.ps1
+++ b/scripts/bootstrap-repo.ps1
@@ -53,6 +53,11 @@ if (-not (Test-Path $gitignorePath)) {
   }
 }
 
+$dependabotPath = Join-Path $target '.github/dependabot.yml'
+if (-not (Test-Path $dependabotPath)) {
+  Copy-Item (Join-Path $standardRoot 'templates/dependabot.yml') $dependabotPath -Force
+}
+
 Copy-Item (Join-Path $standardRoot 'templates/AGENTS.md') (Join-Path $target 'AGENTS.md') -Force
 Copy-Item (Join-Path $standardRoot 'templates/PRD.md') (Join-Path $target 'PRD.md') -Force
 Copy-Item (Join-Path $standardRoot 'templates/ISSUE.md') (Join-Path $target '.github/ISSUE_TEMPLATE/work-item.md') -Force
@@ -111,6 +116,7 @@ Replace the bootstrap-only PR Gate with the smallest objective gate appropriate 
 - Detect and record verified build/test/type/lint/E2E commands in `.agent/project.yaml`.
 - Replace `.github/workflows/pr-gate.yml` so `PR Gate` executes the cheapest sufficient independent evidence.
 - Preserve `.github/workflows/ai-review.yml` so the required exact-head `AI Review` context continues to run.
+- Extend `.github/dependabot.yml` only with package ecosystems this repo actually uses; group patch/minor updates when it reduces CI/review noise and keep majors separate unless compatibility evidence justifies a batch.
 - Extend `.github/CODEOWNERS` with the small repo-specific gate entrypoints whose weakening could make `PR Gate` falsely green; keep the canonical control-plane ownership rules as the final non-comment rules.
 - Keep draft iteration local; ready PR and `merge_group` must produce the real `PR Gate`.
 - Add only tests/tools justified by actual product risk; do not invent a framework just for conformity.

--- a/scripts/bootstrap-repo.ps1
+++ b/scripts/bootstrap-repo.ps1
@@ -40,6 +40,19 @@ New-Item -ItemType Directory -Force (Join-Path $target 'docs/adr') | Out-Null
 New-Item -ItemType Directory -Force (Join-Path $target '.github/ISSUE_TEMPLATE') | Out-Null
 New-Item -ItemType Directory -Force (Join-Path $target '.github/workflows') | Out-Null
 
+$gitignorePath = Join-Path $target '.gitignore'
+if (-not (Test-Path $gitignorePath)) {
+  Copy-Item (Join-Path $standardRoot 'templates/.gitignore') $gitignorePath -Force
+} else {
+  $gitignoreText = Get-Content $gitignorePath -Raw
+  foreach ($entry in @('.worktrees/','.superpowers/')) {
+    if ($gitignoreText -notmatch "(?m)^$([regex]::Escape($entry))\s*$") {
+      Add-Content $gitignorePath $entry -Encoding utf8
+      $gitignoreText += "`n$entry"
+    }
+  }
+}
+
 Copy-Item (Join-Path $standardRoot 'templates/AGENTS.md') (Join-Path $target 'AGENTS.md') -Force
 Copy-Item (Join-Path $standardRoot 'templates/PRD.md') (Join-Path $target 'PRD.md') -Force
 Copy-Item (Join-Path $standardRoot 'templates/ISSUE.md') (Join-Path $target '.github/ISSUE_TEMPLATE/work-item.md') -Force
@@ -80,7 +93,7 @@ ci:
 
 Push-Location $target
 try {
-  & git add AGENTS.md CLAUDE.md PRD.md specs docs/adr .agent .github
+  & git add .gitignore AGENTS.md CLAUDE.md PRD.md specs docs/adr .agent .github
   & git commit -m 'chore: bootstrap lean agent engineering standard'
   if ($LASTEXITCODE -ne 0) { throw 'Initial bootstrap commit failed.' }
   & git push origin HEAD

--- a/scripts/doctor.ps1
+++ b/scripts/doctor.ps1
@@ -95,8 +95,6 @@ foreach ($name in $config.repositories) {
   if ($meta.allow_merge_commit) { $problems.Add('merge commits enabled') }
   if ($meta.allow_rebase_merge) { $problems.Add('rebase enabled') }
 
-<<<<<<< HEAD
-=======
   $actionsRaw = & gh api "repos/$repo/actions/permissions" 2>&1
   if ($LASTEXITCODE -ne 0) { $problems.Add('cannot read Actions permissions') }
   else {
@@ -104,13 +102,10 @@ foreach ($name in $config.repositories) {
     if (-not [bool]$actions.enabled) { $problems.Add('Actions disabled') }
   }
 
->>>>>>> origin/main
   $codeownersRaw = & gh api -H 'Accept: application/vnd.github.raw+json' "repos/$repo/contents/.github/CODEOWNERS?ref=$($meta.default_branch)" 2>&1
   if ($LASTEXITCODE -ne 0) { $problems.Add('CODEOWNERS missing') } else {
     $expectedTail = if ($name -eq 'agent-engineering-standard') { $standardTail } else { $appTail }
     if (-not (Test-CodeownersTail -Content ($codeownersRaw -join "`n") -ExpectedTail $expectedTail)) { $problems.Add('CODEOWNERS ownership map drift') }
-<<<<<<< HEAD
-=======
   }
 
   $aiWorkflowRaw = & gh api "repos/$repo/contents/.github/workflows/ai-review.yml?ref=$($meta.default_branch)" 2>&1
@@ -122,11 +117,7 @@ foreach ($name in $config.repositories) {
       $workflowState = ($workflowStateRaw -join "`n") | ConvertFrom-Json
       if ($workflowState.state -ne 'active') { $problems.Add("AI Review workflow not active: $($workflowState.state)") }
     }
->>>>>>> origin/main
   }
-
-  $aiWorkflowRaw = & gh api "repos/$repo/contents/.github/workflows/ai-review.yml?ref=$($meta.default_branch)" 2>&1
-  if ($LASTEXITCODE -ne 0) { $problems.Add('AI Review caller workflow missing') }
 
   $rulesetsRaw = & gh api "repos/$repo/rulesets" 2>&1
   if ($LASTEXITCODE -ne 0) { $problems.Add('cannot read rulesets') } else {
@@ -138,17 +129,12 @@ foreach ($name in $config.repositories) {
         if ($detail.enforcement -ne 'active') { $problems.Add('ruleset not active') }
         if ($detail.bypass_actors -and @($detail.bypass_actors).Count -gt 0) { $problems.Add('ruleset has bypass actors') }
         if (-not (@($detail.conditions.ref_name.include) -contains '~DEFAULT_BRANCH')) { $problems.Add('ruleset does not target default branch') }
-<<<<<<< HEAD
-        $prRule = $detail.rules | Where-Object { $_.type -eq 'pull_request' } | Select-Object -First 1
-        if (-not $prRule) { $problems.Add('pull-request rule missing') } else {
-=======
         $types = @($detail.rules | ForEach-Object { $_.type })
         foreach ($requiredType in @('deletion','non_fast_forward','pull_request','required_status_checks')) {
           if ($types -notcontains $requiredType) { $problems.Add("missing rule: $requiredType") }
         }
         $prRule = $detail.rules | Where-Object { $_.type -eq 'pull_request' } | Select-Object -First 1
         if ($prRule) {
->>>>>>> origin/main
           if ([int]$prRule.parameters.required_approving_review_count -ne 0) { $problems.Add('human approval requirement is not zero') }
           if ([bool]$prRule.parameters.require_code_owner_review -ne $expectedCodeOwnerReview) { $problems.Add('CODEOWNERS review policy drift') }
           if (-not $prRule.parameters.required_review_thread_resolution) { $problems.Add('review-thread resolution not required') }
@@ -156,17 +142,13 @@ foreach ($name in $config.repositories) {
           if ($allowed.Count -ne 1 -or $allowed[0] -ne 'squash') { $problems.Add('ruleset not squash-only') }
         }
         $statusRule = $detail.rules | Where-Object { $_.type -eq 'required_status_checks' } | Select-Object -First 1
-<<<<<<< HEAD
-        if (-not $statusRule) { $problems.Add('required-status rule missing') } else {
-=======
         if ($statusRule) {
->>>>>>> origin/main
           foreach ($context in @($config.required_status_context,$config.required_ai_review_context)) {
             $check = @($statusRule.parameters.required_status_checks) | Where-Object { $_.context -eq $context } | Select-Object -First 1
             if (-not $check) { $problems.Add("required context missing: $context") }
             elseif ([int]$check.integration_id -ne $actionsAppId) { $problems.Add("$context not bound to GitHub Actions") }
           }
-        }
+        } else { $problems.Add('required-status rule missing') }
       }
     }
   }

--- a/scripts/lib/review-policy.ps1
+++ b/scripts/lib/review-policy.ps1
@@ -21,44 +21,25 @@ function Get-RequiredReviewProviders {
 
 function Get-PreferredIndependentReviewer {
   param(
-<<<<<<< HEAD
-    [ValidateSet('claude','copilot','codex','human')][string]$Implementer,
-=======
     [Parameter(Mandatory)][ValidateSet('chatgpt','claude','copilot','codex','human','unknown')][string]$Implementer,
->>>>>>> origin/main
     [bool]$CodexAvailable = $true,
     [bool]$CopilotAvailable = $true
   )
 
-<<<<<<< HEAD
-  if ($Implementer -ne 'codex' -and $CodexAvailable) { return 'codex' }
-  if ($Implementer -ne 'copilot' -and $CopilotAvailable) { return 'copilot' }
-  throw "No mechanically connected independent reviewer is available for implementer '$Implementer'."
-=======
   foreach ($provider in @(Get-RequiredReviewProviders -Implementer $Implementer)) {
     if ($provider -eq 'codex' -and $CodexAvailable) { return 'codex' }
     if ($provider -eq 'copilot' -and $CopilotAvailable) { return 'copilot' }
   }
   throw "No required connected reviewer is available for implementer '$Implementer'."
->>>>>>> origin/main
 }
 
 function Test-IndependentReview {
   param(
-<<<<<<< HEAD
-    [Parameter(Mandatory)][ValidateSet('claude','copilot','codex','human')][string]$Implementer,
-    [Parameter(Mandatory)][ValidateSet('copilot','codex')][string]$ReviewerProvider
-  )
-
-  if ($Implementer -eq 'human') { return $true }
-  return $Implementer -ne $ReviewerProvider
-=======
     [Parameter(Mandatory)][ValidateSet('chatgpt','claude','copilot','codex','human','unknown')][string]$Implementer,
     [Parameter(Mandatory)][ValidateSet('copilot','codex')][string]$ReviewerProvider
   )
 
   return @((Get-RequiredReviewProviders -Implementer $Implementer)) -contains $ReviewerProvider
->>>>>>> origin/main
 }
 
 function Assert-ManualGateJustification {

--- a/scripts/prune-portfolio.ps1
+++ b/scripts/prune-portfolio.ps1
@@ -1,0 +1,94 @@
+param(
+  [string[]]$Repositories = @(),
+  [string]$LocalRoot = '',
+  [switch]$Apply
+)
+
+$ErrorActionPreference = 'Stop'
+foreach ($cmd in @('gh','git')) {
+  if (-not (Get-Command $cmd -ErrorAction SilentlyContinue)) { throw "$cmd is required." }
+}
+
+$standardRoot = (Resolve-Path (Join-Path $PSScriptRoot '..')).Path
+$config = Get-Content (Join-Path $standardRoot 'policy/github-defaults.json') -Raw | ConvertFrom-Json
+if (-not $LocalRoot) { $LocalRoot = Split-Path $standardRoot -Parent }
+if ($Repositories.Count -eq 0) {
+  $Repositories = @($config.repositories | ForEach-Object { "$($config.owner)/$_" })
+}
+
+& gh auth status | Out-Host
+if ($LASTEXITCODE -ne 0) { throw 'gh is not authenticated.' }
+
+foreach ($repo in $Repositories) {
+  Write-Host "`n=== $repo ===" -ForegroundColor Cyan
+  $name = ($repo -split '/')[-1]
+  $local = Join-Path $LocalRoot $name
+
+  if (Test-Path (Join-Path $local '.git')) {
+    Write-Host "Local clone: $local"
+    $worktrees = & git -C $local worktree list --porcelain 2>&1
+    if ($LASTEXITCODE -eq 0) {
+      foreach ($line in $worktrees) {
+        if ($line -like 'worktree *') {
+          $path = $line.Substring(9)
+          if (Test-Path $path) {
+            $dirty = & git -C $path status --porcelain 2>$null
+            if ($dirty) { Write-Host "  DIRTY WORKTREE (kept): $path" -ForegroundColor Yellow }
+          }
+        }
+      }
+    }
+
+    if ($Apply) {
+      & git -C $local worktree prune --verbose | Out-Host
+      if ($LASTEXITCODE -ne 0) { throw "worktree prune failed for $repo" }
+    } else {
+      & git -C $local worktree prune --dry-run --verbose | Out-Host
+      if ($LASTEXITCODE -ne 0) { throw "worktree prune dry-run failed for $repo" }
+    }
+  } else {
+    Write-Host "Local clone not found under $LocalRoot; local worktree cleanup skipped." -ForegroundColor DarkGray
+  }
+
+  $metaRaw = & gh api "repos/$repo" 2>&1
+  if ($LASTEXITCODE -ne 0) { Write-Warning "Cannot inspect $repo"; continue }
+  $defaultBranch = (($metaRaw -join "`n") | ConvertFrom-Json).default_branch
+
+  $branchesRaw = & gh api --paginate "repos/$repo/branches?per_page=100" --jq '.[].name' 2>&1
+  if ($LASTEXITCODE -ne 0) { Write-Warning "Cannot list branches for $repo"; continue }
+  $branches = @($branchesRaw | Where-Object { $_ })
+
+  $openPrRaw = & gh pr list --repo $repo --state open --json headRefName --limit 500 2>&1
+  $openPrBranches = if ($LASTEXITCODE -eq 0) {
+    @(($openPrRaw -join "`n") | ConvertFrom-Json | ForEach-Object { $_.headRefName })
+  } else { @() }
+
+  foreach ($branch in $branches) {
+    if ($branch -eq $defaultBranch -or $branch -like 'dependabot/*' -or $openPrBranches -contains $branch) { continue }
+
+    $baseEncoded = [uri]::EscapeDataString([string]$defaultBranch)
+    $branchEncoded = [uri]::EscapeDataString([string]$branch)
+    $compareRaw = & gh api "repos/$repo/compare/$baseEncoded...$branchEncoded" 2>&1
+    if ($LASTEXITCODE -ne 0) {
+      Write-Host "  KEEP (compare failed): $branch" -ForegroundColor Yellow
+      continue
+    }
+    $compare = ($compareRaw -join "`n") | ConvertFrom-Json
+    if ([int]$compare.ahead_by -gt 0) {
+      Write-Host "  KEEP (unique commits=$($compare.ahead_by)): $branch" -ForegroundColor Magenta
+      continue
+    }
+
+    if ($Apply) {
+      & gh api --method DELETE "repos/$repo/git/refs/heads/$branchEncoded" 2>&1 | Out-Null
+      if ($LASTEXITCODE -eq 0) { Write-Host "  DELETED merged/equivalent branch: $branch" -ForegroundColor Green }
+      else { Write-Host "  KEEP (delete failed): $branch" -ForegroundColor Yellow }
+    } else {
+      Write-Host "  WOULD DELETE merged/equivalent branch: $branch" -ForegroundColor DarkYellow
+    }
+  }
+}
+
+if (-not $Apply) {
+  Write-Host "`nDRY RUN ONLY. Re-run with -Apply to prune stale metadata and delete only proven merged/equivalent remote branches." -ForegroundColor Yellow
+}

--- a/scripts/request-independent-review.ps1
+++ b/scripts/request-independent-review.ps1
@@ -13,32 +13,6 @@ if ($LASTEXITCODE -ne 0) { throw 'gh is not authenticated.' }
 
 $config = Get-Content (Join-Path $PSScriptRoot '..\policy\github-defaults.json') -Raw | ConvertFrom-Json
 $reviewPolicy = $config.independent_review
-<<<<<<< HEAD
-$prRaw = & gh pr view $Pr --repo $Repo --json isDraft,state,headRefOid,headRefName,author,body 2>&1
-if ($LASTEXITCODE -ne 0) { throw ($prRaw -join "`n") }
-$pr = ($prRaw -join "`n") | ConvertFrom-Json
-if ($pr.state -ne 'OPEN') { throw "PR #$Pr is not open." }
-if ($pr.isDraft) { throw "PR #$Pr is draft; semantic review is intentionally deferred." }
-
-$headRef = [string]$pr.headRefName
-$author  = [string]$pr.author.login
-$prBody  = [string]$pr.body
-
-$implementer = $null
-if     ($headRef -match '^agent/(codex|claude|copilot)/') { $implementer = $Matches[1].ToLowerInvariant() }
-elseif ($headRef -match '^claude/')                        { $implementer = 'claude' }
-elseif ($headRef -match '^copilot/' -or $author -eq 'Copilot') { $implementer = 'copilot' }
-elseif ($author -match '^chatgpt-codex-connector(?:\[bot\])?$') { $implementer = 'codex' }
-elseif ($prBody -match '(?im)^\s*Implementer:\s*human\s*$') { $implementer = 'human' }
-
-if (-not $implementer) {
-  throw "Unknown implementation provenance. Agent PRs must use agent/<provider>/... or a recognized provider branch/author; human PRs must declare 'Implementer: human' in the PR body."
-}
-
-$commentsRaw = & gh api "repos/$Repo/issues/$Pr/comments?per_page=100" 2>&1
-if ($LASTEXITCODE -ne 0) { throw ($commentsRaw -join "`n") }
-$comments = @(($commentsRaw -join "`n") | ConvertFrom-Json)
-=======
 
 $prRaw = & gh api "repos/$Repo/pulls/$Pr" 2>&1
 if ($LASTEXITCODE -ne 0) { throw ($prRaw -join "`n") }
@@ -56,16 +30,10 @@ elseif ($headRef -match '^copilot/' -or $author -eq 'Copilot') { $implementer = 
 elseif ($author -match '^chatgpt-codex-connector(?:\[bot\])?$') { $implementer = 'codex' }
 
 $requiredProviders = @(Get-RequiredReviewProviders -Implementer $implementer)
->>>>>>> origin/main
 
 $reviewsRaw = & gh api "repos/$Repo/pulls/$Pr/reviews?per_page=100" 2>&1
 if ($LASTEXITCODE -ne 0) { throw ($reviewsRaw -join "`n") }
 $reviews = @(($reviewsRaw -join "`n") | ConvertFrom-Json)
-<<<<<<< HEAD
-$currentIndependent = @($reviews | Where-Object {
-  $reviewerProvider = Get-ReviewProviderFromLogin -Login $_.user.login
-  $_.commit_id -eq $pr.headRefOid -and $_.state -notin @('DISMISSED','PENDING') -and $reviewerProvider -and (Test-IndependentReview -Implementer $implementer -ReviewerProvider $reviewerProvider)
-=======
 $commentsRaw = & gh api "repos/$Repo/issues/$Pr/comments?per_page=100" 2>&1
 if ($LASTEXITCODE -ne 0) { throw ($commentsRaw -join "`n") }
 $comments = @(($commentsRaw -join "`n") | ConvertFrom-Json)
@@ -84,7 +52,6 @@ foreach ($provider in @('codex','copilot')) {
 $structuredCopilotResponses = @($comments | Where-Object {
   (Get-ReviewProviderFromLogin -Login $_.user.login) -eq 'copilot' -and
   $_.body -match '(?im)^\s*AI-REVIEW\s+(PASS|FAIL)\b'
->>>>>>> origin/main
 })
 $currentStructuredCopilot = @($structuredCopilotResponses | Where-Object { $_.body -match [regex]::Escape($headSha) } | Sort-Object created_at)
 if ($currentStructuredCopilot.Count -gt 0 -and $currentStructuredCopilot[-1].body -match '(?im)^\s*AI-REVIEW\s+PASS\b') {
@@ -97,19 +64,6 @@ if ($missing.Count -eq 0) {
   exit 0
 }
 
-<<<<<<< HEAD
-$codexReviews = @($reviews | Where-Object { (Get-ReviewProviderFromLogin -Login $_.user.login) -eq 'codex' }).Count
-$copilotReviews = @($reviews | Where-Object { (Get-ReviewProviderFromLogin -Login $_.user.login) -eq 'copilot' }).Count
-$codexRequests = @($comments | Where-Object { $_.body -match '(?i)@codex\s+review' }).Count
-
-if ($Provider -eq 'auto') {
-  $Provider = Get-PreferredIndependentReviewer `
-    -Implementer $implementer `
-    -CodexAvailable (($codexReviews -lt [int]$reviewPolicy.max_codex_reviews_per_pr) -and ($codexRequests -lt [int]$reviewPolicy.max_codex_reviews_per_pr)) `
-    -CopilotAvailable ([bool]$reviewPolicy.copilot_fallback -and $copilotReviews -lt [int]$reviewPolicy.max_copilot_reviews_per_pr)
-}
-if (-not (Test-IndependentReview -Implementer $implementer -ReviewerProvider $Provider)) { throw "Reviewer '$Provider' is not independent from attested implementer '$implementer'." }
-=======
 # Budgets count actual semantic responses, not duplicate trigger comments.
 $codexPassCount = @($reviews | Where-Object { (Get-ReviewProviderFromLogin -Login $_.user.login) -eq 'codex' }).Count
 $copilotFormalCount = @($reviews | Where-Object { (Get-ReviewProviderFromLogin -Login $_.user.login) -eq 'copilot' }).Count
@@ -135,22 +89,12 @@ if ($Provider -eq 'auto') {
   }
 }
 if ($missing -notcontains $Provider) { throw "Reviewer '$Provider' is not a missing required provider for implementer '$implementer'. Missing: $($missing -join ', ')." }
->>>>>>> origin/main
 
 switch ($Provider) {
   'codex' {
     if (-not $codexAvailable) { throw "Codex is unavailable or already requested for current head $headSha." }
     & gh pr comment $Pr --repo $Repo --body "@codex review`n`n$codexMarker" | Out-Host
     if ($LASTEXITCODE -ne 0) { throw "Could not request Codex review for $Repo PR #$Pr." }
-<<<<<<< HEAD
-    Write-Host "REVIEW REQUESTED: Codex ($($codexRequests + 1)/$($reviewPolicy.max_codex_reviews_per_pr)); attested implementer=$implementer." -ForegroundColor Green
-  }
-  'copilot' {
-    if ($copilotReviews -ge [int]$reviewPolicy.max_copilot_reviews_per_pr) { throw "Copilot review budget exhausted for PR #$Pr." }
-    & gh pr edit $Pr --repo $Repo --add-reviewer '@copilot' | Out-Host
-    if ($LASTEXITCODE -ne 0) { throw "Could not request Copilot review for $Repo PR #$Pr." }
-    Write-Host "REVIEW REQUESTED: Copilot fallback ($($copilotReviews + 1)/$($reviewPolicy.max_copilot_reviews_per_pr)); attested implementer=$implementer." -ForegroundColor Yellow
-=======
     Write-Host "REVIEW REQUESTED: Codex response budget $($codexPassCount + 1)/$($reviewPolicy.max_codex_reviews_per_pr); head=$headSha; implementer=$implementer." -ForegroundColor Green
   }
   'copilot' {
@@ -159,6 +103,5 @@ switch ($Provider) {
     & gh pr comment $Pr --repo $Repo --body $prompt | Out-Host
     if ($LASTEXITCODE -ne 0) { throw "Could not request Copilot fallback review for $Repo PR #$Pr." }
     Write-Host "REVIEW REQUESTED: Copilot response budget $($copilotPassCount + 1)/$($reviewPolicy.max_copilot_reviews_per_pr); head=$headSha; implementer=$implementer." -ForegroundColor Yellow
->>>>>>> origin/main
   }
 }

--- a/templates/.gitignore
+++ b/templates/.gitignore
@@ -1,0 +1,3 @@
+# Local agent scratch state — never commit
+.worktrees/
+.superpowers/

--- a/templates/AGENTS.md
+++ b/templates/AGENTS.md
@@ -4,29 +4,74 @@ This repository follows `kgsmith19/agent-engineering-standard`, pinned in `.agen
 
 ## Product truth
 
-- `PRD.md` — what/why/outcomes/requirements
-- `specs/` — implementation contract only when behavior is nontrivial
-- `docs/adr/` — consequential, hard-to-reverse architecture decisions only
+Read only the context needed for the assigned work, in this order:
 
-## Work
+1. `PRD.md` — what/why/outcomes/requirements
+2. relevant `specs/` — exact behavior when nontrivial
+3. relevant `docs/adr/` — consequential architecture constraints
+4. the assigned GitHub Issue — durable work scope
 
-GitHub Issues are the durable work-item source.
+Do not invent a consequential product decision when the source truth is missing or contradictory. Record the blocker and stop that slice.
 
-`Issue → SPEC if needed → thin slice → evidence → RED/minimum GREEN when appropriate → PR → PR Gate → merge/release`
+## Lean delivery loop
 
-Work one thin slice at a time. Keep PRs coherent and reviewable. Keep PRs draft while still iterating; make them ready only after local verification.
+`Issue → SPEC if needed → thin slice → RED/minimum GREEN → local verification → draft PR → PR Gate → independent AI Review → merge/release`
 
-## Quality
+- Work one thin slice at a time; scope widening becomes another slice/Issue.
+- Use the smallest correct implementation. Avoid speculative abstractions and unrelated refactors.
+- Write/adjust behavioral proof before implementation when practical; RED must fail for the missing behavior, not setup noise.
+- Never weaken tests, evaluators, required checks, security boundaries, or thresholds merely to obtain GREEN.
+- Update affected product/engineering truth in the same PR.
 
-Use the cheapest evidence sufficient for the change. Do not weaken tests, evaluators, policies, or security boundaries to obtain GREEN. Verify before claiming completion.
+## Isolation and parallelism
 
-## Risk
+- Every write-capable task uses its own branch/worktree. Never share a working directory between concurrent writers.
+- Controlled agent branches use `agent/<provider>/<issue-or-work>` when the harness allows it.
+- Read-only research/review may fan out in parallel.
+- Parallel writers require disjoint file scopes and separate worktrees. Default maximum: 3.
+- One coordinator integrates results and runs final verification.
 
-Use the shared R0–R4 scale. The implementing agent may raise risk, never lower it. R3/R4 and control-plane changes require fresh independent semantic review before merge.
+## Risk and authority
 
-## Code Review Rules
+Use the shared R0–R4 scale. The implementing agent may raise risk, never lower it.
+
+- Control-plane changes are at least R3.
+- R4 never auto-merges; the manual step authorizes the destructive/financial/privileged/irreversible consequence.
+- Any manual gate must state: failure class prevented, why automation is insufficient, decision owner, and measurable gate-removal condition.
+
+## CI and repair
+
+Keep active implementation in a draft PR. Run fast local checks before pushing coherent changes.
+
+When `PR Gate` fails:
+
+1. classify the failure: implementation, specification/oracle, environment, flaky, or policy
+2. fix implementation/environment failures at the root cause
+3. retry a genuinely flaky failure once
+4. do not silently override specification/policy conflicts
+5. stop after 3 failed fix attempts for the same cause and record the blocker
+
+Do not push cosmetic or empty commits just to retrigger CI.
+
+## Independent review and merge
+
+Writing code is not completion.
+
+- A semantic reviewer must be independent of the implementing agent/session; use another provider when practical and mechanically supported.
+- Use the shared review automation when available, but never claim review success unless GitHub records the required `AI Review` evidence on the current head SHA.
+- A later push invalidates prior exact-head semantic evidence.
+- Resolve review threads only after the finding is fixed or explicitly demonstrated to be a false positive.
+- Auto-merge is allowed only when the current head has required `PR Gate` + `AI Review`, review threads are resolved, risk is eligible, and no justified authority gate applies.
+
+## Hygiene
+
+- `.worktrees/` and `.superpowers/` are local scratch state and must stay ignored.
+- Remove merged/abandoned branches and stale worktree metadata only when no unique or dirty work can be lost.
+- If a manual workaround is likely to recur, automate it when small/safe or log one bounded automation/research candidate with evidence and a next experiment.
+
+## Reviewer rules
 
 - Flag requirement/spec mismatches even when tests pass.
-- Flag tests that can pass without proving the behavior they claim to prove.
-- Flag weakened authority/security/evaluator boundaries and unnecessary scope/complexity.
-- For UI changes, confirm important user-visible behavior is covered by an appropriate Playwright journey or explicitly justified stronger evidence.
+- Flag tests that can pass without proving the claimed behavior.
+- Flag weakened authority/security/evaluator boundaries and unnecessary complexity.
+- For UI changes, require appropriate user-visible evidence such as a focused Playwright journey unless stronger evidence is justified.

--- a/templates/AI_REVIEW.yml
+++ b/templates/AI_REVIEW.yml
@@ -5,11 +5,6 @@ on:
     types: [opened, reopened, synchronize, ready_for_review, edited]
   pull_request_review:
     types: [submitted, dismissed]
-<<<<<<< HEAD
-
-jobs:
-  update-ai-review:
-=======
   issue_comment:
     types: [created, edited]
 
@@ -20,15 +15,10 @@ concurrency:
 jobs:
   update-ai-review:
     if: github.event_name != 'issue_comment' || github.event.issue.pull_request != null
->>>>>>> origin/main
     permissions:
       checks: write
       contents: read
       pull-requests: read
     uses: kgsmith19/agent-engineering-standard/.github/workflows/ai-review-reusable.yml@main
     with:
-<<<<<<< HEAD
-      pr_number: ${{ github.event.pull_request.number }}
-=======
       pr_number: ${{ github.event.pull_request.number || github.event.issue.number }}
->>>>>>> origin/main

--- a/templates/PULL_REQUEST.md
+++ b/templates/PULL_REQUEST.md
@@ -4,15 +4,9 @@
 Issue:
 Spec:
 Slice(s):
-<<<<<<< HEAD
-Implementer: claude / copilot / codex / human
-
-> Agent-created PRs must use a recognized provider author/prefix or `agent/<provider>/...`; `AI Review` fails closed on unknown implementation provenance.
-=======
 Implementer: chatgpt / claude / copilot / codex / human
 
 > The Implementer line is descriptive, not trusted agent identity. Controlled agent work should use `agent/<provider>/...` (for example `agent/chatgpt/42-fix`). Ordinary/user-authored branches are treated as ambiguous and require both Codex + Copilot for unattended merge.
->>>>>>> origin/main
 
 ## What Changed
 -

--- a/templates/dependabot.yml
+++ b/templates/dependabot.yml
@@ -1,0 +1,23 @@
+version: 2
+
+updates:
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+      time: "06:00"
+      timezone: America/New_York
+    open-pull-requests-limit: 2
+    groups:
+      routine-actions:
+        applies-to: version-updates
+        update-types:
+          - minor
+          - patch
+    commit-message:
+      prefix: "chore(deps)"
+
+# Add only the package ecosystem(s) this repository actually uses.
+# Group patch/minor updates when that reduces CI/review noise; keep major upgrades
+# separate unless compatibility evidence justifies a deliberate combined migration.

--- a/tests/review-policy.tests.ps1
+++ b/tests/review-policy.tests.ps1
@@ -18,14 +18,6 @@ Assert-Equal 'ChatGPT implementation routes to Copilot' (Get-PreferredIndependen
 Assert-Equal 'Claude implementation routes to Codex' (Get-PreferredIndependentReviewer -Implementer claude) 'codex'
 Assert-Equal 'Copilot implementation routes to Codex' (Get-PreferredIndependentReviewer -Implementer copilot) 'codex'
 Assert-Equal 'Codex implementation routes to Copilot' (Get-PreferredIndependentReviewer -Implementer codex) 'copilot'
-<<<<<<< HEAD
-Assert-Throws 'Codex without Copilot is blocked instead of pretending Claude is connected' {
-  Get-PreferredIndependentReviewer -Implementer codex -CopilotAvailable $false
-}
-Assert-Throws 'Codex cannot review Codex when it is the only provider' {
-  Get-PreferredIndependentReviewer -Implementer codex -CopilotAvailable $false -CodexAvailable $true
-}
-=======
 Assert-Equal 'Unknown provenance starts with Codex' (Get-PreferredIndependentReviewer -Implementer unknown) 'codex'
 Assert-Equal 'Human/user-authored provenance starts with Codex' (Get-PreferredIndependentReviewer -Implementer human) 'codex'
 Assert-Throws 'Codex without Copilot is blocked instead of pretending Claude is connected' { Get-PreferredIndependentReviewer -Implementer codex -CopilotAvailable $false }
@@ -35,22 +27,15 @@ Assert-Equal 'Unknown provenance requires two providers' $unknownProviders.Count
 Assert-Equal 'Unknown first provider is Codex' $unknownProviders[0] 'codex'
 Assert-Equal 'Unknown second provider is Copilot' $unknownProviders[1] 'copilot'
 Assert-Equal 'ChatGPT requires Copilot specifically' (@(Get-RequiredReviewProviders -Implementer chatgpt)[0]) 'copilot'
->>>>>>> origin/main
 
 Assert-Equal 'Codex bot login recognized' (Get-ReviewProviderFromLogin -Login 'chatgpt-codex-connector[bot]') 'codex'
 Assert-Equal 'Copilot bot login recognized' (Get-ReviewProviderFromLogin -Login 'copilot-pull-request-reviewer[bot]') 'copilot'
 Assert-Equal 'Copilot coding-agent login recognized' (Get-ReviewProviderFromLogin -Login 'copilot-swe-agent[bot]') 'copilot'
 Assert-Equal 'unknown reviewer ignored' (Get-ReviewProviderFromLogin -Login 'random-bot[bot]') $null
-<<<<<<< HEAD
-Assert-Equal 'different provider is independent' (Test-IndependentReview -Implementer claude -ReviewerProvider codex) $true
-Assert-Equal 'same provider is not independent' (Test-IndependentReview -Implementer codex -ReviewerProvider codex) $false
-Assert-Equal 'human implementation accepts an AI reviewer' (Test-IndependentReview -Implementer human -ReviewerProvider codex) $true
-=======
 Assert-Equal 'Claude-Codex pair is valid' (Test-IndependentReview -Implementer claude -ReviewerProvider codex) $true
 Assert-Equal 'Codex-Codex pair is invalid' (Test-IndependentReview -Implementer codex -ReviewerProvider codex) $false
 Assert-Equal 'ChatGPT-Codex is not accepted as cross-provider' (Test-IndependentReview -Implementer chatgpt -ReviewerProvider codex) $false
 Assert-Equal 'ChatGPT-Copilot is cross-provider' (Test-IndependentReview -Implementer chatgpt -ReviewerProvider copilot) $true
->>>>>>> origin/main
 
 $validGate = [pscustomobject]@{
   failure_class_prevented = 'irreversible production data loss'

--- a/tests/standard-hygiene.tests.ps1
+++ b/tests/standard-hygiene.tests.ps1
@@ -1,0 +1,48 @@
+$ErrorActionPreference = 'Stop'
+$root = (Resolve-Path (Join-Path $PSScriptRoot '..')).Path
+
+function Assert-True {
+  param([string]$Name, $Condition)
+  if (-not $Condition) { throw "$Name failed." }
+}
+
+foreach ($relative in @(
+  '.gitignore',
+  'scripts/prune-portfolio.ps1',
+  'templates/.gitignore',
+  'templates/dependabot.yml'
+)) {
+  Assert-True "required file $relative" (Test-Path (Join-Path $root $relative))
+}
+
+$textExtensions = @('.md','.ps1','.yml','.yaml','.json','.txt')
+$conflicts = Get-ChildItem $root -Recurse -File | Where-Object {
+  $_.FullName -notmatch '[\\/]\.git[\\/]' -and $textExtensions -contains $_.Extension.ToLowerInvariant()
+} | Select-String -Pattern '^(<<<<<<< .+|=======|>>>>>>> .+)$'
+if ($conflicts) {
+  throw "Raw merge-conflict markers found:`n$($conflicts -join "`n")"
+}
+
+$ignore = Get-Content (Join-Path $root 'templates/.gitignore') -Raw
+foreach ($entry in @('.worktrees/','.superpowers/')) {
+  Assert-True "gitignore contains $entry" ($ignore -match "(?m)^$([regex]::Escape($entry))\s*$")
+}
+
+$dependabot = Get-Content (Join-Path $root 'templates/dependabot.yml') -Raw
+Assert-True 'Dependabot v2' ($dependabot -match '(?m)^version:\s*2\s*$')
+Assert-True 'Dependabot GitHub Actions ecosystem' ($dependabot -match 'package-ecosystem:\s*github-actions')
+Assert-True 'Dependabot groups minor updates' ($dependabot -match '(?m)^\s*-\s*minor\s*$')
+Assert-True 'Dependabot groups patch updates' ($dependabot -match '(?m)^\s*-\s*patch\s*$')
+
+$agentsLines = @(Get-Content (Join-Path $root 'templates/AGENTS.md')).Count
+if ($agentsLines -gt 120) { throw "templates/AGENTS.md exceeded lean 120-line budget: $agentsLines" }
+
+$bootstrap = Get-Content (Join-Path $root 'scripts/bootstrap-repo.ps1') -Raw
+Assert-True 'bootstrap manages scratch ignore' ($bootstrap -match 'templates/\.gitignore')
+Assert-True 'bootstrap installs Dependabot default' ($bootstrap -match 'templates/dependabot\.yml')
+
+$tokens = $null; $errors = $null
+[System.Management.Automation.Language.Parser]::ParseFile((Join-Path $root 'scripts/prune-portfolio.ps1'), [ref]$tokens, [ref]$errors) | Out-Null
+if ($errors.Count -gt 0) { throw "prune-portfolio.ps1 parse failed: $($errors[0].Message)" }
+
+Write-Host 'standard-hygiene tests: PASS' -ForegroundColor Green


### PR DESCRIPTION
## Goal
Pause the overlapping WIP branches and get `main` back to one conflict-free, tested control-plane state.

## Consolidates
- PR #31: all 12 committed merge-conflict-marker resolutions, preserving the newer reviewed side plus the `doctor.ps1` status-rule fix.
- PR #30: isolated worktree / bounded parallel-agent rules and scratch ignores, with a safer local+remote cleanup implementation.
- PR #33: only the lean native Dependabot grouping concept; no speculative 189-line major-upgrade classifier.
- PR #34: the useful autonomous delivery/state-machine rules compressed into a lean template instead of the 263-line duplicated operating manual.

## Intentionally not included
- PR #32 cheap Issue resolver: it is still WIP and contains no unique implemented resolver yet.
- PR #33 heuristic major-upgrade classifier: too speculative/complex for the current evidence.
- Any live GitHub settings/ruleset mutation beyond what existing standard tooling already owns.

## Safety improvements
- New CI hygiene test fails on raw `<<<<<<<` / `=======` / `>>>>>>>` conflict debris.
- Worktree/branch cleanup is dry-run by default, only prunes stale local metadata, preserves dirty work, skips open-PR/Dependabot branches, and deletes remote branches only when GitHub reports zero unique commits.
- Existing `.gitignore` files are preserved; missing scratch entries are appended instead of overwriting the file.
- Generic Dependabot default only groups GitHub Actions patch/minor updates; repo-specific ecosystems are added only when actually used.

## Verification
- `PR Gate`: PASS on head `afd3bf735b0d286fb4b13905c48f818a2b464080`.
- legacy branch-protection tests: PASS
- standard-lock tests: PASS
- independent-review policy tests: PASS
- standard-hygiene/conflict-marker test: PASS
- local doctor: PASS
- no unresolved review threads exist.
- Codex and Copilot full-head review requests were issued, but neither reviewer service returned review evidence during this recovery window. Therefore `AI Review` is not claimed green.

## Risk
R3 control-plane consolidation.

## Manual Recovery Gate
- Failure class prevented: `main` contains raw committed merge-conflict markers across the control plane, including the AI Review workflow itself, so normal CI/review automation is partially self-broken.
- Why automation is insufficient today: the default-branch workflow that normally reacts to review comments is one of the corrupted files, and the independently requested Codex/Copilot reviewer services did not return evidence; the broken judge cannot reliably bootstrap its own repair.
- Decision owner: repository owner.
- Gate removal condition: this conflict-free consolidation is merged, `main` passes the new conflict-marker hygiene guard, and subsequent PRs again use the normal exact-head `PR Gate` + `AI Review` path.

No force push, policy weakening, check deletion, or ruleset bypass is authorized. A normal GitHub squash merge may proceed only if GitHub permits it under the live protection state.