### PR TITLE
fix: enforce Ready PR creation before auto-merge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,9 @@ jobs:
       - name: Test ready-at-creation enforcement
         shell: pwsh
         run: ./tests/draft-prevention.tests.ps1
+      - name: Lint PR creation contract
+        shell: pwsh
+        run: ./scripts/lint-pr-creation.ps1
       - name: Test standard hygiene
         shell: pwsh
         run: ./tests/standard-hygiene.tests.ps1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,9 @@ jobs:
       - name: Test machine review policy
         shell: pwsh
         run: ./tests/review-policy.tests.ps1
+      - name: Test ready-at-creation enforcement
+        shell: pwsh
+        run: ./tests/draft-prevention.tests.ps1
       - name: Test standard hygiene
         shell: pwsh
         run: ./tests/standard-hygiene.tests.ps1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: PR Gate
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
+    types: [opened, synchronize, reopened, ready_for_review, converted_to_draft]
   push:
     branches: [main]
   merge_group:
@@ -17,11 +17,16 @@ concurrency:
 jobs:
   pr-gate:
     name: PR Gate
-    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - name: Enforce Ready at creation
+        if: github.event_name == 'pull_request' && github.event.pull_request.draft
+        shell: bash
+        run: |
+          echo '::error::Ready-at-creation policy violation. Create PRs with draft:false; gh callers must omit --draft.'
+          exit 1
       - name: Test legacy branch-protection logic
         shell: pwsh
         run: ./tests/legacy-protection.tests.ps1

--- a/AGENT_RULES.md
+++ b/AGENT_RULES.md
@@ -42,7 +42,12 @@ Do not repeat the same failing strategy indefinitely. Escalate consequential amb
 
 ## 6. Automated PR state machine
 
-Open a coherent PR non-draft with its `risk:R*` label already applied, so the lane engages with zero promotion latency. Use a draft only while implementation is genuinely still changing — drafts cannot auto-merge, and `status:ready` promotes one to Ready automatically when it becomes coherent.
+Finish and verify one coherent slice locally, then open its PR Ready. Draft PRs are forbidden because GitHub cannot merge them and a conversion step introduces a race before auto-merge.
+
+- REST, SDK, GraphQL, and connector creation calls set `draft: false` and verify the returned PR is not draft.
+- `gh pr create` callers omit `--draft` and verify `gh pr view --json isDraft --jq .isDraft` returns `false`.
+- Never use `gh pr ready` or automated draft conversion in the steady-state lane.
+- If a draft is observed, automation applies `status:blocked`, emits the exact contract error, and stops before auto-merge.
 
 Every unattended merge requires one GitHub check on the **latest head SHA**:
 
@@ -73,7 +78,7 @@ A clean formal review, structured exact-head Copilot PASS, or exact-head Codex t
 
 - deterministic checks run before model review
 - the AI Review runner wakes only when review evidence changes
-- no AI review for drafts or every micro-push
+- no AI review for policy-invalid drafts or every micro-push
 - normal budget: initial reviewed head plus one post-fix reviewed head
 - CI repair: maximum 7 attempts
 - review repair: maximum 1 batched attempt

--- a/DELIVERY_GITHUB.md
+++ b/DELIVERY_GITHUB.md
@@ -10,7 +10,7 @@ GitHub Issues are the durable work-item source. A PR is the smallest coherent in
 
 `Issue → SPEC only if needed → thin slices → PR (opened Ready, risk label at creation) → PR Gate → GitHub auto-merge → release → observe`
 
-Open PRs non-draft with the `risk:R*` label already applied so the lane engages with zero promotion latency. Draft-first remains supported (label `status:ready` to promote), just slower.
+Open every PR Ready with its `risk:R*` label already applied. REST, SDK, GraphQL, and connector calls set `draft: false`; `gh pr create` omits `--draft`. Verify the returned state before any auto-merge call.
 
 Do not enlarge PRs merely to save CI minutes. Save minutes through local slice verification, fewer pushes, cancellation, caching, and path/risk-aware tests.
 
