### PR TITLE
feat: wire autonomous PR flow and Projects workboard

### DIFF
--- a/.agent/project.yaml
+++ b/.agent/project.yaml
@@ -10,7 +10,7 @@ commands:
   bootstrap_repo: pwsh -NoProfile -File scripts/bootstrap-repo.ps1 -Name <repo>
   upgrade_repos: pwsh -NoProfile -File scripts/upgrade-repos.ps1
   codex_review: pwsh -NoProfile -File scripts/codex-review.ps1
-  auto_merge_r0_r2: pwsh -NoProfile -File scripts/auto-merge.ps1 -Repo <owner/repo> -Pr <number> -Risk <R0|R1|R2>
+  auto_merge_r0_r3: pwsh -NoProfile -File scripts/auto-merge.ps1 -Repo <owner/repo> -Pr <number> -Risk <R0|R1|R2|R3>
 
 risk:
   default: R3
@@ -23,7 +23,9 @@ risk:
     - .github/workflows/**
 
 work_tracking:
-  system: github-issues
+  system: github-projects
+  project: "Agentic Portfolio"
+  backing_record: github-issues
 
 ci:
   required_check: PR Gate

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: CI
+name: PR Gate
 
 on:
   pull_request:
@@ -10,7 +10,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: pr-gate-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:

--- a/.github/workflows/pr-automation.yml
+++ b/.github/workflows/pr-automation.yml
@@ -6,12 +6,16 @@ on:
   workflow_run:
     workflows: ["PR Gate"]
     types: [completed]
+  pull_request_review:
+    types: [submitted]
+  issue_comment:
+    types: [created, edited]
 
 permissions:
   contents: read
 
 concurrency:
-  group: pr-automation-${{ github.repository }}-${{ github.event.pull_request.number || github.event.workflow_run.pull_requests[0].number || github.run_id }}
+  group: pr-automation-${{ github.repository }}-${{ github.event.pull_request.number || github.event.issue.number || github.event.workflow_run.pull_requests[0].number || github.run_id }}
   cancel-in-progress: false
 
 jobs:
@@ -109,4 +113,31 @@ jobs:
         shell: pwsh
         run: |
           & pwsh -NoProfile -File .standard/scripts/request-independent-review.ps1 -Repo $env:GITHUB_REPOSITORY -Pr ([int]$env:PR_NUMBER) -Provider auto
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+
+  request-followup-ai-review:
+    if: >-
+      (github.event_name == 'pull_request_review' && github.event.action == 'submitted') ||
+      (github.event_name == 'issue_comment' && github.event.issue.pull_request != null)
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: read
+    env:
+      GH_TOKEN: ${{ github.token }}
+      PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
+    steps:
+      - name: Checkout trusted standard
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        with:
+          repository: kgsmith19/agent-engineering-standard
+          ref: main
+          path: .standard
+          persist-credentials: false
+      - name: Request next provider only after a current-head pass
+        shell: pwsh
+        run: |
+          & pwsh -NoProfile -File .standard/scripts/request-independent-review.ps1 -Repo $env:GITHUB_REPOSITORY -Pr ([int]$env:PR_NUMBER) -Provider auto -FollowupOnly
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }

--- a/.github/workflows/pr-automation.yml
+++ b/.github/workflows/pr-automation.yml
@@ -1,0 +1,88 @@
+name: PR Automation
+
+on:
+  pull_request_target:
+    types: [opened, reopened, ready_for_review, synchronize, labeled, unlabeled]
+  workflow_run:
+    workflows: ["PR Gate"]
+    types: [completed]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: pr-automation-${{ github.repository }}-${{ github.event.pull_request.number || github.event.workflow_run.pull_requests[0].number || github.run_id }}
+  cancel-in-progress: false
+
+jobs:
+  arm-auto-merge:
+    if: github.event_name == 'pull_request_target' && github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    permissions:
+      contents: write
+      pull-requests: write
+    env:
+      GH_TOKEN: ${{ github.token }}
+      PR_NUMBER: ${{ github.event.pull_request.number }}
+    steps:
+      - name: Checkout trusted standard
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        with:
+          repository: kgsmith19/agent-engineering-standard
+          ref: main
+          path: .standard
+          persist-credentials: false
+      - name: Arm eligible auto-merge
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $repo = $env:GITHUB_REPOSITORY
+          $prRaw = & gh api "repos/$repo/pulls/$env:PR_NUMBER" 2>&1
+          if ($LASTEXITCODE -ne 0) { throw ($prRaw -join "`n") }
+          $pr = ($prRaw -join "`n") | ConvertFrom-Json
+          if ($pr.state -ne 'open' -or $pr.draft) { exit 0 }
+
+          $riskLabels = @($pr.labels | ForEach-Object { $_.name } | Where-Object { $_ -match '^risk:R[0-4]$' })
+          if ($riskLabels.Count -gt 1) { throw "Multiple risk labels found: $($riskLabels -join ', ')" }
+          $risk = if ($riskLabels.Count -eq 1) { $riskLabels[0].Substring(5) } else { 'R2' }
+
+          $output = & pwsh -NoProfile -File .standard/scripts/auto-merge.ps1 -Repo $repo -Pr ([int]$env:PR_NUMBER) -Risk $risk 2>&1
+          if ($LASTEXITCODE -ne 0) {
+            $text = $output -join "`n"
+            if ($text -match 'Auto-merge refused by justified control-plane gate|Auto-merge refused for R4') {
+              Write-Host "Auto-merge intentionally not armed: $text" -ForegroundColor Yellow
+              exit 0
+            }
+            throw $text
+          }
+          $output | Out-Host
+
+  request-ai-review:
+    if: >-
+      github.event_name == 'workflow_run' &&
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.pull_requests[0] != null
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: read
+    env:
+      GH_TOKEN: ${{ github.token }}
+      PR_NUMBER: ${{ github.event.workflow_run.pull_requests[0].number }}
+    steps:
+      - name: Checkout trusted standard
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        with:
+          repository: kgsmith19/agent-engineering-standard
+          ref: main
+          path: .standard
+          persist-credentials: false
+      - name: Request cheapest missing independent reviewer
+        shell: pwsh
+        run: |
+          & pwsh -NoProfile -File .standard/scripts/request-independent-review.ps1 -Repo $env:GITHUB_REPOSITORY -Pr ([int]$env:PR_NUMBER) -Provider auto
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }

--- a/.github/workflows/pr-automation.yml
+++ b/.github/workflows/pr-automation.yml
@@ -67,13 +67,32 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 3
     permissions:
+      actions: read
       contents: read
       issues: write
       pull-requests: read
     env:
       GH_TOKEN: ${{ github.token }}
       PR_NUMBER: ${{ github.event.workflow_run.pull_requests[0].number }}
+      GATE_RUN_ID: ${{ github.event.workflow_run.id }}
     steps:
+      - name: Verify successful gate belongs to current PR head
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $repo = $env:GITHUB_REPOSITORY
+          $runRaw = & gh api "repos/$repo/actions/runs/$env:GATE_RUN_ID" 2>&1
+          if ($LASTEXITCODE -ne 0) { throw ($runRaw -join "`n") }
+          $gateRun = ($runRaw -join "`n") | ConvertFrom-Json
+
+          $prRaw = & gh api "repos/$repo/pulls/$env:PR_NUMBER" 2>&1
+          if ($LASTEXITCODE -ne 0) { throw ($prRaw -join "`n") }
+          $pr = ($prRaw -join "`n") | ConvertFrom-Json
+
+          if ($gateRun.head_sha -ne $pr.head.sha) {
+            Write-Host "Ignoring stale PR Gate run $env:GATE_RUN_ID for $($gateRun.head_sha); current head is $($pr.head.sha)."
+            exit 0
+          }
       - name: Checkout trusted standard
         uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:

--- a/.github/workflows/pr-automation.yml
+++ b/.github/workflows/pr-automation.yml
@@ -77,6 +77,7 @@ jobs:
       GATE_RUN_ID: ${{ github.event.workflow_run.id }}
     steps:
       - name: Verify successful gate belongs to current PR head
+        id: current-head
         shell: pwsh
         run: |
           $ErrorActionPreference = 'Stop'
@@ -91,9 +92,12 @@ jobs:
 
           if ($gateRun.head_sha -ne $pr.head.sha) {
             Write-Host "Ignoring stale PR Gate run $env:GATE_RUN_ID for $($gateRun.head_sha); current head is $($pr.head.sha)."
+            'current=false' | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
             exit 0
           }
+          'current=true' | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
       - name: Checkout trusted standard
+        if: steps.current-head.outputs.current == 'true'
         uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           repository: kgsmith19/agent-engineering-standard
@@ -101,6 +105,7 @@ jobs:
           path: .standard
           persist-credentials: false
       - name: Request cheapest missing independent reviewer
+        if: steps.current-head.outputs.current == 'true'
         shell: pwsh
         run: |
           & pwsh -NoProfile -File .standard/scripts/request-independent-review.ps1 -Repo $env:GITHUB_REPOSITORY -Pr ([int]$env:PR_NUMBER) -Provider auto

--- a/AGENT_RULES.md
+++ b/AGENT_RULES.md
@@ -76,14 +76,15 @@ The default semantic reviewer performs **one batched multi-lens pass**:
 3. business systems/operational optimization
 4. leanness/complexity/dead-code/manual-toil review
 
-A second semantic pass is justified only after substantive fixes, unresolved ambiguity, or when ambiguous provenance requires the second connected provider.
+Additional semantic responses are paid only when the exact PR head changes or a reviewer returns a material failure.
 
 Cost rules:
 
 - deterministic checks before LLM review
 - Codex primary for Claude/Copilot/ambiguous work; local deep review defaults to `gpt-5.4-mini`
-- max 2 Codex response passes per PR: initial + one post-fix re-review
-- Copilot gets 1 response by default; exactly 1 additional recovery response is allowed only after Copilot returned a material FAIL
+- 1 semantic response per required provider is the normal path
+- hard cap: 3 responses per provider per PR across changed heads/fix cycles; after that, stop and split/restart the PR instead of looping
+- each exact head is requested at most once per provider
 - no default draft review or unlimited review-on-push spending
 - per-head request markers prevent duplicate requests
 - active implementation stays draft so noisy micro-pushes do not consume semantic review budget

--- a/AGENT_RULES.md
+++ b/AGENT_RULES.md
@@ -6,7 +6,7 @@ Produce correct, useful software with minimum human attention, rework, cost, and
 
 ## 1. Work small
 
-Work one thin slice at a time.
+The portfolio GitHub Project is the planning/status surface. Execute work from its linked GitHub Issue backing record, one thin slice at a time.
 
 Before coding:
 
@@ -117,7 +117,7 @@ Repeated manual work must not become normal merely because an agent can keep doi
 
 ## 9. Isolated worktrees and parallel subagents
 
-Every write-capable task runs in one isolated worktree tied to its Issue or slice.
+Every write-capable task runs in one isolated worktree tied to its Project-backed Issue or slice.
 
 - Prefer a harness-native worktree when available; otherwise use `.worktrees/<branch>`.
 - Never share a worktree or working directory between concurrent write agents.

--- a/AGENT_RULES.md
+++ b/AGENT_RULES.md
@@ -83,7 +83,7 @@ Cost rules:
 - deterministic checks before LLM review
 - Codex primary for Claude/Copilot/ambiguous work; local deep review defaults to `gpt-5.4-mini`
 - max 2 Codex response passes per PR: initial + one post-fix re-review
-- max 1 Copilot response pass per PR, low effort
+- Copilot gets 1 response by default; exactly 1 additional recovery response is allowed only after Copilot returned a material FAIL
 - no default draft review or unlimited review-on-push spending
 - per-head request markers prevent duplicate requests
 - active implementation stays draft so noisy micro-pushes do not consume semantic review budget

--- a/DELIVERY_GITHUB.md
+++ b/DELIVERY_GITHUB.md
@@ -6,11 +6,11 @@ Make GitHub the protected integration/enforcement plane while keeping feedback f
 
 ## 1. Work and integration
 
-GitHub Issues are the durable work-item source. A PR is the smallest coherent integration unit, not necessarily one microscopic slice.
+The `Agentic Portfolio` GitHub Project is the cross-repository operating workboard. GitHub Issues remain the durable backing records for executable work, acceptance criteria, PR linkage, and history.
 
 Prefer:
 
-`Issue → SPEC only if needed → thin local slices → draft PR while iterating → ready PR → PR Gate + AI Review → auto-merge/queue → release`
+`Project → Issue → SPEC only if needed → thin local slices → draft PR while iterating → ready PR → PR Gate + AI Review → auto-merge/queue → release`
 
 Do not make PRs artificially large to save CI minutes. Save minutes by verifying slices locally, pushing less often, canceling superseded runs, caching, and reserving expensive assurance for changes that justify it.
 
@@ -92,9 +92,11 @@ For higher-risk releases, build once, identify the immutable artifact/commit, pr
 `policy/github-defaults.json` is the machine-readable portfolio policy.
 
 - `scripts/apply-github-standard.ps1` applies repository settings, labels, Actions, and default-branch rules.
+- `scripts/sync-agentic-project.ps1` creates/syncs the configured portfolio Project and adds open Issue backing records idempotently.
 - `.github/workflows/ai-review-reusable.yml` is the shared exact-head semantic-review evaluator; product repos use the thin caller template.
+- `.github/workflows/pr-automation.yml` and `templates/PR_AUTOMATION.yml` bridge deterministic success to bounded independent-review requests and safe GitHub auto-merge arming.
 - `scripts/request-independent-review.ps1` routes the next missing required provider within the configured response budget.
 - `scripts/auto-merge.ps1` validates the live integration plane and then arms GitHub auto-merge; it does not substitute its own call-time semantic judgment for the required `AI Review` context.
-- `scripts/doctor.ps1 -Remote` verifies effective remote policy, including that the AI Review workflow itself is active, and exits nonzero on drift.
+- `scripts/doctor.ps1 -Remote` verifies effective remote policy, including the portfolio Project and active automation workflows, and exits nonzero on drift.
 
 Prefer centrally maintained policy and stable check naming; keep stack-specific deterministic commands inside each product repo.

--- a/EVIDENCE_LEARNING.md
+++ b/EVIDENCE_LEARNING.md
@@ -11,7 +11,7 @@ Prefer machine-generated evidence over agent-written claims.
 Record enough to reconstruct important runs, including:
 
 - commit/base SHA
-- issue/spec/slice
+- Project item / Issue / spec / slice
 - risk profile
 - checks run/results
 - important capabilities granted
@@ -62,4 +62,4 @@ Do not solve recurring failures by repeatedly telling the agent to try harder.
 
 Telemetry may propose new ideas or maintenance work.
 
-A proposal must still pass the normal Shape / Research → Outcome / Bet process before becoming product work.
+A proposal must still pass the normal Shape / Research → Outcome / Bet process before becoming a Project-backed Issue for product work.

--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@ Idea
 → Shape / Research
 → Outcome / Bet
 → Product Truth
-→ GitHub Issue
+→ GitHub Project
+→ GitHub Issue backing record
 → Spec if needed
 → Thin Slice
 → Evidence
@@ -43,13 +44,13 @@ Every artifact, rule, gate, and CI run must reduce meaningful uncertainty, preve
 
 ## One-time portfolio setup
 
-After product repos contain the thin `AI Review` caller and GitHub CLI is authenticated:
+After product repos contain the thin `AI Review` and `PR Automation` callers and GitHub CLI is authenticated:
 
 ```powershell
 pwsh -File scripts/setup-portfolio.ps1
 ```
 
-That applies repository settings/rules, enables Actions, creates the lean risk/status labels, syncs the optional `Agentic Portfolio` Project, and runs the remote doctor. Do not call the portfolio ready until the remote doctor reports READY.
+That applies repository settings/rules, enables Actions, creates the lean risk/status labels, creates or syncs the `Agentic Portfolio` Project, and runs the remote doctor. Do not call the portfolio ready until the Project sync and remote doctor both succeed.
 
 ## Other automation
 
@@ -57,7 +58,7 @@ That applies repository settings/rules, enables Actions, creates the lean risk/s
 # Bootstrap a new repo with the shared engineering contract.
 pwsh -File scripts/bootstrap-repo.ps1 -Name my-app
 
-# Fan an approved standards commit out as reviewable pin PRs.
+# Fan an approved standards commit out as reviewable pin/workflow PRs.
 pwsh -File scripts/upgrade-repos.ps1
 
 # One cheap batched local semantic review.
@@ -75,13 +76,13 @@ pwsh -File scripts/sync-agentic-project.ps1
 pwsh -File scripts/doctor.ps1 -Remote
 ```
 
-`upgrade-repos.ps1` preserves each existing `.agent/standard.lock` revision key and supports `sha`, `commit`, and `standard_commit` without guessing.
+`upgrade-repos.ps1` preserves each existing `.agent/standard.lock` revision key, supports `sha`, `commit`, and `standard_commit` without guessing, and refreshes the canonical `AI Review` + `PR Automation` callers without replacing repo-specific `PR Gate` logic.
 
 `policy/github-defaults.json` is the machine-readable portfolio policy.
 
 ## GitHub default
 
-Managed repos use GitHub Issues for durable work, draft PRs while agents iterate, squash merge, branch cleanup, protected `main`, and resolved review threads. Integration requires two GitHub-Actions-bound contexts on the latest head:
+Managed repos use the `Agentic Portfolio` GitHub Project as the cross-repo planning/status surface and GitHub Issues as durable backing records. Draft PRs are used while agents iterate. Integration uses squash merge, branch cleanup, protected `main`, resolved review threads, and two GitHub-Actions-bound contexts on the latest head:
 
 - `PR Gate` for deterministic evidence
 - `AI Review` for cross-provider semantic review freshness
@@ -90,7 +91,7 @@ A new push invalidates the previous head's semantic authorization automatically.
 
 Control-plane PRs remain manually merged only while they can modify the evaluator/merge authority that judges them. That gate is removed when enforcement becomes immutable/external to the PR.
 
-The optional cross-repo GitHub Project is a portfolio view only; it is never a competing task database.
+The Project is the portfolio operating workboard, not a second task database. Issues remain the durable records that PRs/specs/acceptance criteria link to.
 
 ## Repo-specific truth
 

--- a/docs/adr/0001-independent-review-routing.md
+++ b/docs/adr/0001-independent-review-routing.md
@@ -14,7 +14,7 @@ Use the smallest provider-specific semantic review set **per mergeable head SHA*
 - Ordinary/user-authored provenance is ambiguous for independence and therefore requires both Codex + Copilot for unattended merge.
 - No Claude fallback is claimed until a mechanical Claude review adapter exists.
 - One semantic response batches software/security, business/product, systems/optimization, and leanness lenses.
-- Budget: at most two Codex response passes (initial + one re-review). Copilot gets one response by default and exactly one additional recovery response only after Copilot returned FAIL on an earlier head.
+- One response per required provider is the normal path. Each exact head is requested at most once per provider. A PR may consume at most three semantic responses per provider across legitimate head changes/fix cycles; after that it must stop and be split/restarted instead of entering an unbounded review loop.
 - Draft churn does not consume semantic-review budget; exact-head request markers prevent duplicate triggers.
 - A push after review creates a new SHA; the previous `AI Review` result cannot authorize that new head.
 - A successful `PR Gate` may request semantic review only when that completed run's `head_sha` still equals the PR's current head.
@@ -25,7 +25,7 @@ Use the smallest provider-specific semantic review set **per mergeable head SHA*
 
 ## Why
 
-A call-time script check is insufficient because auto-merge can remain armed after a later push. A required exact-head check makes GitHub itself enforce semantic-review freshness. Known provider provenance allows one truly cross-provider review, while ambiguous provenance pays for both connected providers rather than trusting a self-attested implementer identity. Batching business/system/lean lenses avoids multiplying calls. A single failure-recovery response prevents a real review failure from permanently deadlocking a corrected PR without creating an unlimited review-on-push loop.
+A call-time script check is insufficient because auto-merge can remain armed after a later push. A required exact-head check makes GitHub itself enforce semantic-review freshness. Known provider provenance allows one truly cross-provider review, while ambiguous provenance pays for both connected providers rather than trusting a self-attested implementer identity. Batching business/system/lean lenses avoids multiplying calls. A small hard cap preserves a bounded path through legitimate post-review fixes and changed heads without making semantic review an unlimited per-push tax.
 
 ## Trust boundary
 

--- a/docs/adr/0001-independent-review-routing.md
+++ b/docs/adr/0001-independent-review-routing.md
@@ -14,9 +14,10 @@ Use the smallest provider-specific semantic review set **per mergeable head SHA*
 - Ordinary/user-authored provenance is ambiguous for independence and therefore requires both Codex + Copilot for unattended merge.
 - No Claude fallback is claimed until a mechanical Claude review adapter exists.
 - One semantic response batches software/security, business/product, systems/optimization, and leanness lenses.
-- Budget: at most two Codex response passes (initial + one re-review) and one Copilot response pass per PR.
+- Budget: at most two Codex response passes (initial + one re-review). Copilot gets one response by default and exactly one additional recovery response only after Copilot returned FAIL on an earlier head.
 - Draft churn does not consume semantic-review budget; exact-head request markers prevent duplicate triggers.
 - A push after review creates a new SHA; the previous `AI Review` result cannot authorize that new head.
+- A successful `PR Gate` may request semantic review only when that completed run's `head_sha` still equals the PR's current head.
 - `AI Review` evaluator runs are serialized per PR so stale concurrent runs cannot overwrite newer evidence.
 - R0-R3 may auto-merge only after latest-head `PR Gate` + `AI Review` and resolved review threads.
 - R4 remains an explicit authorization gate for destructive/financial/privileged/irreversible consequence.
@@ -24,7 +25,7 @@ Use the smallest provider-specific semantic review set **per mergeable head SHA*
 
 ## Why
 
-A call-time script check is insufficient because auto-merge can remain armed after a later push. A required exact-head check makes GitHub itself enforce semantic-review freshness. Known provider provenance allows one truly cross-provider review, while ambiguous provenance pays for both connected providers rather than trusting a self-attested implementer identity. Batching business/system/lean lenses avoids multiplying calls.
+A call-time script check is insufficient because auto-merge can remain armed after a later push. A required exact-head check makes GitHub itself enforce semantic-review freshness. Known provider provenance allows one truly cross-provider review, while ambiguous provenance pays for both connected providers rather than trusting a self-attested implementer identity. Batching business/system/lean lenses avoids multiplying calls. A single failure-recovery response prevents a real review failure from permanently deadlocking a corrected PR without creating an unlimited review-on-push loop.
 
 ## Trust boundary
 

--- a/docs/adr/0001-independent-review-routing.md
+++ b/docs/adr/0001-independent-review-routing.md
@@ -12,6 +12,7 @@ Use the smallest provider-specific semantic review set **per mergeable head SHA*
 - Claude/Copilot implementations require Codex review.
 - Codex implementations require Copilot review.
 - Ordinary/user-authored provenance is ambiguous for independence and therefore requires both Codex + Copilot for unattended merge.
+- For ambiguous provenance, provider #2 is requested only after provider #1 has passed the current head. A current-head FAIL suppresses additional provider spend until the code changes.
 - No Claude fallback is claimed until a mechanical Claude review adapter exists.
 - One semantic response batches software/security, business/product, systems/optimization, and leanness lenses.
 - One response per required provider is the normal path. Each exact head is requested at most once per provider. A PR may consume at most three semantic responses per provider across legitimate head changes/fix cycles; after that it must stop and be split/restarted instead of entering an unbounded review loop.
@@ -25,7 +26,7 @@ Use the smallest provider-specific semantic review set **per mergeable head SHA*
 
 ## Why
 
-A call-time script check is insufficient because auto-merge can remain armed after a later push. A required exact-head check makes GitHub itself enforce semantic-review freshness. Known provider provenance allows one truly cross-provider review, while ambiguous provenance pays for both connected providers rather than trusting a self-attested implementer identity. Batching business/system/lean lenses avoids multiplying calls. A small hard cap preserves a bounded path through legitimate post-review fixes and changed heads without making semantic review an unlimited per-push tax.
+A call-time script check is insufficient because auto-merge can remain armed after a later push. A required exact-head check makes GitHub itself enforce semantic-review freshness. Known provider provenance allows one truly cross-provider review, while ambiguous provenance pays for both connected providers rather than trusting a self-attested implementer identity. Chaining the second ambiguous-provenance reviewer only after the first passes preserves independence without spending both reviews on a head that already has material findings. Batching business/system/lean lenses avoids multiplying calls. A small hard cap preserves a bounded path through legitimate post-review fixes and changed heads without making semantic review an unlimited per-push tax.
 
 ## Trust boundary
 

--- a/policy/github-defaults.json
+++ b/policy/github-defaults.json
@@ -21,12 +21,12 @@
     "required_for_auto_merge": true,
     "preferred_provider": "codex",
     "local_codex_model": "gpt-5.4-mini",
-    "max_codex_reviews_per_pr": 2,
+    "max_codex_reviews_per_pr": 3,
     "copilot_fallback": true,
     "copilot_effort": "low",
     "copilot_review_drafts": false,
     "copilot_review_on_push": false,
-    "max_copilot_reviews_per_pr": 1,
+    "max_copilot_reviews_per_pr": 3,
     "same_provider_counts_as_independent": false
   },
   "manual_gate_required_fields": [

--- a/policy/github-defaults.json
+++ b/policy/github-defaults.json
@@ -1,6 +1,10 @@
 {
   "owner": "kgsmith19",
   "project_title": "Agentic Portfolio",
+  "work_tracking": {
+    "system": "github-projects",
+    "backing_record": "github-issues"
+  },
   "ruleset_name": "Lean PR Gate",
   "required_status_context": "PR Gate",
   "required_ai_review_context": "AI Review",

--- a/scripts/bootstrap-repo.ps1
+++ b/scripts/bootstrap-repo.ps1
@@ -15,7 +15,9 @@ if ($LASTEXITCODE -ne 0) { throw 'gh is not authenticated.' }
 $standardRoot = (Resolve-Path (Join-Path $PSScriptRoot '..')).Path
 $standardSha = (& git -C $standardRoot rev-parse HEAD).Trim()
 if ($LASTEXITCODE -ne 0) { throw 'Could not resolve the standards commit.' }
-$owner = ((Get-Content (Join-Path $standardRoot 'policy/github-defaults.json') -Raw | ConvertFrom-Json).owner)
+$config = Get-Content (Join-Path $standardRoot 'policy/github-defaults.json') -Raw | ConvertFrom-Json
+$owner = $config.owner
+$projectTitle = $config.project_title
 $repo = "$owner/$Name"
 $target = Join-Path $Destination $Name
 
@@ -64,6 +66,7 @@ Copy-Item (Join-Path $standardRoot 'templates/ISSUE.md') (Join-Path $target '.gi
 Copy-Item (Join-Path $standardRoot 'templates/PULL_REQUEST.md') (Join-Path $target '.github/PULL_REQUEST_TEMPLATE.md') -Force
 Copy-Item (Join-Path $standardRoot 'templates/PR_GATE.yml') (Join-Path $target '.github/workflows/pr-gate.yml') -Force
 Copy-Item (Join-Path $standardRoot 'templates/AI_REVIEW.yml') (Join-Path $target '.github/workflows/ai-review.yml') -Force
+Copy-Item (Join-Path $standardRoot 'templates/PR_AUTOMATION.yml') (Join-Path $target '.github/workflows/pr-automation.yml') -Force
 Copy-Item (Join-Path $standardRoot 'templates/CODEOWNERS') (Join-Path $target '.github/CODEOWNERS') -Force
 
 @"
@@ -82,7 +85,9 @@ standard:
   sha: $standardSha
 
 work_tracking:
-  system: github-issues
+  system: github-projects
+  project: "$projectTitle"
+  backing_record: github-issues
 
 ci:
   required_check: "PR Gate"
@@ -91,7 +96,7 @@ ci:
 
 # Before product code lands, replace the bootstrap-only PR Gate with the cheapest
 # repo-specific objective build/test/acceptance evidence for the detected stack.
-# Keep the shared AI Review caller intact unless the control-plane design changes.
+# Keep the shared AI Review and PR Automation callers intact unless the control-plane design changes.
 "@ | Set-Content (Join-Path $target '.agent/project.yaml') -Encoding utf8
 
 '@AGENTS.md' | Set-Content (Join-Path $target 'CLAUDE.md') -Encoding utf8
@@ -116,6 +121,7 @@ Replace the bootstrap-only PR Gate with the smallest objective gate appropriate 
 - Detect and record verified build/test/type/lint/E2E commands in `.agent/project.yaml`.
 - Replace `.github/workflows/pr-gate.yml` so `PR Gate` executes the cheapest sufficient independent evidence.
 - Preserve `.github/workflows/ai-review.yml` so the required exact-head `AI Review` context continues to run.
+- Preserve `.github/workflows/pr-automation.yml` so successful deterministic CI requests the required independent reviewer and eligible PRs arm auto-merge.
 - Extend `.github/dependabot.yml` only with package ecosystems this repo actually uses; group patch/minor updates when it reduces CI/review noise and keep majors separate unless compatibility evidence justifies a batch.
 - Extend `.github/CODEOWNERS` with the small repo-specific gate entrypoints whose weakening could make `PR Gate` falsely green; keep the canonical control-plane ownership rules as the final non-comment rules.
 - Keep draft iteration local; ready PR and `merge_group` must produce the real `PR Gate`.
@@ -128,5 +134,8 @@ R3 — initial control-plane finalization.
 & gh issue create --repo $repo --title 'Finalize repo-specific objective PR Gate before product code' --body $issueBody | Out-Host
 if ($LASTEXITCODE -ne 0) { throw 'Could not create initial control-plane Issue.' }
 
+& pwsh -NoProfile -File (Join-Path $PSScriptRoot 'sync-agentic-project.ps1') -Repositories $Name
+if ($LASTEXITCODE -ne 0) { throw "Could not sync $repo work items to '$projectTitle'." }
+
 Write-Host "`nBOOTSTRAPPED: $repo" -ForegroundColor Green
-Write-Host 'The repo is protected immediately. Complete the generated PR-Gate Issue before adding product code.'
+Write-Host "The repo is protected and tracked in '$projectTitle'. Complete the generated PR-Gate Issue before adding product code."

--- a/scripts/doctor.ps1
+++ b/scripts/doctor.ps1
@@ -68,7 +68,7 @@ if ($config.auto_merge_max_risk -ne 'R3') { throw 'auto_merge_max_risk must rema
 $review = $config.independent_review
 if (-not [bool]$review.required_for_auto_merge) { throw 'Independent AI review must be required before auto-merge.' }
 if ($review.preferred_provider -ne 'codex' -or $review.local_codex_model -ne 'gpt-5.4-mini') { throw 'Current low-cost default must remain Codex + gpt-5.4-mini unless evidence changes.' }
-if ([int]$review.max_codex_reviews_per_pr -ne 2 -or [int]$review.max_copilot_reviews_per_pr -ne 1) { throw 'Review budgets drifted.' }
+if ([int]$review.max_codex_reviews_per_pr -ne 3 -or [int]$review.max_copilot_reviews_per_pr -ne 3) { throw 'Review budgets drifted.' }
 if ([bool]$review.copilot_review_on_push -or [bool]$review.copilot_review_drafts) { throw 'Unbounded Copilot draft/push review must remain off.' }
 if ($review.copilot_effort -ne 'low' -or [bool]$review.same_provider_counts_as_independent) { throw 'Copilot/independence policy drifted.' }
 

--- a/scripts/doctor.ps1
+++ b/scripts/doctor.ps1
@@ -17,17 +17,45 @@ function Test-CodeownersTail {
   return $true
 }
 
+function Add-WorkflowProblems {
+  param(
+    [Parameter(Mandatory)][string]$Repo,
+    [Parameter(Mandatory)][string]$DefaultBranch,
+    [Parameter(Mandatory)][string]$Path,
+    [Parameter(Mandatory)][string]$DisplayName,
+    [Parameter(Mandatory)]$Problems
+  )
+
+  $fileRaw = & gh api "repos/$Repo/contents/.github/workflows/${Path}?ref=$DefaultBranch" 2>&1
+  if ($LASTEXITCODE -ne 0) {
+    $Problems.Add("$DisplayName workflow missing")
+    return
+  }
+
+  $stateRaw = & gh api "repos/$Repo/actions/workflows/$Path" 2>&1
+  if ($LASTEXITCODE -ne 0) {
+    $Problems.Add("cannot read $DisplayName workflow state")
+    return
+  }
+
+  $state = ($stateRaw -join "`n") | ConvertFrom-Json
+  if ($state.state -ne 'active') { $Problems.Add("$DisplayName workflow not active: $($state.state)") }
+}
+
 $required = @(
   'README.md','LIFECYCLE.md','AGENT_RULES.md','QUALITY_RULES.md','SECURITY_RISK_AUTONOMY.md','DELIVERY_GITHUB.md','EVIDENCE_LEARNING.md','AGENTS.md',
-  '.github/CODEOWNERS','.github/workflows/ci.yml','.github/workflows/ai-review.yml','.github/workflows/ai-review-reusable.yml','policy/github-defaults.json',
+  '.github/CODEOWNERS','.github/workflows/ci.yml','.github/workflows/ai-review.yml','.github/workflows/ai-review-reusable.yml','.github/workflows/pr-automation.yml','policy/github-defaults.json',
   'scripts/setup-portfolio.ps1','scripts/apply-github-standard.ps1','scripts/sync-agentic-project.ps1','scripts/codex-review.ps1','scripts/request-independent-review.ps1','scripts/auto-merge.ps1','scripts/bootstrap-repo.ps1','scripts/upgrade-repos.ps1',
   'scripts/lib/legacy-protection.ps1','scripts/lib/standard-lock.ps1','scripts/lib/review-policy.ps1',
   'tests/legacy-protection.tests.ps1','tests/standard-lock.tests.ps1','tests/review-policy.tests.ps1',
-  'templates/AGENTS.md','templates/CODEOWNERS','templates/PR_GATE.yml','templates/AI_REVIEW.yml','templates/PRD.md','templates/SPEC.md','templates/ADR.md','templates/ISSUE.md','templates/PULL_REQUEST.md'
+  'templates/AGENTS.md','templates/CODEOWNERS','templates/PR_GATE.yml','templates/AI_REVIEW.yml','templates/PR_AUTOMATION.yml','templates/PRD.md','templates/SPEC.md','templates/ADR.md','templates/ISSUE.md','templates/PULL_REQUEST.md'
 )
 foreach ($relative in $required) { if (-not (Test-Path (Join-Path $root $relative))) { throw "Missing required file: $relative" } }
 
 $config = Get-Content (Join-Path $root 'policy/github-defaults.json') -Raw | ConvertFrom-Json
+if ($config.work_tracking.system -ne 'github-projects') { throw "work_tracking.system must be 'github-projects'." }
+if ($config.work_tracking.backing_record -ne 'github-issues') { throw "work_tracking.backing_record must be 'github-issues'." }
+if ([string]::IsNullOrWhiteSpace([string]$config.project_title)) { throw 'project_title is required.' }
 if ($config.required_status_context -ne 'PR Gate') { throw "required_status_context must be 'PR Gate'" }
 if ($config.required_ai_review_context -ne 'AI Review') { throw "required_ai_review_context must be 'AI Review'" }
 if ($config.required_approving_review_count -ne 0) { throw 'Default human approval count must remain 0.' }
@@ -78,6 +106,16 @@ if ($LASTEXITCODE -ne 0) { throw 'Could not resolve GitHub Actions App identity.
 $actionsAppId = [int]((($actionsAppRaw -join "`n") | ConvertFrom-Json).id)
 $remoteFailures = New-Object System.Collections.Generic.List[string]
 
+$projectsRaw = & gh project list --owner $config.owner --format json 2>&1
+if ($LASTEXITCODE -ne 0) {
+  $remoteFailures.Add("$($config.owner): cannot access GitHub Projects; ensure gh has project scope")
+} else {
+  $projects = ($projectsRaw -join "`n") | ConvertFrom-Json
+  if (-not ($projects.projects | Where-Object { $_.title -eq $config.project_title } | Select-Object -First 1)) {
+    $remoteFailures.Add("$($config.owner): portfolio project '$($config.project_title)' missing")
+  }
+}
+
 foreach ($name in $config.repositories) {
   $repo = "$($config.owner)/$name"; $problems = New-Object System.Collections.Generic.List[string]
   $metaRaw = & gh api "repos/$repo" 2>&1
@@ -102,22 +140,21 @@ foreach ($name in $config.repositories) {
     if (-not [bool]$actions.enabled) { $problems.Add('Actions disabled') }
   }
 
+  $projectConfigRaw = & gh api -H 'Accept: application/vnd.github.raw+json' "repos/$repo/contents/.agent/project.yaml?ref=$($meta.default_branch)" 2>&1
+  if ($LASTEXITCODE -ne 0) { $problems.Add('project metadata missing') }
+  else {
+    $projectConfig = $projectConfigRaw -join "`n"
+    if ($projectConfig -notmatch '(?m)^work_tracking:\s*$' -or $projectConfig -notmatch '(?m)^\s+system:\s*github-projects\s*$') { $problems.Add('work tracking is not github-projects') }
+  }
+
   $codeownersRaw = & gh api -H 'Accept: application/vnd.github.raw+json' "repos/$repo/contents/.github/CODEOWNERS?ref=$($meta.default_branch)" 2>&1
   if ($LASTEXITCODE -ne 0) { $problems.Add('CODEOWNERS missing') } else {
     $expectedTail = if ($name -eq 'agent-engineering-standard') { $standardTail } else { $appTail }
     if (-not (Test-CodeownersTail -Content ($codeownersRaw -join "`n") -ExpectedTail $expectedTail)) { $problems.Add('CODEOWNERS ownership map drift') }
   }
 
-  $aiWorkflowRaw = & gh api "repos/$repo/contents/.github/workflows/ai-review.yml?ref=$($meta.default_branch)" 2>&1
-  if ($LASTEXITCODE -ne 0) { $problems.Add('AI Review caller workflow missing') }
-  else {
-    $workflowStateRaw = & gh api "repos/$repo/actions/workflows/ai-review.yml" 2>&1
-    if ($LASTEXITCODE -ne 0) { $problems.Add('cannot read AI Review workflow state') }
-    else {
-      $workflowState = ($workflowStateRaw -join "`n") | ConvertFrom-Json
-      if ($workflowState.state -ne 'active') { $problems.Add("AI Review workflow not active: $($workflowState.state)") }
-    }
-  }
+  Add-WorkflowProblems -Repo $repo -DefaultBranch $meta.default_branch -Path 'ai-review.yml' -DisplayName 'AI Review' -Problems $problems
+  Add-WorkflowProblems -Repo $repo -DefaultBranch $meta.default_branch -Path 'pr-automation.yml' -DisplayName 'PR Automation' -Problems $problems
 
   $rulesetsRaw = & gh api "repos/$repo/rulesets" 2>&1
   if ($LASTEXITCODE -ne 0) { $problems.Add('cannot read rulesets') } else {

--- a/scripts/lib/standard-lock.ps1
+++ b/scripts/lib/standard-lock.ps1
@@ -69,3 +69,50 @@ function Update-StandardProjectContent {
   $replacement = $match.Groups['prefix'].Value + $StandardSha + $match.Groups['suffix'].Value
   return $Content.Substring(0, $match.Index) + $replacement + $Content.Substring($match.Index + $match.Length)
 }
+
+function Update-ProjectWorkTrackingContent {
+  param(
+    [Parameter(Mandatory)][AllowEmptyString()][string]$Content,
+    [Parameter(Mandatory)][string]$ProjectTitle
+  )
+
+  if ([string]::IsNullOrWhiteSpace($ProjectTitle) -or $ProjectTitle -match '[\r\n"]') {
+    throw 'ProjectTitle must be a non-empty single-line value without double quotes.'
+  }
+
+  $newline = if ($Content.Contains("`r`n")) { "`r`n" } else { "`n" }
+  $desired = [ordered]@{
+    system = 'github-projects'
+    project = '"' + $ProjectTitle + '"'
+    backing_record = 'github-issues'
+  }
+
+  $blockPattern = '(?ms)^(?<header>work_tracking:[ \t]*(?:#.*)?\r?\n)(?<body>(?:[ \t]+[^\r\n]*(?:\r?\n|$))*)'
+  $block = [regex]::Match($Content, $blockPattern)
+  if (-not $block.Success) {
+    $prefix = $Content
+    if ($prefix.Length -gt 0 -and -not ($prefix.EndsWith("`n") -or $prefix.EndsWith("`r"))) { $prefix += $newline }
+    if ($prefix.Length -gt 0 -and -not $prefix.EndsWith($newline + $newline)) { $prefix += $newline }
+    $body = @($desired.GetEnumerator() | ForEach-Object { "  $($_.Key): $($_.Value)" }) -join $newline
+    return $prefix + 'work_tracking:' + $newline + $body + $newline
+  }
+
+  $body = $block.Groups['body'].Value
+  foreach ($entry in $desired.GetEnumerator()) {
+    $keyPattern = "(?m)^(?<prefix>[ \t]+$([regex]::Escape($entry.Key)):[ \t]*)(?<value>[^#\r\n]*?)(?<suffix>[ \t]*(?:#.*)?\r?)$"
+    $matches = [regex]::Matches($body, $keyPattern)
+    if ($matches.Count -gt 1) { throw "project.yaml work_tracking contains duplicate '$($entry.Key)' fields." }
+    if ($matches.Count -eq 1) {
+      $match = $matches[0]
+      $replacement = $match.Groups['prefix'].Value + $entry.Value + $match.Groups['suffix'].Value
+      $body = $body.Substring(0, $match.Index) + $replacement + $body.Substring($match.Index + $match.Length)
+    }
+    else {
+      if ($body.Length -gt 0 -and -not $body.EndsWith("`n")) { $body += $newline }
+      $body += "  $($entry.Key): $($entry.Value)$newline"
+    }
+  }
+
+  $replacementBlock = $block.Groups['header'].Value + $body
+  return $Content.Substring(0, $block.Index) + $replacementBlock + $Content.Substring($block.Index + $block.Length)
+}

--- a/scripts/lib/standard-lock.ps1
+++ b/scripts/lib/standard-lock.ps1
@@ -80,6 +80,7 @@ function Update-ProjectWorkTrackingContent {
     throw 'ProjectTitle must be a non-empty single-line value without double quotes.'
   }
 
+  $hadTrailingNewline = $Content.EndsWith("`n")
   $newline = if ($Content.Contains("`r`n")) { "`r`n" } else { "`n" }
   $desired = [ordered]@{
     system = 'github-projects'
@@ -94,7 +95,9 @@ function Update-ProjectWorkTrackingContent {
     if ($prefix.Length -gt 0 -and -not ($prefix.EndsWith("`n") -or $prefix.EndsWith("`r"))) { $prefix += $newline }
     if ($prefix.Length -gt 0 -and -not $prefix.EndsWith($newline + $newline)) { $prefix += $newline }
     $body = @($desired.GetEnumerator() | ForEach-Object { "  $($_.Key): $($_.Value)" }) -join $newline
-    return $prefix + 'work_tracking:' + $newline + $body + $newline
+    $result = $prefix + 'work_tracking:' + $newline + $body + $newline
+    if (-not $hadTrailingNewline) { return $result.TrimEnd("`r", "`n") }
+    return $result
   }
 
   $body = $block.Groups['body'].Value
@@ -114,5 +117,7 @@ function Update-ProjectWorkTrackingContent {
   }
 
   $replacementBlock = $block.Groups['header'].Value + $body
-  return $Content.Substring(0, $block.Index) + $replacementBlock + $Content.Substring($block.Index + $block.Length)
+  $result = $Content.Substring(0, $block.Index) + $replacementBlock + $Content.Substring($block.Index + $block.Length)
+  if (-not $hadTrailingNewline) { return $result.TrimEnd("`r", "`n") }
+  return $result
 }

--- a/scripts/request-independent-review.ps1
+++ b/scripts/request-independent-review.ps1
@@ -1,7 +1,8 @@
 param(
   [Parameter(Mandatory)][string]$Repo,
   [Parameter(Mandatory)][int]$Pr,
-  [ValidateSet('auto','codex','copilot')][string]$Provider = 'auto'
+  [ValidateSet('auto','codex','copilot')][string]$Provider = 'auto',
+  [switch]$FollowupOnly
 )
 
 $ErrorActionPreference = 'Stop'
@@ -39,13 +40,16 @@ if ($LASTEXITCODE -ne 0) { throw ($commentsRaw -join "`n") }
 $comments = @(($commentsRaw -join "`n") | ConvertFrom-Json)
 
 $passedCurrent = @{}
+$failedCurrent = @{}
 foreach ($provider in @('codex','copilot')) {
   $providerReviews = @($reviews | Where-Object {
     (Get-ReviewProviderFromLogin -Login $_.user.login) -eq $provider -and
     $_.commit_id -eq $headSha -and $_.state -notin @('DISMISSED','PENDING')
   } | Sort-Object submitted_at)
-  if ($providerReviews.Count -gt 0 -and $providerReviews[-1].state -ne 'CHANGES_REQUESTED') {
-    $passedCurrent[$provider] = $true
+  if ($providerReviews.Count -gt 0) {
+    $latest = $providerReviews[-1]
+    if ($latest.state -eq 'CHANGES_REQUESTED') { $failedCurrent[$provider] = $true }
+    else { $passedCurrent[$provider] = $true }
   }
 }
 
@@ -53,9 +57,25 @@ $structuredCopilotResponses = @($comments | Where-Object {
   (Get-ReviewProviderFromLogin -Login $_.user.login) -eq 'copilot' -and
   $_.body -match '(?im)^\s*AI-REVIEW\s+(PASS|FAIL)\b'
 })
-$currentStructuredCopilot = @($structuredCopilotResponses | Where-Object { $_.body -match [regex]::Escape($headSha) } | Sort-Object created_at)
-if ($currentStructuredCopilot.Count -gt 0 -and $currentStructuredCopilot[-1].body -match '(?im)^\s*AI-REVIEW\s+PASS\b') {
-  $passedCurrent['copilot'] = $true
+$currentStructuredCopilot = @($structuredCopilotResponses | Where-Object {
+  $_.body -match [regex]::Escape($headSha)
+} | Sort-Object created_at)
+if ($currentStructuredCopilot.Count -gt 0) {
+  $latestStructured = $currentStructuredCopilot[-1]
+  if ($latestStructured.body -match '(?im)^\s*AI-REVIEW\s+FAIL\b') {
+    $failedCurrent['copilot'] = $true
+    $passedCurrent.Remove('copilot')
+  }
+  elseif (-not $failedCurrent.ContainsKey('copilot')) {
+    $passedCurrent['copilot'] = $true
+  }
+}
+
+foreach ($requiredProvider in $requiredProviders) {
+  if ($failedCurrent.ContainsKey($requiredProvider)) {
+    Write-Host "CURRENT-HEAD REQUIRED REVIEW FAILED: $requiredProvider on $headSha. Fix the implementation before spending another provider response." -ForegroundColor Yellow
+    exit 0
+  }
 }
 
 $missing = @($requiredProviders | Where-Object { -not $passedCurrent.ContainsKey($_) })
@@ -64,11 +84,16 @@ if ($missing.Count -eq 0) {
   exit 0
 }
 
+$passedRequiredCount = @($requiredProviders | Where-Object { $passedCurrent.ContainsKey($_) }).Count
+if ($FollowupOnly -and $passedRequiredCount -eq 0) {
+  Write-Host "FOLLOW-UP REVIEW NOT NEEDED: no required provider has passed current head $headSha yet."
+  exit 0
+}
+
 # Count actual semantic responses across the PR. One response is the normal path.
-# The hard cap of three exists only to preserve a bounded path through legitimate
-# head changes (for example PASS -> small fix -> FAIL -> correction) without
-# turning every push into an unlimited review loop. Each exact head can be
-# requested at most once by the marker checks below.
+# The hard cap of three preserves a bounded path through legitimate head changes
+# without turning every push into an unlimited review loop. Each exact head can
+# be requested at most once by the marker checks below.
 $codexPassCount = @($reviews | Where-Object { (Get-ReviewProviderFromLogin -Login $_.user.login) -eq 'codex' }).Count
 $copilotFormalCount = @($reviews | Where-Object { (Get-ReviewProviderFromLogin -Login $_.user.login) -eq 'copilot' }).Count
 $copilotStructuredCount = $structuredCopilotResponses.Count
@@ -89,6 +114,10 @@ if ($Provider -eq 'auto') {
     if ($candidate -eq 'copilot' -and $copilotAvailable) { $Provider = 'copilot'; break }
   }
   if (-not $Provider) {
+    if ($FollowupOnly) {
+      Write-Host "FOLLOW-UP REVIEW NOT REQUESTED: no missing provider is currently requestable for head $headSha."
+      exit 0
+    }
     throw "No budgeted required reviewer is available for current head $headSha. Missing: $($missing -join ', '). Codex passes=$codexPassCount/$($reviewPolicy.max_codex_reviews_per_pr), Copilot passes=$copilotPassCount/$($reviewPolicy.max_copilot_reviews_per_pr). Split or restart the PR rather than creating an unbounded review loop."
   }
 }

--- a/scripts/request-independent-review.ps1
+++ b/scripts/request-independent-review.ps1
@@ -64,19 +64,15 @@ if ($missing.Count -eq 0) {
   exit 0
 }
 
-# Budgets count actual semantic responses, not duplicate trigger comments.
+# Count actual semantic responses across the PR. One response is the normal path.
+# The hard cap of three exists only to preserve a bounded path through legitimate
+# head changes (for example PASS -> small fix -> FAIL -> correction) without
+# turning every push into an unlimited review loop. Each exact head can be
+# requested at most once by the marker checks below.
 $codexPassCount = @($reviews | Where-Object { (Get-ReviewProviderFromLogin -Login $_.user.login) -eq 'codex' }).Count
-$copilotFormal = @($reviews | Where-Object { (Get-ReviewProviderFromLogin -Login $_.user.login) -eq 'copilot' })
-$copilotFormalCount = $copilotFormal.Count
+$copilotFormalCount = @($reviews | Where-Object { (Get-ReviewProviderFromLogin -Login $_.user.login) -eq 'copilot' }).Count
 $copilotStructuredCount = $structuredCopilotResponses.Count
 $copilotPassCount = $copilotFormalCount + $copilotStructuredCount
-
-# One normal Copilot response is the default budget. If Copilot actually failed a prior
-# head, permit exactly one post-fix recovery response so the PR has a bounded path back
-# to green. A second failure exhausts the budget; no unbounded review-on-push loop.
-$copilotHadFailure = @($structuredCopilotResponses | Where-Object { $_.body -match '(?im)^\s*AI-REVIEW\s+FAIL\b' }).Count -gt 0 -or
-  @($copilotFormal | Where-Object { $_.state -eq 'CHANGES_REQUESTED' }).Count -gt 0
-$copilotResponseLimit = [int]$reviewPolicy.max_copilot_reviews_per_pr + $(if ($copilotHadFailure) { 1 } else { 0 })
 
 $codexMarker = "<!-- ai-review-request:codex:$headSha -->"
 $copilotMarker = "<!-- ai-review-request:copilot:$headSha -->"
@@ -84,7 +80,7 @@ $codexOutstanding = @($comments | Where-Object { $_.body -like "*$codexMarker*" 
 $copilotOutstanding = @($comments | Where-Object { $_.body -like "*$copilotMarker*" }).Count -gt 0
 
 $codexAvailable = ($codexPassCount -lt [int]$reviewPolicy.max_codex_reviews_per_pr) -and -not $codexOutstanding
-$copilotAvailable = [bool]$reviewPolicy.copilot_fallback -and ($copilotPassCount -lt $copilotResponseLimit) -and -not $copilotOutstanding
+$copilotAvailable = [bool]$reviewPolicy.copilot_fallback -and ($copilotPassCount -lt [int]$reviewPolicy.max_copilot_reviews_per_pr) -and -not $copilotOutstanding
 
 if ($Provider -eq 'auto') {
   $Provider = $null
@@ -93,7 +89,7 @@ if ($Provider -eq 'auto') {
     if ($candidate -eq 'copilot' -and $copilotAvailable) { $Provider = 'copilot'; break }
   }
   if (-not $Provider) {
-    throw "No budgeted required reviewer is available for current head $headSha. Missing: $($missing -join ', '). Codex passes=$codexPassCount/$($reviewPolicy.max_codex_reviews_per_pr), Copilot passes=$copilotPassCount/$copilotResponseLimit."
+    throw "No budgeted required reviewer is available for current head $headSha. Missing: $($missing -join ', '). Codex passes=$codexPassCount/$($reviewPolicy.max_codex_reviews_per_pr), Copilot passes=$copilotPassCount/$($reviewPolicy.max_copilot_reviews_per_pr). Split or restart the PR rather than creating an unbounded review loop."
   }
 }
 if ($missing -notcontains $Provider) { throw "Reviewer '$Provider' is not a missing required provider for implementer '$implementer'. Missing: $($missing -join ', ')." }
@@ -110,6 +106,6 @@ switch ($Provider) {
     $prompt = "@copilot Independently review the CURRENT PR head only. Do not modify files or push commits. Apply software/security, business/product ROI, systems/optimization, and strict leanness lenses. Report only material P0-P2 findings. Start with AI-REVIEW PASS or AI-REVIEW FAIL and include exact SHA $headSha.`n`n$copilotMarker"
     & gh pr comment $Pr --repo $Repo --body $prompt | Out-Host
     if ($LASTEXITCODE -ne 0) { throw "Could not request Copilot fallback review for $Repo PR #$Pr." }
-    Write-Host "REVIEW REQUESTED: Copilot response budget $($copilotPassCount + 1)/$copilotResponseLimit; head=$headSha; implementer=$implementer." -ForegroundColor Yellow
+    Write-Host "REVIEW REQUESTED: Copilot response budget $($copilotPassCount + 1)/$($reviewPolicy.max_copilot_reviews_per_pr); head=$headSha; implementer=$implementer." -ForegroundColor Yellow
   }
 }

--- a/scripts/request-independent-review.ps1
+++ b/scripts/request-independent-review.ps1
@@ -66,9 +66,17 @@ if ($missing.Count -eq 0) {
 
 # Budgets count actual semantic responses, not duplicate trigger comments.
 $codexPassCount = @($reviews | Where-Object { (Get-ReviewProviderFromLogin -Login $_.user.login) -eq 'codex' }).Count
-$copilotFormalCount = @($reviews | Where-Object { (Get-ReviewProviderFromLogin -Login $_.user.login) -eq 'copilot' }).Count
+$copilotFormal = @($reviews | Where-Object { (Get-ReviewProviderFromLogin -Login $_.user.login) -eq 'copilot' })
+$copilotFormalCount = $copilotFormal.Count
 $copilotStructuredCount = $structuredCopilotResponses.Count
 $copilotPassCount = $copilotFormalCount + $copilotStructuredCount
+
+# One normal Copilot response is the default budget. If Copilot actually failed a prior
+# head, permit exactly one post-fix recovery response so the PR has a bounded path back
+# to green. A second failure exhausts the budget; no unbounded review-on-push loop.
+$copilotHadFailure = @($structuredCopilotResponses | Where-Object { $_.body -match '(?im)^\s*AI-REVIEW\s+FAIL\b' }).Count -gt 0 -or
+  @($copilotFormal | Where-Object { $_.state -eq 'CHANGES_REQUESTED' }).Count -gt 0
+$copilotResponseLimit = [int]$reviewPolicy.max_copilot_reviews_per_pr + $(if ($copilotHadFailure) { 1 } else { 0 })
 
 $codexMarker = "<!-- ai-review-request:codex:$headSha -->"
 $copilotMarker = "<!-- ai-review-request:copilot:$headSha -->"
@@ -76,7 +84,7 @@ $codexOutstanding = @($comments | Where-Object { $_.body -like "*$codexMarker*" 
 $copilotOutstanding = @($comments | Where-Object { $_.body -like "*$copilotMarker*" }).Count -gt 0
 
 $codexAvailable = ($codexPassCount -lt [int]$reviewPolicy.max_codex_reviews_per_pr) -and -not $codexOutstanding
-$copilotAvailable = [bool]$reviewPolicy.copilot_fallback -and ($copilotPassCount -lt [int]$reviewPolicy.max_copilot_reviews_per_pr) -and -not $copilotOutstanding
+$copilotAvailable = [bool]$reviewPolicy.copilot_fallback -and ($copilotPassCount -lt $copilotResponseLimit) -and -not $copilotOutstanding
 
 if ($Provider -eq 'auto') {
   $Provider = $null
@@ -85,7 +93,7 @@ if ($Provider -eq 'auto') {
     if ($candidate -eq 'copilot' -and $copilotAvailable) { $Provider = 'copilot'; break }
   }
   if (-not $Provider) {
-    throw "No budgeted required reviewer is available for current head $headSha. Missing: $($missing -join ', '). Codex passes=$codexPassCount/$($reviewPolicy.max_codex_reviews_per_pr), Copilot passes=$copilotPassCount/$($reviewPolicy.max_copilot_reviews_per_pr)."
+    throw "No budgeted required reviewer is available for current head $headSha. Missing: $($missing -join ', '). Codex passes=$codexPassCount/$($reviewPolicy.max_codex_reviews_per_pr), Copilot passes=$copilotPassCount/$copilotResponseLimit."
   }
 }
 if ($missing -notcontains $Provider) { throw "Reviewer '$Provider' is not a missing required provider for implementer '$implementer'. Missing: $($missing -join ', ')." }
@@ -102,6 +110,6 @@ switch ($Provider) {
     $prompt = "@copilot Independently review the CURRENT PR head only. Do not modify files or push commits. Apply software/security, business/product ROI, systems/optimization, and strict leanness lenses. Report only material P0-P2 findings. Start with AI-REVIEW PASS or AI-REVIEW FAIL and include exact SHA $headSha.`n`n$copilotMarker"
     & gh pr comment $Pr --repo $Repo --body $prompt | Out-Host
     if ($LASTEXITCODE -ne 0) { throw "Could not request Copilot fallback review for $Repo PR #$Pr." }
-    Write-Host "REVIEW REQUESTED: Copilot response budget $($copilotPassCount + 1)/$($reviewPolicy.max_copilot_reviews_per_pr); head=$headSha; implementer=$implementer." -ForegroundColor Yellow
+    Write-Host "REVIEW REQUESTED: Copilot response budget $($copilotPassCount + 1)/$copilotResponseLimit; head=$headSha; implementer=$implementer." -ForegroundColor Yellow
   }
 }

--- a/scripts/setup-portfolio.ps1
+++ b/scripts/setup-portfolio.ps1
@@ -1,7 +1,3 @@
-param(
-  [switch]$SkipProject
-)
-
 $ErrorActionPreference = 'Stop'
 $here = $PSScriptRoot
 
@@ -16,14 +12,10 @@ Write-Host "`n1/3 Applying repository settings, Actions, labels, and branch rule
 & pwsh -NoProfile -File (Join-Path $here 'apply-github-standard.ps1')
 if ($LASTEXITCODE -ne 0) { throw 'GitHub standard application failed.' }
 
-if (-not $SkipProject) {
-  Write-Host "`n2/3 Syncing the optional Agentic Portfolio project..." -ForegroundColor Cyan
-  & pwsh -NoProfile -File (Join-Path $here 'sync-agentic-project.ps1')
-  if ($LASTEXITCODE -ne 0) {
-    Write-Warning 'Project sync failed. If gh reports a missing project scope, run: gh auth refresh -s project, then rerun this script.'
-  }
-} else {
-  Write-Host "`n2/3 Project sync skipped." -ForegroundColor DarkGray
+Write-Host "`n2/3 Syncing the Agentic Portfolio workboard..." -ForegroundColor Cyan
+& pwsh -NoProfile -File (Join-Path $here 'sync-agentic-project.ps1')
+if ($LASTEXITCODE -ne 0) {
+  throw 'Project sync failed. Ensure GitHub CLI has Projects scope: gh auth refresh -s project'
 }
 
 Write-Host "`n3/3 Verifying effective remote state..." -ForegroundColor Cyan

--- a/scripts/sync-agentic-project.ps1
+++ b/scripts/sync-agentic-project.ps1
@@ -1,5 +1,6 @@
 param(
-  [string]$ConfigPath = (Join-Path $PSScriptRoot "..\policy\github-defaults.json")
+  [string]$ConfigPath = (Join-Path $PSScriptRoot "..\policy\github-defaults.json"),
+  [string[]]$Repositories
 )
 
 $ErrorActionPreference = "Stop"
@@ -12,8 +13,10 @@ if (-not (Get-Command gh -ErrorAction SilentlyContinue)) {
 if ($LASTEXITCODE -ne 0) { throw "gh is not authenticated." }
 
 $config = Get-Content $ConfigPath -Raw | ConvertFrom-Json
+if ($config.work_tracking.system -ne 'github-projects') { throw "work_tracking.system must be 'github-projects'." }
 $owner = $config.owner
 $title = $config.project_title
+$targets = if ($Repositories -and $Repositories.Count -gt 0) { @($Repositories) } else { @($config.repositories) }
 
 $projectsRaw = & gh project list --owner $owner --format json 2>&1
 if ($LASTEXITCODE -ne 0) {
@@ -35,9 +38,9 @@ if (-not $project) { throw "Project '$title' could not be resolved after creatio
 $number = $project.number
 Write-Host "Using project #${number}: $title"
 
-foreach ($name in $config.repositories) {
-  $repo = "$owner/$name"
-  Write-Host "Syncing open issues from $repo"
+foreach ($name in $targets) {
+  $repo = if ($name -match '/') { $name } else { "$owner/$name" }
+  Write-Host "Syncing open work items from $repo"
   $issuesRaw = & gh issue list --repo $repo --state open --limit 100 --json url 2>&1
   if ($LASTEXITCODE -ne 0) {
     Write-Warning "Could not list issues for $repo"
@@ -53,4 +56,4 @@ foreach ($name in $config.repositories) {
   }
 }
 
-Write-Host "`nProject sync complete. GitHub Issues remain the source of truth; this project is only a cross-repo view." -ForegroundColor Green
+Write-Host "`nProject sync complete. '$title' is the portfolio operating workboard; GitHub Issues remain the durable backing records." -ForegroundColor Green

--- a/scripts/upgrade-repos.ps1
+++ b/scripts/upgrade-repos.ps1
@@ -65,7 +65,13 @@ pinned_by: upgrade-repos.ps1
         Set-Content $project $p -Encoding utf8 -NoNewline
       }
 
-      $paths = @($lock)
+      New-Item -ItemType Directory -Force '.github/workflows' | Out-Null
+      $aiReview = '.github/workflows/ai-review.yml'
+      $prAutomation = '.github/workflows/pr-automation.yml'
+      Copy-Item (Join-Path $standardRoot 'templates/AI_REVIEW.yml') $aiReview -Force
+      Copy-Item (Join-Path $standardRoot 'templates/PR_AUTOMATION.yml') $prAutomation -Force
+
+      $paths = @($lock, $aiReview, $prAutomation)
       if (Test-Path $project) { $paths += $project }
       & git add -- $paths
       if ($LASTEXITCODE -ne 0) { throw 'git add failed' }
@@ -77,7 +83,7 @@ pinned_by: upgrade-repos.ps1
         if ($LASTEXITCODE -ne 0) { throw 'commit failed' }
         & git push -u origin $branch | Out-Host
         if ($LASTEXITCODE -ne 0) { throw 'push failed' }
-        $body = "Pins the shared engineering standard to $StandardSha. No product behavior change. Review as an R3 control-plane dependency update; existing repo-specific quality gates remain authoritative."
+        $body = "Pins the shared engineering standard to $StandardSha and refreshes the canonical AI Review + PR Automation callers. No product behavior change. Review as an R3 control-plane dependency update; the repo-specific PR Gate remains authoritative."
         & gh pr create --repo $repo --base main --head $branch --title "Upgrade agent engineering standard to $short" --body $body | Out-Host
         if ($LASTEXITCODE -ne 0) { throw 'PR creation failed' }
       }

--- a/scripts/upgrade-repos.ps1
+++ b/scripts/upgrade-repos.ps1
@@ -21,6 +21,7 @@ if ($StandardSha -notmatch '^[0-9a-fA-F]{40}$') { throw 'StandardSha must be a f
 
 $config = Get-Content $ConfigPath -Raw | ConvertFrom-Json
 $owner = $config.owner
+$projectTitle = $config.project_title
 $short = $StandardSha.Substring(0,8)
 $pinnedAt = Get-Date -Format yyyy-MM-dd
 
@@ -59,11 +60,12 @@ pinned_by: upgrade-repos.ps1
       }
 
       $project = '.agent/project.yaml'
-      if ((Test-Path $project) -and $previousStandardSha) {
-        $p = Get-Content $project -Raw
-        $p = Update-StandardProjectContent -Content $p -PreviousStandardSha $previousStandardSha -StandardSha $StandardSha
-        Set-Content $project $p -Encoding utf8 -NoNewline
+      $projectText = if (Test-Path $project) { Get-Content $project -Raw } else { '' }
+      if ($previousStandardSha -and $projectText) {
+        $projectText = Update-StandardProjectContent -Content $projectText -PreviousStandardSha $previousStandardSha -StandardSha $StandardSha
       }
+      $projectText = Update-ProjectWorkTrackingContent -Content $projectText -ProjectTitle $projectTitle
+      Set-Content $project $projectText -Encoding utf8 -NoNewline
 
       New-Item -ItemType Directory -Force '.github/workflows' | Out-Null
       $aiReview = '.github/workflows/ai-review.yml'
@@ -71,8 +73,7 @@ pinned_by: upgrade-repos.ps1
       Copy-Item (Join-Path $standardRoot 'templates/AI_REVIEW.yml') $aiReview -Force
       Copy-Item (Join-Path $standardRoot 'templates/PR_AUTOMATION.yml') $prAutomation -Force
 
-      $paths = @($lock, $aiReview, $prAutomation)
-      if (Test-Path $project) { $paths += $project }
+      $paths = @($lock, $project, $aiReview, $prAutomation)
       & git add -- $paths
       if ($LASTEXITCODE -ne 0) { throw 'git add failed' }
 
@@ -83,12 +84,12 @@ pinned_by: upgrade-repos.ps1
         if ($LASTEXITCODE -ne 0) { throw 'commit failed' }
         & git push -u origin $branch | Out-Host
         if ($LASTEXITCODE -ne 0) { throw 'push failed' }
-        $body = "Pins the shared engineering standard to $StandardSha and refreshes the canonical AI Review + PR Automation callers. No product behavior change. Review as an R3 control-plane dependency update; the repo-specific PR Gate remains authoritative."
+        $body = "Pins the shared engineering standard to $StandardSha, migrates work tracking to the '$projectTitle' Project with Issues as durable backing records, and refreshes the canonical AI Review + PR Automation callers. No product behavior change. Review as an R3 control-plane dependency update; the repo-specific PR Gate remains authoritative."
         & gh pr create --repo $repo --base main --head $branch --title "Upgrade agent engineering standard to $short" --body $body | Out-Host
         if ($LASTEXITCODE -ne 0) { throw 'PR creation failed' }
       }
       else {
-        Write-Host 'already pinned; no PR needed'
+        Write-Host 'already converged; no PR needed'
       }
     }
     finally { Pop-Location }

--- a/templates/AGENTS.md
+++ b/templates/AGENTS.md
@@ -11,11 +11,13 @@ Read only the context needed for the assigned work, in this order:
 3. relevant `docs/adr/` — consequential architecture constraints
 4. the assigned GitHub Issue — durable work scope
 
+The portfolio GitHub Project is the planning/status surface; the linked Issue is the executable backing record.
+
 Do not invent a consequential product decision when the source truth is missing or contradictory. Record the blocker and stop that slice.
 
 ## Lean delivery loop
 
-`Issue → SPEC if needed → thin slice → RED/minimum GREEN → local verification → draft PR → PR Gate → independent AI Review → merge/release`
+`Project → Issue → SPEC if needed → thin slice → RED/minimum GREEN → local verification → draft PR → PR Gate → independent AI Review → merge/release`
 
 - Work one thin slice at a time; scope widening becomes another slice/Issue.
 - Use the smallest correct implementation. Avoid speculative abstractions and unrelated refactors.

--- a/templates/PR_AUTOMATION.yml
+++ b/templates/PR_AUTOMATION.yml
@@ -67,14 +67,37 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 3
     permissions:
+      actions: read
       contents: read
       issues: write
       pull-requests: read
     env:
       GH_TOKEN: ${{ github.token }}
       PR_NUMBER: ${{ github.event.workflow_run.pull_requests[0].number }}
+      GATE_RUN_ID: ${{ github.event.workflow_run.id }}
     steps:
+      - name: Verify successful gate belongs to current PR head
+        id: current-head
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $repo = $env:GITHUB_REPOSITORY
+          $runRaw = & gh api "repos/$repo/actions/runs/$env:GATE_RUN_ID" 2>&1
+          if ($LASTEXITCODE -ne 0) { throw ($runRaw -join "`n") }
+          $gateRun = ($runRaw -join "`n") | ConvertFrom-Json
+
+          $prRaw = & gh api "repos/$repo/pulls/$env:PR_NUMBER" 2>&1
+          if ($LASTEXITCODE -ne 0) { throw ($prRaw -join "`n") }
+          $pr = ($prRaw -join "`n") | ConvertFrom-Json
+
+          if ($gateRun.head_sha -ne $pr.head.sha) {
+            Write-Host "Ignoring stale PR Gate run $env:GATE_RUN_ID for $($gateRun.head_sha); current head is $($pr.head.sha)."
+            'current=false' | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+            exit 0
+          }
+          'current=true' | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
       - name: Checkout trusted standard
+        if: steps.current-head.outputs.current == 'true'
         uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           repository: kgsmith19/agent-engineering-standard
@@ -82,6 +105,7 @@ jobs:
           path: .standard
           persist-credentials: false
       - name: Request cheapest missing independent reviewer
+        if: steps.current-head.outputs.current == 'true'
         shell: pwsh
         run: |
           & pwsh -NoProfile -File .standard/scripts/request-independent-review.ps1 -Repo $env:GITHUB_REPOSITORY -Pr ([int]$env:PR_NUMBER) -Provider auto

--- a/templates/PR_AUTOMATION.yml
+++ b/templates/PR_AUTOMATION.yml
@@ -6,12 +6,16 @@ on:
   workflow_run:
     workflows: ["PR Gate"]
     types: [completed]
+  pull_request_review:
+    types: [submitted]
+  issue_comment:
+    types: [created, edited]
 
 permissions:
   contents: read
 
 concurrency:
-  group: pr-automation-${{ github.repository }}-${{ github.event.pull_request.number || github.event.workflow_run.pull_requests[0].number || github.run_id }}
+  group: pr-automation-${{ github.repository }}-${{ github.event.pull_request.number || github.event.issue.number || github.event.workflow_run.pull_requests[0].number || github.run_id }}
   cancel-in-progress: false
 
 jobs:
@@ -109,4 +113,31 @@ jobs:
         shell: pwsh
         run: |
           & pwsh -NoProfile -File .standard/scripts/request-independent-review.ps1 -Repo $env:GITHUB_REPOSITORY -Pr ([int]$env:PR_NUMBER) -Provider auto
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+
+  request-followup-ai-review:
+    if: >-
+      (github.event_name == 'pull_request_review' && github.event.action == 'submitted') ||
+      (github.event_name == 'issue_comment' && github.event.issue.pull_request != null)
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: read
+    env:
+      GH_TOKEN: ${{ github.token }}
+      PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
+    steps:
+      - name: Checkout trusted standard
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        with:
+          repository: kgsmith19/agent-engineering-standard
+          ref: main
+          path: .standard
+          persist-credentials: false
+      - name: Request next provider only after a current-head pass
+        shell: pwsh
+        run: |
+          & pwsh -NoProfile -File .standard/scripts/request-independent-review.ps1 -Repo $env:GITHUB_REPOSITORY -Pr ([int]$env:PR_NUMBER) -Provider auto -FollowupOnly
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }

--- a/templates/PR_AUTOMATION.yml
+++ b/templates/PR_AUTOMATION.yml
@@ -1,0 +1,88 @@
+name: PR Automation
+
+on:
+  pull_request_target:
+    types: [opened, reopened, ready_for_review, synchronize, labeled, unlabeled]
+  workflow_run:
+    workflows: ["PR Gate"]
+    types: [completed]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: pr-automation-${{ github.repository }}-${{ github.event.pull_request.number || github.event.workflow_run.pull_requests[0].number || github.run_id }}
+  cancel-in-progress: false
+
+jobs:
+  arm-auto-merge:
+    if: github.event_name == 'pull_request_target' && github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    permissions:
+      contents: write
+      pull-requests: write
+    env:
+      GH_TOKEN: ${{ github.token }}
+      PR_NUMBER: ${{ github.event.pull_request.number }}
+    steps:
+      - name: Checkout trusted standard
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        with:
+          repository: kgsmith19/agent-engineering-standard
+          ref: main
+          path: .standard
+          persist-credentials: false
+      - name: Arm eligible auto-merge
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $repo = $env:GITHUB_REPOSITORY
+          $prRaw = & gh api "repos/$repo/pulls/$env:PR_NUMBER" 2>&1
+          if ($LASTEXITCODE -ne 0) { throw ($prRaw -join "`n") }
+          $pr = ($prRaw -join "`n") | ConvertFrom-Json
+          if ($pr.state -ne 'open' -or $pr.draft) { exit 0 }
+
+          $riskLabels = @($pr.labels | ForEach-Object { $_.name } | Where-Object { $_ -match '^risk:R[0-4]$' })
+          if ($riskLabels.Count -gt 1) { throw "Multiple risk labels found: $($riskLabels -join ', ')" }
+          $risk = if ($riskLabels.Count -eq 1) { $riskLabels[0].Substring(5) } else { 'R2' }
+
+          $output = & pwsh -NoProfile -File .standard/scripts/auto-merge.ps1 -Repo $repo -Pr ([int]$env:PR_NUMBER) -Risk $risk 2>&1
+          if ($LASTEXITCODE -ne 0) {
+            $text = $output -join "`n"
+            if ($text -match 'Auto-merge refused by justified control-plane gate|Auto-merge refused for R4') {
+              Write-Host "Auto-merge intentionally not armed: $text" -ForegroundColor Yellow
+              exit 0
+            }
+            throw $text
+          }
+          $output | Out-Host
+
+  request-ai-review:
+    if: >-
+      github.event_name == 'workflow_run' &&
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.pull_requests[0] != null
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: read
+    env:
+      GH_TOKEN: ${{ github.token }}
+      PR_NUMBER: ${{ github.event.workflow_run.pull_requests[0].number }}
+    steps:
+      - name: Checkout trusted standard
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        with:
+          repository: kgsmith19/agent-engineering-standard
+          ref: main
+          path: .standard
+          persist-credentials: false
+      - name: Request cheapest missing independent reviewer
+        shell: pwsh
+        run: |
+          & pwsh -NoProfile -File .standard/scripts/request-independent-review.ps1 -Repo $env:GITHUB_REPOSITORY -Pr ([int]$env:PR_NUMBER) -Provider auto
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }

--- a/tests/standard-hygiene.tests.ps1
+++ b/tests/standard-hygiene.tests.ps1
@@ -10,7 +10,8 @@ foreach ($relative in @(
   '.gitignore',
   'scripts/prune-portfolio.ps1',
   'templates/.gitignore',
-  'templates/dependabot.yml'
+  'templates/dependabot.yml',
+  'templates/PR_AUTOMATION.yml'
 )) {
   Assert-True "required file $relative" (Test-Path (Join-Path $root $relative))
 }
@@ -40,6 +41,17 @@ if ($agentsLines -gt 120) { throw "templates/AGENTS.md exceeded lean 120-line bu
 $bootstrap = Get-Content (Join-Path $root 'scripts/bootstrap-repo.ps1') -Raw
 Assert-True 'bootstrap manages scratch ignore' ($bootstrap -match 'templates/\.gitignore')
 Assert-True 'bootstrap installs Dependabot default' ($bootstrap -match 'templates/dependabot\.yml')
+
+$prAutomation = Get-Content (Join-Path $root 'templates/PR_AUTOMATION.yml') -Raw
+Assert-True 'PR automation reacts to formal reviews' ($prAutomation -match '(?m)^\s*pull_request_review:\s*$')
+Assert-True 'PR automation reacts to structured review comments' ($prAutomation -match '(?m)^\s*issue_comment:\s*$')
+Assert-True 'PR automation chains only follow-up reviews' ($prAutomation -match '-FollowupOnly')
+Assert-True 'PR automation rejects stale gate heads' ($prAutomation -match 'gateRun\.head_sha\s+-ne\s+\$pr\.head\.sha')
+
+$requestReview = Get-Content (Join-Path $root 'scripts/request-independent-review.ps1') -Raw
+Assert-True 'review router exposes follow-up-only mode' ($requestReview -match '\[switch\]\$FollowupOnly')
+Assert-True 'review router stops on current-head failure' ($requestReview -match 'CURRENT-HEAD REQUIRED REVIEW FAILED')
+Assert-True 'review router requires a prior pass for follow-up' ($requestReview -match 'passedRequiredCount')
 
 $tokens = $null; $errors = $null
 [System.Management.Automation.Language.Parser]::ParseFile((Join-Path $root 'scripts/prune-portfolio.ps1'), [ref]$tokens, [ref]$errors) | Out-Null

--- a/tests/standard-lock.tests.ps1
+++ b/tests/standard-lock.tests.ps1
@@ -132,6 +132,43 @@ Assert-Equal -Name 'leaves unrelated project commit unchanged' `
   -Actual (Update-StandardProjectContent -Content $projectUnrelated -PreviousStandardSha $old -StandardSha $new) `
   -Expected $projectUnrelated
 
+$existingTracking = @"
+project:
+  name: app
+work_tracking:
+  system: github-issues
+  labels_present: [future]
+"@
+$existingTrackingExpected = @"
+project:
+  name: app
+work_tracking:
+  system: github-projects
+  labels_present: [future]
+  project: "Agentic Portfolio"
+  backing_record: github-issues
+"@
+Assert-Equal -Name 'migrates tracking while preserving repo-specific keys' `
+  -Actual (Update-ProjectWorkTrackingContent -Content $existingTracking -ProjectTitle 'Agentic Portfolio') `
+  -Expected $existingTrackingExpected
+
+$missingTracking = @"
+project:
+  name: app
+"@
+$missingTrackingExpected = @"
+project:
+  name: app
+
+work_tracking:
+  system: github-projects
+  project: "Agentic Portfolio"
+  backing_record: github-issues
+"@
+Assert-Equal -Name 'adds tracking block when missing' `
+  -Actual (Update-ProjectWorkTrackingContent -Content $missingTracking -ProjectTitle 'Agentic Portfolio') `
+  -Expected $missingTrackingExpected
+
 Assert-Throws -Name 'refuses missing revision field' -Action {
   Update-StandardLockContent -Content "revision: $old`npinned_at: 2026-08-08" -StandardSha $new -PinnedAt $date
 }
@@ -150,6 +187,10 @@ Assert-Throws -Name 'refuses invalid target SHA' -Action {
 
 Assert-Throws -Name 'refuses ambiguous project references' -Action {
   Update-StandardProjectContent -Content "sha: $old`nstandard_sha: $old" -PreviousStandardSha $old -StandardSha $new
+}
+
+Assert-Throws -Name 'refuses duplicate work tracking system fields' -Action {
+  Update-ProjectWorkTrackingContent -Content "work_tracking:`n  system: github-issues`n  system: github-projects`n" -ProjectTitle 'Agentic Portfolio'
 }
 
 Write-Host 'standard-lock tests: PASS' -ForegroundColor Green


### PR DESCRIPTION
## Outcome
Close the two highest-value control-plane gaps: event-driven PR integration and a centralized GitHub Projects operating workboard.

## Changes
- Add one bounded `PR Automation` workflow and template.
  - successful `PR Gate` requests only the missing cross-provider reviewer within the existing budget
  - ready PR events arm GitHub auto-merge only through the existing fail-closed live-policy validator
  - write-token jobs checkout only trusted `agent-engineering-standard@main`, never untrusted PR code
- Rename the control repo workflow to stable `PR Gate` so `workflow_run` routing is deterministic.
- Make `Agentic Portfolio` the cross-repo planning/status surface while retaining Issues as durable backing records.
- Make portfolio setup/project sync fail closed instead of optional.
- Bootstrap new repos with Projects metadata + PR Automation.
- Upgrade existing repos by refreshing only canonical AI Review/PR Automation callers while preserving repo-specific PR Gate logic.
- Extend `doctor.ps1` to detect missing Projects policy/project metadata and inactive/missing PR Automation.
- Synchronize the lean docs and agent instructions with `Project → Issue → slice → PR`.

## Traceability
- Advances #37. Live Project creation/sync still requires an authenticated GitHub CLI surface with Projects-v2 scope.
- Advances #17. Live branch/ruleset application and an auto-merge canary remain required before #17 is complete.

## Verification expected
- `PR Gate`
- legacy branch-protection tests
- standard-lock tests
- independent-review policy tests
- standard-hygiene test
- local doctor

## Risk
R3 control-plane.

## Manual Gate
- Failure class prevented: this PR changes repository-level automation/evaluator/merge orchestration that could otherwise authorize itself.
- Why automation is insufficient today: governing enforcement still lives in this repository and live default-branch protection is not yet externally immutable.
- Decision owner: repository owner.
- Gate removal condition: governing evaluator/merge enforcement moves to immutable external or organization-required policy that this repository cannot modify.