### PR TITLE
Fix typed PR-number shadowing in automation entrypoints

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,9 @@ jobs:
       - name: Test ready-at-creation enforcement
         shell: pwsh
         run: ./tests/draft-prevention.tests.ps1
+      - name: Test automation entrypoints
+        shell: pwsh
+        run: ./tests/automation-entrypoints.tests.ps1
       - name: Lint PR creation contract
         shell: pwsh
         run: ./scripts/lint-pr-creation.ps1

--- a/scripts/auto-merge.ps1
+++ b/scripts/auto-merge.ps1
@@ -20,15 +20,15 @@ $config = Get-Content (Join-Path $PSScriptRoot '..\policy\github-defaults.json')
 
 $prRaw = & gh pr view $Pr --repo $Repo --json isDraft,state,labels,baseRefName,headRefName,author 2>&1
 if ($LASTEXITCODE -ne 0) { throw ($prRaw -join "`n") }
-$pr = ($prRaw -join "`n") | ConvertFrom-Json
-if ($pr.state -ne 'OPEN') { throw "PR #$Pr is not open." }
-if ($pr.isDraft) { throw "Ready-at-creation policy violation: $Repo PR #$Pr is draft. Auto-merge was not attempted." }
-if (@($pr.labels | ForEach-Object { $_.name }) -contains 'status:blocked') { throw "PR #$Pr is status:blocked." }
-if ([string]$pr.author.login -eq 'Copilot' -or [string]$pr.headRefName -like 'copilot/*') {
+$prData = ($prRaw -join "`n") | ConvertFrom-Json
+if ($prData.state -ne 'OPEN') { throw "PR #$Pr is not open." }
+if ($prData.isDraft) { throw "Ready-at-creation policy violation: $Repo PR #$Pr is draft. Auto-merge was not attempted." }
+if (@($prData.labels | ForEach-Object { $_.name }) -contains 'status:blocked') { throw "PR #$Pr is status:blocked." }
+if ([string]$prData.author.login -eq 'Copilot' -or [string]$prData.headRefName -like 'copilot/*') {
   throw 'Copilot-cloud-agent-owned PRs require human review/merge by GitHub platform policy and cannot use the unattended lane.'
 }
 
-$labelRisk = Get-RiskFromLabels @($pr.labels | ForEach-Object { $_.name })
+$labelRisk = Get-RiskFromLabels @($prData.labels | ForEach-Object { $_.name })
 if ($Risk -ne $labelRisk) { throw "Risk mismatch: caller supplied $Risk but PR labels resolve to $labelRisk." }
 $riskNumber = [int]$Risk.Substring(1)
 $maxRisk = [int]([string]$config.auto_merge_max_risk).Substring(1)
@@ -54,7 +54,7 @@ if ($controlPlane -and [bool]$config.manual_gates.control_plane.required) {
 $metaRaw = Invoke-WithAdminToken { & gh api "repos/$Repo" 2>&1 }
 if ($LASTEXITCODE -ne 0) { throw "Cannot inspect live repository settings for $Repo." }
 $meta = ($metaRaw -join "`n") | ConvertFrom-Json
-if ($pr.baseRefName -ne $meta.default_branch) { throw "PR targets '$($pr.baseRefName)', not protected default branch '$($meta.default_branch)'." }
+if ($prData.baseRefName -ne $meta.default_branch) { throw "PR targets '$($prData.baseRefName)', not protected default branch '$($meta.default_branch)'." }
 if (-not $meta.allow_auto_merge) { throw 'Live GitHub setting drift: auto-merge is off.' }
 if (-not $meta.allow_update_branch) { throw 'Live GitHub setting drift: update branch is off.' }
 if (-not $meta.allow_squash_merge -or $meta.allow_merge_commit -or $meta.allow_rebase_merge) { throw 'Live GitHub merge policy is not squash-only.' }

--- a/scripts/doctor.ps1
+++ b/scripts/doctor.ps1
@@ -25,7 +25,7 @@ $required = @(
   'README.md','LIFECYCLE.md','AGENT_RULES.md','QUALITY_RULES.md','SECURITY_RISK_AUTONOMY.md','DELIVERY_GITHUB.md','EVIDENCE_LEARNING.md','AGENTS.md','docs/AUTONOMOUS-PR-STATE-MACHINE.md',
   '.github/workflows/ci.yml','.github/workflows/ai-review.yml','.github/workflows/ai-review-reusable.yml','.github/workflows/pr-automation.yml','.github/workflows/pr-automation-reusable.yml','policy/github-defaults.json',
   'scripts/setup-portfolio.ps1','scripts/apply-github-standard.ps1','scripts/codex-review.ps1','scripts/request-independent-review.ps1','scripts/request-machine-review.ps1','scripts/evaluate-ai-review.ps1','scripts/reconcile-machine-review-threads.ps1','scripts/auto-merge.ps1','scripts/pr-orchestrator.ps1','scripts/gate-result-router.ps1','scripts/review-metrics.ps1','scripts/lint-pr-creation.ps1','scripts/bootstrap-repo.ps1','scripts/upgrade-repos.ps1','scripts/prune-portfolio.ps1',
-  'scripts/lib/standard-lock.ps1','scripts/lib/review-policy.ps1','tests/legacy-protection.tests.ps1','tests/standard-lock.tests.ps1','tests/review-policy.tests.ps1','tests/draft-prevention.tests.ps1','tests/standard-hygiene.tests.ps1',
+  'scripts/lib/standard-lock.ps1','scripts/lib/review-policy.ps1','tests/legacy-protection.tests.ps1','tests/standard-lock.tests.ps1','tests/review-policy.tests.ps1','tests/draft-prevention.tests.ps1','tests/automation-entrypoints.tests.ps1','tests/standard-hygiene.tests.ps1',
   'templates/.gitignore','templates/AGENTS.md','templates/PR_GATE.yml','templates/AI_REVIEW.yml','templates/PR_AUTOMATION.yml','templates/dependabot.yml','templates/PRD.md','templates/SPEC.md','templates/ADR.md','templates/ISSUE.md','templates/PULL_REQUEST.md'
 )
 foreach ($relative in $required) {

--- a/scripts/request-machine-review.ps1
+++ b/scripts/request-machine-review.ps1
@@ -24,12 +24,12 @@ function Get-Paged {
 
 $prRaw = & gh api "repos/$Repo/pulls/$Pr" 2>&1
 if ($LASTEXITCODE -ne 0) { throw ($prRaw -join "`n") }
-$pr = ($prRaw -join "`n") | ConvertFrom-Json
-if ($pr.state -ne 'open') { throw "PR #$Pr is not open." }
-if ($pr.draft) { throw "Ready-at-creation policy violation: $Repo PR #$Pr is draft." }
+$prData = ($prRaw -join "`n") | ConvertFrom-Json
+if ($prData.state -ne 'open') { throw "PR #$Pr is not open." }
+if ($prData.draft) { throw "Ready-at-creation policy violation: $Repo PR #$Pr is draft." }
 
-$headSha = [string]$pr.head.sha
-$prAuthor = [string]$pr.user.login
+$headSha = [string]$prData.head.sha
+$prAuthor = [string]$prData.user.login
 $prCommits = @(Get-Paged "repos/$Repo/pulls/$Pr/commits?per_page=100")
 $actorLogins = @($prCommits | ForEach-Object { [string]$_.author.login; [string]$_.committer.login } | Where-Object { $_ })
 $implementers = @(Get-MachineImplementerProvidersForActors -ActorLogins $actorLogins -PrAuthorLogin $prAuthor)

--- a/tests/automation-entrypoints.tests.ps1
+++ b/tests/automation-entrypoints.tests.ps1
@@ -1,0 +1,128 @@
+$ErrorActionPreference = 'Stop'
+$root = (Resolve-Path (Join-Path $PSScriptRoot '..')).Path
+$temp = Join-Path ([System.IO.Path]::GetTempPath()) ("automation-entrypoints-" + [guid]::NewGuid().ToString('N'))
+$oldPath = $env:PATH
+$oldLog = $env:GH_FAKE_LOG
+$oldScenario = $env:GH_FAKE_SCENARIO
+
+function Assert-True {
+  param([string]$Name,$Condition)
+  if (-not $Condition) { throw "$Name failed." }
+}
+
+try {
+  New-Item -ItemType Directory -Path $temp | Out-Null
+  $log = Join-Path $temp 'gh.log'
+  $fakeGh = Join-Path $temp 'gh'
+  @'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >> "$GH_FAKE_LOG"
+
+if [[ "$GH_FAKE_SCENARIO" == "auto-merge-drift" || "$GH_FAKE_SCENARIO" == "auto-merge-ready" ]]; then
+  if [[ "$1 $2" == "pr view" ]]; then
+    printf '%s\n' '{"state":"OPEN","isDraft":false,"labels":[{"name":"risk:R2"}],"baseRefName":"main","headRefName":"dependabot/npm_and_yarn/example","author":{"login":"dependabot[bot]"}}'
+  elif [[ "$1" == "api" && "$*" == *"requested_reviewers"* ]]; then
+    printf '%s\n' '{"users":[]}'
+  elif [[ "$1" == "api" && "$*" == *"pulls/17/files"* ]]; then
+    printf '%s\n' 'package-lock.json'
+  elif [[ "$*" == "api repos/kgsmith19/example" ]]; then
+    if [[ "$GH_FAKE_SCENARIO" == "auto-merge-drift" ]]; then
+      printf '%s\n' '{"default_branch":"main","allow_auto_merge":false,"allow_update_branch":true,"allow_squash_merge":true,"allow_merge_commit":false,"allow_rebase_merge":false}'
+    else
+      printf '%s\n' '{"default_branch":"main","allow_auto_merge":true,"allow_update_branch":true,"allow_squash_merge":true,"allow_merge_commit":false,"allow_rebase_merge":false}'
+    fi
+  elif [[ "$*" == "api /apps/github-actions" ]]; then
+    printf '%s\n' '{"id":15368}'
+  elif [[ "$1" == "api" && "$*" == *"rules/branches/main"* ]]; then
+    printf '%s\n' '[[{"ruleset_id":101}]]'
+  elif [[ "$1" == "api" && "$*" == *"rulesets?per_page=100"* ]]; then
+    printf '%s\n' '[[{"id":101,"name":"Lean PR Gate","target":"branch","enforcement":"active"}]]'
+  elif [[ "$*" == "api repos/kgsmith19/example/rulesets/101" ]]; then
+    printf '%s\n' '{"enforcement":"active","bypass_actors":[],"conditions":{"ref_name":{"include":["~DEFAULT_BRANCH"]}},"rules":[{"type":"pull_request","parameters":{"required_approving_review_count":0,"require_code_owner_review":false,"require_last_push_approval":false,"dismiss_stale_reviews_on_push":true,"required_review_thread_resolution":false,"allowed_merge_methods":["squash"]}},{"type":"required_status_checks","parameters":{"required_status_checks":[{"context":"PR Gate","integration_id":15368}]}}]}'
+  elif [[ "$1 $2" == "pr merge" && "$*" == *"--auto --squash"* ]]; then
+    :
+  else
+    printf 'unexpected auto-merge fake gh call: %s\n' "$*" >&2
+    exit 91
+  fi
+elif [[ "$GH_FAKE_SCENARIO" == "review-request" ]]; then
+  if [[ "$*" == "api repos/kgsmith19/example/pulls/17" ]]; then
+    printf '%s\n' '{"state":"open","draft":false,"head":{"sha":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"},"user":{"login":"dependabot[bot]"}}'
+  elif [[ "$1" == "api" && "$*" == *"pulls/17/commits"* ]]; then
+    printf '%s\n' '[[{"author":{"login":"dependabot[bot]"},"committer":{"login":"dependabot[bot]"}}]]'
+  elif [[ "$1" == "api" && "$*" == *"pulls/17/reviews"* ]]; then
+    printf '%s\n' '[[]]'
+  elif [[ "$1" == "api" && "$*" == *"pulls/17/comments"* ]]; then
+    printf '%s\n' '[[]]'
+  elif [[ "$1" == "api" && "$*" == *"issues/17/comments"* ]]; then
+    printf '%s\n' '[[]]'
+  elif [[ "$1 $2" == "pr comment" ]]; then
+    :
+  else
+    printf 'unexpected review-request fake gh call: %s\n' "$*" >&2
+    exit 92
+  fi
+else
+  printf 'unknown fake gh scenario: %s\n' "$GH_FAKE_SCENARIO" >&2
+  exit 93
+fi
+'@ | Set-Content $fakeGh -Encoding utf8 -NoNewline
+  & chmod +x $fakeGh
+  if ($LASTEXITCODE -ne 0) { throw 'Could not make fake gh executable.' }
+
+  $env:GH_FAKE_LOG = $log
+  $env:PATH = "$temp$([System.IO.Path]::PathSeparator)$oldPath"
+
+  $env:GH_FAKE_SCENARIO = 'auto-merge-drift'
+  $autoMergeFailure = $null
+  try {
+    & (Join-Path $root 'scripts/auto-merge.ps1') -Repo 'kgsmith19/example' -Pr 17 -Risk R2
+  }
+  catch { $autoMergeFailure = $_.Exception.Message }
+
+  Assert-True 'auto-merge reaches the real live-setting diagnostic' ($autoMergeFailure -match 'Live GitHub setting drift: auto-merge is off')
+  Assert-True 'auto-merge does not overwrite the typed PR number with PR JSON' ($autoMergeFailure -notmatch 'PSCustomObject.*System.Int32')
+
+  Clear-Content $log
+  $env:GH_FAKE_SCENARIO = 'auto-merge-ready'
+  $readyFailure = $null
+  try {
+    & (Join-Path $root 'scripts/auto-merge.ps1') -Repo 'kgsmith19/example' -Pr 17 -Risk R2
+  }
+  catch { $readyFailure = $_.Exception.Message }
+
+  Assert-True 'eligible dependency PR passes the unchanged live policy checks' (-not $readyFailure)
+  $readyCalls = Get-Content $log -Raw
+  Assert-True 'eligible dependency PR arms native squash auto-merge' ($readyCalls -match 'pr merge 17 --repo kgsmith19/example --auto --squash')
+  Assert-True 'arming path verifies the GitHub Actions-bound PR Gate ruleset' ($readyCalls -match 'api repos/kgsmith19/example/rulesets/101')
+
+  $fixture = Join-Path $temp 'review-fixture'
+  New-Item -ItemType Directory -Path (Join-Path $fixture 'scripts/lib') -Force | Out-Null
+  New-Item -ItemType Directory -Path (Join-Path $fixture 'policy') -Force | Out-Null
+  Copy-Item (Join-Path $root 'scripts/request-machine-review.ps1') (Join-Path $fixture 'scripts/request-machine-review.ps1')
+  Copy-Item (Join-Path $root 'scripts/lib/review-policy.ps1') (Join-Path $fixture 'scripts/lib/review-policy.ps1')
+  $enabledConfig = Get-Content (Join-Path $root 'policy/github-defaults.json') -Raw | ConvertFrom-Json
+  $enabledConfig.independent_review.dispatch_mode = 'enabled'
+  $enabledConfig | ConvertTo-Json -Depth 20 | Set-Content (Join-Path $fixture 'policy/github-defaults.json') -Encoding utf8
+
+  Clear-Content $log
+  $env:GH_FAKE_SCENARIO = 'review-request'
+  $reviewFailure = $null
+  try {
+    & (Join-Path $fixture 'scripts/request-machine-review.ps1') -Repo 'kgsmith19/example' -Pr 17 -Provider auto
+  }
+  catch { $reviewFailure = $_.Exception.Message }
+
+  Assert-True 'review requester accepts parsed PR JSON without changing the typed PR number' (-not $reviewFailure)
+  $calls = Get-Content $log -Raw
+  Assert-True 'review requester reaches the independent reviewer request' ($calls -match 'pr comment 17 --repo kgsmith19/example')
+}
+finally {
+  $env:PATH = $oldPath
+  $env:GH_FAKE_LOG = $oldLog
+  $env:GH_FAKE_SCENARIO = $oldScenario
+  Remove-Item -Recurse -Force $temp -ErrorAction SilentlyContinue
+}
+
+Write-Host 'automation-entrypoints tests: PASS' -ForegroundColor Green

--- a/tests/standard-hygiene.tests.ps1
+++ b/tests/standard-hygiene.tests.ps1
@@ -10,7 +10,7 @@ $required = @(
   '.gitignore','docs/AUTONOMOUS-PR-STATE-MACHINE.md',
   '.github/workflows/ai-review-reusable.yml','.github/workflows/pr-automation-reusable.yml','.github/workflows/pr-automation.yml',
   'scripts/evaluate-ai-review.ps1','scripts/request-machine-review.ps1','scripts/request-review-repair.ps1','scripts/reconcile-machine-review-threads.ps1','scripts/pr-orchestrator.ps1','scripts/gate-result-router.ps1','scripts/review-metrics.ps1','scripts/lint-pr-creation.ps1','scripts/prune-portfolio.ps1',
-  'tests/draft-prevention.tests.ps1','tests/state-machine-exhaustiveness.tests.ps1',
+  'tests/draft-prevention.tests.ps1','tests/automation-entrypoints.tests.ps1','tests/state-machine-exhaustiveness.tests.ps1',
   'templates/.gitignore','templates/AI_REVIEW.yml','templates/PR_AUTOMATION.yml','templates/dependabot.yml'
 )
 foreach ($relative in $required) { Assert-True "required file $relative" (Test-Path (Join-Path $root $relative)) }


### PR DESCRIPTION
Refs #52.

## Root cause

`auto-merge.ps1` and `request-machine-review.ps1` each declare `[int]$Pr`, then assign parsed PR JSON to `$pr`. PowerShell variable names are case-insensitive, so the object assignment targets the typed integer parameter and fails before the real policy decision.

This is the exact failure observed in ACC UI PRs #10-#13 and in the reviewer-request job that was later mislabeled as a reviewer-budget problem.

## Change

- Keep the typed PR number as `$Pr`.
- Store parsed JSON as `$prData` in both entrypoints.
- Add fake-`gh` regression coverage for the prior collision, the precise live-setting diagnostic, a fully eligible R2 dependency PR arming native squash auto-merge, and the reviewer-request path.
- Register the regression in `PR Gate` and local doctor.

No risk, draft, control-plane, ruleset, approval, bypass, merge-method, or required-check gate is changed.

## Evidence

- RED reproduced locally before the rename.
- GREEN: all PowerShell tests, PR-creation lint, `git diff --check`, and `doctor.ps1` (`LOCAL: READY`).
- Exact-head `PR Gate`: https://github.com/kgsmith19/agent-engineering-standard/actions/runs/31341061147 (`success`).
- Independent control-plane diff review: PASS, no P0-P2 findings.

## Rollout containment

This PR fixes the shared incident defect, but it is not the full #52 correction. Its base includes the quarantined `84e8413` control-plane revision. Do **not** advance product caller pins to this PR's eventual merge SHA until every remaining #52 acceptance criterion and the exact-head live canary pass.

Only after one full standard SHA is proven: roll that SHA to consumers, manually integrate the R3 caller changes, run `scripts/setup-portfolio.ps1` once with Administration-capable GitHub CLI credentials, require `REMOTE: READY`, and prove a real low-risk dependency auto-merge canary.