@@ -67,15 +67,11 @@ The canonical ruleset is the sole default-branch authority. Legacy branch protec
 
 ```mermaid
 flowchart TD
-    A[PR opened or updated] --> B{Copilot-owned PR?}
-    B -- Yes --> C[Block: re-home to a non-Copilot PR]
-    B -- No --> D{Draft?}
-    D -- Yes --> E[No AI review and no auto-merge]
-    E --> F{status:ready added?}
-    F -- No --> E
-    F -- Yes --> G[Mark Ready automatically]
+    A[PR opened or updated] --> B{Draft?}
+    B -- Yes --> C[Block: ready-at-creation violation]
+    B -- No --> D{Copilot-owned PR?}
+    D -- Yes --> E[Block: re-home to a non-Copilot PR]
     D -- No --> H[Classify risk and changed paths]
-    G --> H
     H --> I{R4 or self-modifying control plane?}
     I -- Yes --> J[Run machine evidence; tag Kyle for justified authority]
     I -- No --> K[Validate live ruleset and arm squash auto-merge]
@@ -99,19 +95,17 @@ flowchart TD
 
 A push always creates a new decision cycle. Old `AI Review` evidence cannot authorize a new head.
 
-## 5. Draft PR rules
+## 5. Ready-at-creation rules
 
-Drafts are the low-cost implementation workspace:
+Draft PRs are not part of the autonomous state machine. GitHub natively refuses to merge them, so adding conversion creates an avoidable state and race.
 
-- repository `PR Gate` may defer draft checks
-- no semantic reviewer is requested
-- the AI Review workflow does not run on ordinary pushes
-- auto-merge is disabled
-- pushes do not consume review budget
+- Complete and verify the coherent slice locally before creating the PR.
+- REST, SDK, GraphQL, and connector callers set `draft: false` and verify the returned state.
+- `gh pr create` callers omit `--draft`, then verify `isDraft == false`.
+- A draft event fails `PR Gate`, applies `status:blocked`, posts one actionable diagnostic, and never reaches auto-merge.
+- Legacy manual conversion to Ready may clear the block, but automated conversion is forbidden.
 
-When coherent, the agent adds `status:ready`. `PR Automation` marks the draft Ready, removes the label, arms auto-merge when eligible, and begins the normal gate sequence.
-
-GitHub cannot merge a draft. Automatic promotion is the correct solution; eliminating drafts would increase review and CI spend.
+`status:ready` remains an Issue-queue label only. It never changes PR draft state.
 
 ## 6. Machine review rules
 
@@ -145,7 +139,7 @@ The AI Review runner wakes only when semantic evidence changes: formal review, i
 | Formal or inline review finds P0-P2 | Copilot performs one batched repair | 1 | second reviewed head still fails |
 | Codex review stalls | independent Copilot review fallback when allowed | 1 per head | 12-hour reviewer safety timeout |
 | Merge conflict | Dependabot rebase or Copilot semantic conflict resolution | 6 | `status:blocked` |
-| Draft ready for integration | `status:ready` promotes to Ready | 1 state change | remains draft without label |
+| Draft opened or conversion attempted | fail workflow, apply `status:blocked`, stop before auto-merge | none | Ready state is restored explicitly |
 | New push after green review | invalidate old review and restart | max 2 reviewed heads | `status:blocked` |
 | R4 | automated evidence, then human authority | none | explicit authorization |
 | Self-modifying control plane | automated evidence, then owner integration | none | external immutable judge exists |
@@ -155,7 +149,7 @@ A stop never silently assigns Kyle as reviewer. It posts the exact blocker and t
 ## 8. Actions and model efficiency
 
 - deterministic checks before model review
-- no draft or every-push AI review
+- no AI review for policy-invalid drafts or every-push chatter
 - one batched multi-lens response
 - initial reviewed head plus one post-fix reviewed head
 - cancel superseded deterministic/evaluator runs

--- a/README.md
+++ b/README.md
@@ -17,8 +17,7 @@ Idea
 → Thin Slice
 → RED → Minimum GREEN
 → Local Verification
-→ Draft PR
-→ `status:ready`
+→ Ready PR (`draft: false`)
 → `PR Gate`
 → automatic squash merge
 → Release / Runtime Proof
@@ -83,8 +82,8 @@ pwsh -NoProfile -File .\scripts\prune-portfolio.ps1
 Managed repositories use:
 
 - GitHub Issues as durable work items
-- draft PRs during implementation
-- `status:ready` for automatic promotion to Ready
+- Ready PRs at creation; API/SDK/connector calls set `draft: false`, and `gh pr create` omits `--draft`
+- fail-closed workflow enforcement if a PR is ever opened or converted to draft
 - exact workflow and status name `PR Gate` — the sole required context (machine review is advisory-only per ADR 0002)
 - zero required human approvals
 - no native `CODEOWNERS`

--- a/docs/AUTONOMOUS-PR-STATE-MACHINE.md
+++ b/docs/AUTONOMOUS-PR-STATE-MACHINE.md
@@ -22,12 +22,13 @@ This is the authoritative decision map for routine pull-request integration acro
 14. Temporary reviewer latency remains recoverable; pending review pauses auto-merge and the 12-hour safety timeout is checked by an hourly watchdog.
 15. Automation state/budget/request markers are authoritative only when posted by a trusted automation author.
 16. If a trusted base predates the evaluator/orchestrator during the one-time bootstrap, reusable workflows execute no proposed PR scripts and remain on the explicit external authority path.
+17. Every PR is Ready at creation. Draft state is a policy violation, not an implementation state.
 
 ## States
 
 | State | Meaning | Exit condition |
 |---|---|---|
-| `DRAFT` | Implementation is still changing | `status:ready` or explicit Ready |
+| `PR_CONTRACT_BLOCKED` | A PR was opened or converted to draft | explicit Ready state followed by fresh evaluation |
 | `READY_UNVERIFIED` | Merge intent exists; current head is unproven | `PR Gate` starts |
 | `GATE_RUNNING` | Deterministic evidence is running | pass, failure, timeout, skip, approval block, newer head |
 | `CI_REPAIR` | Copilot is repairing deterministic failure on the existing PR | new head or retry exhaustion |
@@ -49,12 +50,8 @@ flowchart TD
     B --> C{Copilot-owned PR?}
     C -- Yes --> C1[BLOCKED: re-home into non-Copilot PR]
     C -- No --> D{Draft?}
-    D -- Yes --> E[Disable auto-merge; spend no AI review]
-    E --> F{status:ready added?}
-    F -- No --> E
-    F -- Yes --> G[Mark Ready and remove status:ready]
+    D -- Yes --> E[BLOCKED: fail ready-at-creation contract]
     D -- No --> H[Classify risk and changed paths]
-    G --> H
     H --> I{Conflict?}
     I -- Yes --> J[Dependabot rebase or Copilot conflict repair]
     J --> A
@@ -88,11 +85,11 @@ flowchart TD
 
 | Event or condition | Detection | Automated action | Result |
 |---|---|---|---|
-| Draft opened | `pull_request_target.opened` | Remove forbidden reviewers; auto-merge off; no AI runner | `DRAFT` |
+| Draft opened | `pull_request_target.opened` | Disable auto-merge; apply `status:blocked`; post one diagnostic; fail workflow | `PR_CONTRACT_BLOCKED` |
 | Ready opened | PR event | Classify risk/path and arm auto-merge if eligible | `READY_UNVERIFIED` |
-| `status:ready` on draft | label event | Mark Ready; remove label | `READY_UNVERIFIED` |
-| Converted back to draft | `converted_to_draft` | Disable auto-merge; semantic runner stays idle | `DRAFT` |
-| Push while draft | `synchronize` | No semantic spend | `DRAFT` |
+| Converted to draft | `converted_to_draft` | Disable auto-merge; apply block; fail workflow; never auto-convert | `PR_CONTRACT_BLOCKED` |
+| Legacy draft explicitly made Ready | `ready_for_review` | Resolve the draft block and re-evaluate all current facts | `READY_UNVERIFIED` |
+| Push while draft | `synchronize` | Repeat the visible contract failure; never spend semantic-review budget | `PR_CONTRACT_BLOCKED` |
 | Push while Ready | new SHA | Old evidence becomes irrelevant; state restarts | `READY_UNVERIFIED` |
 | `kgsmith19` requested as reviewer | `review_requested` | Immediately remove requested reviewer; tag only later if authority is truly required | routine lane |
 | Stale workflow result | event SHA != current SHA | Ignore | unchanged |
@@ -173,6 +170,7 @@ This is not a generic waiting state. It means a concrete fact exists:
 - required workflow/check missing or skipped
 - reviewer safety timeout exceeded
 - risk labels contradictory
+- PR is draft or was converted to draft
 - no connected reviewer remains independent of all detected latest-head machine actors
 - PR is Copilot-owned and therefore platform-human-merge-only
 
@@ -193,8 +191,8 @@ That is intentionally different from GitHub requested-reviewer state.
 
 The implementation is incomplete until these canaries succeed:
 
-1. Draft: checks/review/merge remain paused.
-2. Ready label: `status:ready` promotes the draft.
+1. Ready-at-creation: a Ready canary enters `PR Gate` immediately.
+2. Draft rejection: a deliberate draft receives `status:blocked`, a failing contract diagnostic, no `gh pr ready`, and no auto-merge attempt.
 3. Happy path: gate passes, independent machine reviewer passes, GitHub auto-merges with no human action.
 4. Finding: deliberate formal or inline finding blocks; Copilot repairs existing PR; new head is independently reviewed; merge completes.
 5. CI failure: deliberate failure creates one bounded repair task and never weakens the gate.

--- a/policy/github-defaults.json
+++ b/policy/github-defaults.json
@@ -34,7 +34,6 @@
     "review_on_every_push": false
   },
   "pr_automation": {
-    "draft_ready_label": "status:ready",
     "blocked_label": "status:blocked",
     "max_ci_fix_attempts": 7,
     "max_review_fix_attempts": 1,

--- a/scripts/apply-github-standard.ps1
+++ b/scripts/apply-github-standard.ps1
@@ -41,7 +41,7 @@ $labels = @(
   @{ name='risk:R2'; color='F1C40F'; description='normal product/API change' },
   @{ name='risk:R3'; color='E67E22'; description='sensitive/control-plane boundary' },
   @{ name='risk:R4'; color='C0392B'; description='destructive/financial/privileged/irreversible' },
-  @{ name='status:ready'; color='0E8A16'; description='promote a coherent draft into the automated merge lane' },
+  @{ name='status:ready'; color='0E8A16'; description='Issue is approved for autonomous execution' },
   @{ name='status:blocked'; color='B60205'; description='bounded automation stopped on a real dependency/decision' }
 )
 

--- a/scripts/auto-merge.ps1
+++ b/scripts/auto-merge.ps1
@@ -22,7 +22,7 @@ $prRaw = & gh pr view $Pr --repo $Repo --json isDraft,state,labels,baseRefName,h
 if ($LASTEXITCODE -ne 0) { throw ($prRaw -join "`n") }
 $pr = ($prRaw -join "`n") | ConvertFrom-Json
 if ($pr.state -ne 'OPEN') { throw "PR #$Pr is not open." }
-if ($pr.isDraft) { throw "PR #$Pr is draft." }
+if ($pr.isDraft) { throw "Ready-at-creation policy violation: $Repo PR #$Pr is draft. Auto-merge was not attempted." }
 if (@($pr.labels | ForEach-Object { $_.name }) -contains 'status:blocked') { throw "PR #$Pr is status:blocked." }
 if ([string]$pr.author.login -eq 'Copilot' -or [string]$pr.headRefName -like 'copilot/*') {
   throw 'Copilot-cloud-agent-owned PRs require human review/merge by GitHub platform policy and cannot use the unattended lane.'

--- a/scripts/bootstrap-repo.ps1
+++ b/scripts/bootstrap-repo.ps1
@@ -138,7 +138,7 @@ Replace the bootstrap-only PR Gate with the smallest objective gate appropriate 
 - Preserve exact-SHA-pinned `.github/workflows/ai-review.yml` and `.github/workflows/pr-automation.yml`.
 - Extend `.github/dependabot.yml` only with package ecosystems this repo actually uses; group patch/minor updates when it reduces CI/review noise.
 - Keep native `.github/CODEOWNERS` absent so Kyle is never auto-requested as a routine reviewer.
-- Keep draft iteration quiet; `status:ready` promotes a coherent draft, then `PR Gate` + exact-head `AI Review` govern auto-merge.
+- Finish the coherent slice locally, then create the PR Ready. REST/SDK/connector callers set `draft:false`; `gh pr create` callers omit `--draft`.
 - Add only tests/tools justified by actual product risk; do not invent a framework for conformity.
 - Update `ci.gate_profile` away from `bootstrap-only`.
 

--- a/scripts/bootstrap-repo.ps1
+++ b/scripts/bootstrap-repo.ps1
@@ -138,7 +138,7 @@ Replace the bootstrap-only PR Gate with the smallest objective gate appropriate 
 - Preserve exact-SHA-pinned `.github/workflows/ai-review.yml` and `.github/workflows/pr-automation.yml`.
 - Extend `.github/dependabot.yml` only with package ecosystems this repo actually uses; group patch/minor updates when it reduces CI/review noise.
 - Keep native `.github/CODEOWNERS` absent so Kyle is never auto-requested as a routine reviewer.
-- Finish the coherent slice locally, then create the PR Ready. REST/SDK/connector callers set `draft:false`; `gh pr create` callers omit `--draft`.
+- Finish the coherent slice locally, then create the PR Ready. REST/SDK/connector callers set `draft:false`; CLI callers use the Ready default.
 - Add only tests/tools justified by actual product risk; do not invent a framework for conformity.
 - Update `ci.gate_profile` away from `bootstrap-only`.
 

--- a/scripts/doctor.ps1
+++ b/scripts/doctor.ps1
@@ -24,8 +24,8 @@ function Add-Problem {
 $required = @(
   'README.md','LIFECYCLE.md','AGENT_RULES.md','QUALITY_RULES.md','SECURITY_RISK_AUTONOMY.md','DELIVERY_GITHUB.md','EVIDENCE_LEARNING.md','AGENTS.md','docs/AUTONOMOUS-PR-STATE-MACHINE.md',
   '.github/workflows/ci.yml','.github/workflows/ai-review.yml','.github/workflows/ai-review-reusable.yml','.github/workflows/pr-automation.yml','.github/workflows/pr-automation-reusable.yml','policy/github-defaults.json',
-  'scripts/setup-portfolio.ps1','scripts/apply-github-standard.ps1','scripts/sync-agentic-project.ps1','scripts/codex-review.ps1','scripts/request-independent-review.ps1','scripts/request-machine-review.ps1','scripts/evaluate-ai-review.ps1','scripts/reconcile-machine-review-threads.ps1','scripts/auto-merge.ps1','scripts/pr-orchestrator.ps1','scripts/bootstrap-repo.ps1','scripts/upgrade-repos.ps1','scripts/prune-portfolio.ps1',
-  'scripts/lib/standard-lock.ps1','scripts/lib/review-policy.ps1','tests/legacy-protection.tests.ps1','tests/standard-lock.tests.ps1','tests/review-policy.tests.ps1','tests/standard-hygiene.tests.ps1',
+  'scripts/setup-portfolio.ps1','scripts/apply-github-standard.ps1','scripts/sync-agentic-project.ps1','scripts/codex-review.ps1','scripts/request-independent-review.ps1','scripts/request-machine-review.ps1','scripts/evaluate-ai-review.ps1','scripts/reconcile-machine-review-threads.ps1','scripts/auto-merge.ps1','scripts/pr-orchestrator.ps1','scripts/lint-pr-creation.ps1','scripts/bootstrap-repo.ps1','scripts/upgrade-repos.ps1','scripts/prune-portfolio.ps1',
+  'scripts/lib/standard-lock.ps1','scripts/lib/review-policy.ps1','tests/legacy-protection.tests.ps1','tests/standard-lock.tests.ps1','tests/review-policy.tests.ps1','tests/draft-prevention.tests.ps1','tests/standard-hygiene.tests.ps1',
   'templates/.gitignore','templates/AGENTS.md','templates/PR_GATE.yml','templates/AI_REVIEW.yml','templates/PR_AUTOMATION.yml','templates/dependabot.yml','templates/PRD.md','templates/SPEC.md','templates/ADR.md','templates/ISSUE.md','templates/PULL_REQUEST.md'
 )
 foreach ($relative in $required) {
@@ -52,7 +52,8 @@ if ([int]$review.absolute_timeout_minutes -le ([int]$review.primary_wait_minutes
 if ([bool]$review.review_drafts -or [bool]$review.review_on_every_push) { throw 'Draft/every-push AI review spend must remain off.' }
 
 $automation = $config.pr_automation
-if ($automation.draft_ready_label -ne 'status:ready' -or $automation.blocked_label -ne 'status:blocked') { throw 'PR state labels drifted.' }
+if ($automation.PSObject.Properties.Name -contains 'draft_ready_label') { throw 'Draft promotion must not exist in strict ready-at-creation policy.' }
+if ($automation.blocked_label -ne 'status:blocked') { throw 'PR blocked-state label drifted.' }
 foreach ($pair in @(@('max_ci_fix_attempts',7),@('max_review_fix_attempts',1),@('max_conflict_fix_attempts',6))) {
   if ([int]$automation.PSObject.Properties[$pair[0]].Value -ne [int]$pair[1]) { throw "Repair budget drifted: $($pair[0])." }
 }

--- a/scripts/evaluate-ai-review.ps1
+++ b/scripts/evaluate-ai-review.ps1
@@ -48,7 +48,7 @@ if ($LASTEXITCODE -ne 0) { throw ($prRaw -join "`n") }
 $prData = ($prRaw -join "`n") | ConvertFrom-Json
 $headSha = [string]$prData.head.sha
 if ($prData.draft) {
-  Set-AiReviewCheck $headSha failure 'Draft PR: machine review is intentionally deferred until Ready.'
+  Set-AiReviewCheck $headSha failure 'Ready-at-creation policy violation: draft PRs are forbidden.'
   exit 0
 }
 

--- a/scripts/lint-pr-creation.ps1
+++ b/scripts/lint-pr-creation.ps1
@@ -1,0 +1,35 @@
+param(
+  [string]$Root = (Resolve-Path (Join-Path $PSScriptRoot '..')).Path
+)
+
+$ErrorActionPreference = 'Stop'
+if (-not (Test-Path $Root -PathType Container)) { throw "Lint root does not exist: $Root" }
+
+$extensions = @('.ps1','.psm1','.sh','.bash','.js','.mjs','.cjs','.ts','.tsx','.py','.rb','.yml','.yaml','.json')
+$excludedDirectories = @('.git','.worktrees','.superpowers','docs','tests','node_modules','vendor')
+$patterns = @(
+  [pscustomobject]@{ name='gh draft flag'; regex='(?im)\bgh\s+pr\s+create\b[^\r\n]*(?:--draft|(?:^|\s)-d(?:\s|$))' },
+  [pscustomobject]@{ name='API or SDK draft true'; regex='(?im)(?:["'']?draft["'']?)\s*[:=]\s*(?:true|\$true)\b' }
+)
+
+$violations = New-Object System.Collections.Generic.List[string]
+$resolvedRoot = (Resolve-Path $Root).Path
+foreach ($file in Get-ChildItem $resolvedRoot -Recurse -File) {
+  if ($file.FullName -eq $PSCommandPath) { continue }
+  if ($extensions -notcontains $file.Extension.ToLowerInvariant()) { continue }
+  $relative = [System.IO.Path]::GetRelativePath($resolvedRoot,$file.FullName)
+  $segments = $relative -split '[\\/]'
+  if (@($segments | Where-Object { $excludedDirectories -contains $_ }).Count -gt 0) { continue }
+
+  $content = Get-Content $file.FullName -Raw
+  $normalized = $content -replace '(?m)`\s*\r?\n',' ' -replace '(?m)\\\s*\r?\n',' '
+  foreach ($pattern in $patterns) {
+    if ($normalized -match $pattern.regex) { $violations.Add("${relative}: $($pattern.name)") }
+  }
+}
+
+if ($violations.Count -gt 0) {
+  throw "Draft PR creation is forbidden. Create Ready with draft:false; gh callers must omit --draft and -d.`n$($violations -join "`n")"
+}
+
+Write-Host 'PR creation lint: PASS' -ForegroundColor Green

--- a/scripts/pr-orchestrator.ps1
+++ b/scripts/pr-orchestrator.ps1
@@ -184,14 +184,10 @@ function Ensure-PrState {
   if ($prData.state -ne 'OPEN') { return $prData }
   $labels = @($prData.labels | ForEach-Object { $_.name })
   if ($prData.isDraft) {
-    Disable-AutoMerge $Number $prData
-    if ($labels -notcontains $automation.draft_ready_label) { return $prData }
-    Invoke-WithAdminToken { & gh pr ready $Number --repo $Repo | Out-Host }
-    if ($LASTEXITCODE -ne 0) { throw "Could not mark $Repo PR #$Number Ready." }
-    & gh pr edit $Number --repo $Repo --remove-label $automation.draft_ready_label 2>&1 | Out-Null
-    $prData = Get-Pr $Number
-    $labels = @($prData.labels | ForEach-Object { $_.name })
+    Set-Blocked $Number 'draft-pr' 'Ready-at-creation policy violation. Agents must create pull requests with draft:false; gh callers must omit --draft.' $prData
+    throw "Ready-at-creation policy violation: $Repo PR #$Number is draft."
   }
+  Resolve-Block $Number 'draft-pr' 'The pull request is Ready.' $prData
   if ([string]$prData.author.login -eq 'Copilot' -or [string]$prData.headRefName -like 'copilot/*') {
     Set-Blocked $Number 'copilot-owned-pr' 'GitHub requires human review and merge for pull requests created by Copilot cloud agent. Use Copilot only on an existing non-Copilot PR, or re-home this work through a non-Copilot implementation lane.' $prData
     return $prData

--- a/scripts/request-machine-review.ps1
+++ b/scripts/request-machine-review.ps1
@@ -22,7 +22,7 @@ $prRaw = & gh api "repos/$Repo/pulls/$Pr" 2>&1
 if ($LASTEXITCODE -ne 0) { throw ($prRaw -join "`n") }
 $pr = ($prRaw -join "`n") | ConvertFrom-Json
 if ($pr.state -ne 'open') { throw "PR #$Pr is not open." }
-if ($pr.draft) { throw "PR #$Pr is draft; machine review is deferred until Ready." }
+if ($pr.draft) { throw "Ready-at-creation policy violation: $Repo PR #$Pr is draft." }
 
 $headSha = [string]$pr.head.sha
 $commitRaw = & gh api "repos/$Repo/commits/$headSha" 2>&1

--- a/scripts/upgrade-repos.ps1
+++ b/scripts/upgrade-repos.ps1
@@ -131,6 +131,10 @@ Risk: R3 control-plane dependency update. This bootstrap rollout is manually int
 "@
       $prUrl = (& gh pr create --repo $repo --base main --head $branch --title "Upgrade autonomous engineering standard to $short" --body $body 2>&1 | Out-String).Trim()
       if ($LASTEXITCODE -ne 0 -or -not $prUrl) { throw 'PR creation failed' }
+      $createdRaw = & gh pr view $prUrl --repo $repo --json number,url,isDraft 2>&1
+      if ($LASTEXITCODE -ne 0) { throw "PR created but its ready-at-creation postcondition could not be verified: $prUrl" }
+      $created = ($createdRaw -join "`n") | ConvertFrom-Json
+      if ([bool]$created.isDraft) { throw "Ready-at-creation policy violation: rollout PR #$($created.number) is draft: $($created.url)" }
       & gh pr edit $prUrl --add-label 'risk:R3' | Out-Host
       if ($LASTEXITCODE -ne 0) { throw "PR created but risk:R3 could not be applied: $prUrl" }
       Write-Host "created $prUrl" -ForegroundColor Green

--- a/templates/AGENTS.md
+++ b/templates/AGENTS.md
@@ -15,7 +15,7 @@ Do not invent consequential product decisions. Record a real blocker and stop th
 
 ## Lean delivery loop
 
-`Issue → SPEC only if needed → thin slice → RED/minimum GREEN → local verification → draft PR → Ready → PR Gate → exact-head AI Review → automatic squash merge → release`
+`Issue → SPEC only if needed → thin slice → RED/minimum GREEN → local verification → Ready PR → PR Gate → exact-head AI Review → automatic squash merge → release`
 
 - Work one thin slice at a time; scope widening becomes another slice or Issue.
 - Prefer the smallest correct implementation. Avoid speculative abstractions, dependencies, and unrelated refactors.
@@ -40,11 +40,14 @@ Use R0–R4. The implementing agent may raise risk, never lower it.
 - Any manual authority gate must state the failure prevented, why automation is insufficient, decision owner, and measurable removal condition.
 - Kyle may be tagged for authority, but must never be assigned as a routine GitHub reviewer.
 
-## Draft and Ready
+## PR creation contract
 
-Keep active implementation draft so micro-pushes do not spend semantic-review budget or arm merge.
+Complete and verify the coherent slice locally before opening its PR. Every PR is Ready at creation.
 
-When coherent and locally verified, add `status:ready`. Automation marks the PR Ready and removes the label. Converting back to draft pauses the lane again.
+- REST, SDK, GraphQL, and connector calls set `draft: false` and verify the returned state.
+- `gh pr create` omits `--draft`, then `gh pr view --json isDraft --jq .isDraft` must return `false`.
+- Never convert a Ready PR to draft and never use `gh pr ready` as a pipeline transition.
+- A draft is a policy failure: automation blocks it and never attempts auto-merge.
 
 Copilot cloud agent may repair an existing non-Copilot PR. Do not let Copilot cloud agent own/create a PR intended for unattended merge because GitHub requires those PRs to be human-reviewed and merged.
 
@@ -79,7 +82,7 @@ After `PR Gate` passes, automation requests one fresh machine review task/sessio
 
 Routine auto-merge requires:
 
-- non-draft, non-Copilot-owned PR
+- Ready-at-creation, non-Copilot-owned PR
 - eligible R0–R3 risk
 - no `status:blocked`
 - no self-modifying control-plane path

--- a/templates/PR_GATE.yml
+++ b/templates/PR_GATE.yml
@@ -2,7 +2,7 @@ name: PR Gate
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
+    types: [opened, synchronize, reopened, ready_for_review, converted_to_draft]
   merge_group:
 
 permissions:
@@ -14,13 +14,16 @@ concurrency:
 
 jobs:
   bootstrap-gate:
-    # Static check name: the job-level if already skips drafts, so the draft branch
-    # of a dynamic name can never render, and the ruleset requires the literal 'PR Gate'.
     name: PR Gate
-    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - name: Enforce Ready at creation
+        if: github.event_name == 'pull_request' && github.event.pull_request.draft
+        shell: bash
+        run: |
+          echo '::error::Ready-at-creation policy violation. Create PRs with draft:false; gh callers must omit --draft.'
+          exit 1
       - name: Verify bootstrap control files
         shell: bash
         run: |

--- a/templates/PULL_REQUEST.md
+++ b/templates/PULL_REQUEST.md
@@ -30,9 +30,9 @@ R0 / R1 / R2 / R3 / R4
 - [ ] Repeated manual work was automated in-scope or logged as one bounded candidate
 - [ ] `kgsmith19` is not requested as a reviewer
 
-## Draft / Ready
-- Keep Draft while implementation changes.
-- Add `status:ready` only when the coherent PR should enter the automated gate/review/merge lane.
+## Ready-at-creation contract
+- [ ] This PR was opened Ready, never Draft.
+- [ ] Its creation call used `draft: false`, or `gh pr create` without `--draft`.
 
 ## Authority Gate (only when actually required)
 None, or state all four:

--- a/tests/draft-prevention.tests.ps1
+++ b/tests/draft-prevention.tests.ps1
@@ -1,0 +1,58 @@
+$ErrorActionPreference = 'Stop'
+$root = (Resolve-Path (Join-Path $PSScriptRoot '..')).Path
+$temp = Join-Path ([System.IO.Path]::GetTempPath()) ("draft-prevention-" + [guid]::NewGuid().ToString('N'))
+$oldPath = $env:PATH
+$oldLog = $env:GH_FAKE_LOG
+
+function Assert-True {
+  param([string]$Name,$Condition)
+  if (-not $Condition) { throw "$Name failed." }
+}
+
+try {
+  New-Item -ItemType Directory -Path $temp | Out-Null
+  $log = Join-Path $temp 'gh.log'
+  $fakeGh = Join-Path $temp 'gh'
+  @'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >> "$GH_FAKE_LOG"
+
+if [[ "$1 $2" == "pr view" ]]; then
+  printf '%s\n' '{"number":17,"state":"OPEN","isDraft":true,"labels":[],"headRefOid":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","headRefName":"agent/17-test","baseRefName":"main","author":{"login":"kgsmith19"},"autoMergeRequest":null,"mergeable":"MERGEABLE","title":"draft contract test","updatedAt":"2026-08-09T00:00:00Z"}'
+elif [[ "$1" == "api" && "$*" == *"requested_reviewers"* ]]; then
+  printf '%s\n' '{"users":[]}'
+elif [[ "$1" == "api" && "$*" == *"issues/17/comments"* ]]; then
+  printf '%s\n' '[[]]'
+elif [[ "$1 $2" == "pr edit" || "$1 $2" == "pr comment" ]]; then
+  :
+else
+  printf 'unexpected fake gh call: %s\n' "$*" >&2
+  exit 91
+fi
+'@ | Set-Content $fakeGh -Encoding utf8 -NoNewline
+  & chmod +x $fakeGh
+  if ($LASTEXITCODE -ne 0) { throw 'Could not make fake gh executable.' }
+
+  $env:GH_FAKE_LOG = $log
+  $env:PATH = "$temp$([System.IO.Path]::PathSeparator)$oldPath"
+
+  $failure = $null
+  try {
+    & (Join-Path $root 'scripts/pr-orchestrator.ps1') -Mode pr-event -Repo 'kgsmith19/example' -Pr 17
+  }
+  catch { $failure = $_.Exception.Message }
+
+  Assert-True 'draft PR fails the workflow contract' ($failure -match 'ready-at-creation')
+  $calls = Get-Content $log -Raw
+  Assert-True 'draft PR is visibly blocked' ($calls -match 'pr edit 17 --repo kgsmith19/example --add-label status:blocked')
+  Assert-True 'draft PR receives one actionable diagnostic' ($calls -match 'pr comment 17 --repo kgsmith19/example')
+  Assert-True 'draft PR never reaches auto-merge' ($calls -notmatch 'pr merge 17 .* --auto')
+}
+finally {
+  $env:PATH = $oldPath
+  $env:GH_FAKE_LOG = $oldLog
+  Remove-Item -Recurse -Force $temp -ErrorAction SilentlyContinue
+}
+
+Write-Host 'draft-prevention tests: PASS' -ForegroundColor Green

--- a/tests/draft-prevention.tests.ps1
+++ b/tests/draft-prevention.tests.ps1
@@ -19,7 +19,7 @@ set -euo pipefail
 printf '%s\n' "$*" >> "$GH_FAKE_LOG"
 
 if [[ "$1 $2" == "pr view" ]]; then
-  printf '%s\n' '{"number":17,"state":"OPEN","isDraft":true,"labels":[],"headRefOid":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","headRefName":"agent/17-test","baseRefName":"main","author":{"login":"kgsmith19"},"autoMergeRequest":null,"mergeable":"MERGEABLE","title":"draft contract test","updatedAt":"2026-08-09T00:00:00Z"}'
+  printf '%s\n' '{"number":17,"state":"OPEN","isDraft":true,"labels":[{"name":"status:ready"}],"headRefOid":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","headRefName":"agent/17-test","baseRefName":"main","author":{"login":"kgsmith19"},"autoMergeRequest":null,"mergeable":"MERGEABLE","title":"draft contract test","updatedAt":"2026-08-09T00:00:00Z"}'
 elif [[ "$1" == "api" && "$*" == *"requested_reviewers"* ]]; then
   printf '%s\n' '{"users":[]}'
 elif [[ "$1" == "api" && "$*" == *"issues/17/comments"* ]]; then
@@ -47,7 +47,22 @@ fi
   $calls = Get-Content $log -Raw
   Assert-True 'draft PR is visibly blocked' ($calls -match 'pr edit 17 --repo kgsmith19/example --add-label status:blocked')
   Assert-True 'draft PR receives one actionable diagnostic' ($calls -match 'pr comment 17 --repo kgsmith19/example')
+  Assert-True 'draft PR is never auto-converted' ($calls -notmatch 'pr ready 17')
   Assert-True 'draft PR never reaches auto-merge' ($calls -notmatch 'pr merge 17 .* --auto')
+
+  $fixture = Join-Path $temp 'lint-fixture'
+  New-Item -ItemType Directory -Path (Join-Path $fixture 'scripts') | Out-Null
+  Set-Content (Join-Path $fixture 'scripts/good.ps1') 'gh pr create --repo owner/repo --base main --head agent/17-test --title test --body ok' -NoNewline
+  Set-Content (Join-Path $fixture 'scripts/bad.ps1') 'gh pr create --repo owner/repo --base main --head agent/18-test --draft --title test --body bad' -NoNewline
+
+  $lintFailure = $null
+  try { & (Join-Path $root 'scripts/lint-pr-creation.ps1') -Root $fixture }
+  catch { $lintFailure = $_.Exception.Message }
+  Assert-True 'PR creation lint rejects --draft' ($lintFailure -match 'bad\.ps1')
+
+  Remove-Item (Join-Path $fixture 'scripts/bad.ps1')
+  & (Join-Path $root 'scripts/lint-pr-creation.ps1') -Root $fixture
+  Assert-True 'PR creation lint accepts Ready gh creation' ($LASTEXITCODE -eq 0)
 }
 finally {
   $env:PATH = $oldPath

--- a/tests/review-policy.tests.ps1
+++ b/tests/review-policy.tests.ps1
@@ -72,7 +72,7 @@ Assert-Equal 'Post-fix finding head exhausts one-repair budget' (Get-ReviewRepai
 Assert-Throws 'Repair budget must be positive' { Get-ReviewRepairDecision -HeadSha $head -AttemptedHeadShas @() -MaxAttempts 0 -HasFindings $true }
 
 Assert-Equal 'No risk label defaults to R2' (Get-RiskFromLabels @()) 'R2'
-Assert-Equal 'Single risk label is parsed' (Get-RiskFromLabels @('risk:R3','status:ready')) 'R3'
+Assert-Equal 'Single risk label is parsed' (Get-RiskFromLabels @('risk:R3','status:blocked')) 'R3'
 Assert-Throws 'Multiple risk labels fail closed' { Get-RiskFromLabels @('risk:R1','risk:R3') }
 
 Assert-Equal 'Workflow is control plane' (Test-ControlPlanePath '.github/workflows/pr-gate.yml') $true

--- a/tests/standard-hygiene.tests.ps1
+++ b/tests/standard-hygiene.tests.ps1
@@ -9,7 +9,8 @@ function Assert-NotContains { param([string]$Name,[string]$Path,[string]$Pattern
 $required = @(
   '.gitignore','docs/AUTONOMOUS-PR-STATE-MACHINE.md',
   '.github/workflows/ai-review-reusable.yml','.github/workflows/pr-automation-reusable.yml','.github/workflows/pr-automation.yml',
-  'scripts/evaluate-ai-review.ps1','scripts/request-machine-review.ps1','scripts/request-review-repair.ps1','scripts/reconcile-machine-review-threads.ps1','scripts/pr-orchestrator.ps1','scripts/prune-portfolio.ps1',
+  'scripts/evaluate-ai-review.ps1','scripts/request-machine-review.ps1','scripts/request-review-repair.ps1','scripts/reconcile-machine-review-threads.ps1','scripts/pr-orchestrator.ps1','scripts/lint-pr-creation.ps1','scripts/prune-portfolio.ps1',
+  'tests/draft-prevention.tests.ps1',
   'templates/.gitignore','templates/AI_REVIEW.yml','templates/PR_AUTOMATION.yml','templates/dependabot.yml'
 )
 foreach ($relative in $required) { Assert-True "required file $relative" (Test-Path (Join-Path $root $relative)) }


### PR DESCRIPTION
## Coordination

Stacked on Claude-owned PR #46. This PR does not push to or rewrite Claude's branch. Claude can merge this branch into #46 without rebasing either branch.

## Architecture

Strict Path A: every agent opens a Ready PR at creation.

- REST, SDK, GraphQL, and connector calls set `draft: false` and verify the response.
- `gh pr create` omits `--draft` and verifies `isDraft == false`.
- Draft conversion is removed from the steady-state lane.
- A draft event applies `status:blocked`, emits one actionable failure, and stops before auto-merge.
- Executable source lint rejects `--draft`, `-d`, and `draft: true`.

## TDD evidence

- RED run 31332061670: the orchestrator silently accepted a draft.
- RED run 31332217427: the new creation lint was absent.
- GREEN run 31332676602: PR Gate, behavioral draft test, creation lint, hygiene, and doctor all passed.

## Scope

Updates the central policy, orchestrator, CLI rollout postcondition, PR Gate/template enforcement, agent templates, and authoritative docs. Existing product callers receive this through the next exact-SHA standard rollout.

Risk: R3 control plane.