### PR TITLE
feat: single-trigger fleet-wide standard propagation (closes the content-propagation gap, adds idempotent rollout PRs)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,9 @@ jobs:
       - name: "Gate: Script Smoke Tests"
         shell: pwsh
         run: ./tests/script-smoke.tests.ps1
+      - name: "Gate: Upgrade-Repos Rollout Tests"
+        shell: pwsh
+        run: ./tests/upgrade-repos.tests.ps1
       - name: "Gate: Automation Entrypoint Tests"
         shell: pwsh
         run: ./tests/automation-entrypoints.tests.ps1

--- a/.github/workflows/ops-portfolio-bootstrap.yml
+++ b/.github/workflows/ops-portfolio-bootstrap.yml
@@ -2,6 +2,8 @@ name: "Ops: Portfolio Bootstrap"
 
 on:
   workflow_dispatch:
+  push:
+    branches: [main]
   schedule:
     - cron: "41 6 * * 1"
 

--- a/docs/superpowers/specs/2026-08-10-single-trigger-portfolio-propagation-design.md
+++ b/docs/superpowers/specs/2026-08-10-single-trigger-portfolio-propagation-design.md
@@ -1,0 +1,83 @@
+# Single-Trigger Fleet-Wide Standard Propagation
+
+Status: approved by Kyle on 2026-08-10
+Tracks: #57
+
+## Outcome
+
+A merge to `agent-engineering-standard`'s `main` propagates settings, content, and drift
+verification to every managed repo in one automatic run -- no manual step required, and
+re-running never creates a duplicate PR.
+
+## Problem
+
+`ops-portfolio-bootstrap.yml` only ran on `workflow_dispatch` and a weekly `schedule`; a
+merge to `main` did not trigger it. Even when it did run, `setup-portfolio.ps1` called
+`apply-github-standard.ps1` (settings) then `doctor.ps1 -Remote` (verification), but never
+`upgrade-repos.ps1` (the script that pins the new standard SHA into each product repo's
+`.agent/standard.lock` and regenerates its thin-caller workflows). So the content half of
+the standard has never actually propagated as part of any automated run -- only settings
+did.
+
+Separately, `upgrade-repos.ps1` names its rollout branch `chore/standard-<short-sha-of-the-
+new-commit>` and only checks for an existing open PR on that exact branch name. Every new
+standard commit therefore produced a brand-new branch and PR, leaving any prior still-open
+rollout PR stale and orphaned. This is exactly what happened in practice: three real rollout
+PRs went stale this way and had to be manually reconciled.
+
+## Chosen approach
+
+Three small, targeted changes, all in this repo:
+
+1. **Trigger.** Add `push: branches: [main]` to `ops-portfolio-bootstrap.yml`'s `on:`
+   block, alongside the existing `workflow_dispatch` and weekly `schedule`. The
+   AUTOMATION_TOKEN identity check, concurrency group, and permissions are unchanged --
+   the bootstrap lane still fails closed without the dedicated automation identity.
+
+2. **Content propagation.** `setup-portfolio.ps1` now runs
+   `apply-github-standard.ps1` -> `upgrade-repos.ps1` -> `doctor.ps1 -Remote`: apply
+   settings, then pin the content SHA and regenerate thin-caller workflows in every
+   product repo, then verify the resulting remote state matches. Each step throws with a
+   clear message on nonzero exit, matching the existing style.
+
+3. **Idempotent rollout PRs.** `upgrade-repos.ps1` now searches for ANY open PR in the
+   target repo whose head branch matches the glob `chore/standard-*`, not just the exact
+   new branch name. If one exists, the regenerated content is force-pushed onto that same
+   branch instead of opening a new branch/PR. If none exists, behavior is unchanged:
+   create `chore/standard-<short-sha>` and open a new PR. One rollout PR stays open per
+   repo, ever, and it always carries the current standard.
+
+## Auto-merge posture
+
+Rollout PRs now relabel from `risk:R3` to `risk:R2`. The propagated content was already
+reviewed once, at this repo's own PR gate; deterministically regenerating identical,
+template-driven content into product repos is not new independent risk, and this design's
+auto-merge ceiling (unattended auto-merge is capped at R2, per
+`docs/superpowers/specs/2026-08-09-all-13-github-automation-design.md`) already anticipated
+this exact class of change. `upgrade-repos.ps1` only ever writes to known, template-driven
+paths (`.agent/standard.lock`, `.agent/project.yaml`, the `AI Review` / `PR Automation`
+caller workflows, `.github/dependabot.yml`, and the `ci.yml` name normalization) -- never
+arbitrary content.
+
+The mechanism change in this repo (the trigger, the propagation step, and the reuse-PR
+logic) is itself `risk:R3`, control-plane: it changes what governs later unattended merges
+across the fleet, so it is not itself eligible for unattended auto-merge.
+
+## Rejected alternatives
+
+- Leaving the weekly schedule as the only propagation path: correct eventually, but leaves
+  up to a week of drift between a merged standard change and every product repo picking it
+  up, and does nothing about the orphaned-PR problem.
+- Deleting and recreating the rollout PR on every new standard commit instead of reusing
+  the branch: preserves history and review state worse than reusing the branch, and still
+  produces PR churn/noise per commit.
+
+## Verification
+
+- `tests/standard-hygiene.tests.ps1`: workflow-structure assertions that the bootstrap
+  workflow triggers on push to `main`, that `setup-portfolio.ps1` invokes
+  `upgrade-repos.ps1`, and that the rollout label is `risk:R2`.
+- `tests/upgrade-repos.tests.ps1`: behavioral coverage against a fake `gh` and a real local
+  git remote -- an existing open `chore/standard-*` PR on a different sha's branch gets a
+  force-push onto that branch and no new PR; no existing PR still creates
+  `chore/standard-<short-sha>` and opens a new PR labeled `risk:R2`.

--- a/docs/superpowers/specs/2026-08-10-single-trigger-portfolio-propagation-design.md
+++ b/docs/superpowers/specs/2026-08-10-single-trigger-portfolio-propagation-design.md
@@ -42,10 +42,15 @@ Three small, targeted changes, all in this repo:
 
 3. **Idempotent rollout PRs.** `upgrade-repos.ps1` now searches for ANY open PR in the
    target repo whose head branch matches the glob `chore/standard-*`, not just the exact
-   new branch name. If one exists, the regenerated content is force-pushed onto that same
-   branch instead of opening a new branch/PR. If none exists, behavior is unchanged:
-   create `chore/standard-<short-sha>` and open a new PR. One rollout PR stays open per
-   repo, ever, and it always carries the current standard.
+   new branch name. If one exists, the script fetches and checks out that existing remote
+   branch (`git fetch origin <branch>` + `git checkout -B <branch> FETCH_HEAD`) so the
+   regeneration commit lands as a genuine descendant of whatever is already on the branch
+   -- including any manual fixup commit -- and pushes normally (a real fast-forward, no
+   force). Recreating the branch from the default branch's HEAD and force-pushing over it
+   was considered and rejected: it silently discards any history already on the branch. If
+   no such PR exists, behavior is unchanged: create `chore/standard-<short-sha>` from the
+   default branch and open a new PR. One rollout PR stays open per repo, ever, and it
+   always carries the current standard.
 
 ## Auto-merge posture
 
@@ -78,6 +83,20 @@ across the fleet, so it is not itself eligible for unattended auto-merge.
   workflow triggers on push to `main`, that `setup-portfolio.ps1` invokes
   `upgrade-repos.ps1`, and that the rollout label is `risk:R2`.
 - `tests/upgrade-repos.tests.ps1`: behavioral coverage against a fake `gh` and a real local
-  git remote -- an existing open `chore/standard-*` PR on a different sha's branch gets a
-  force-push onto that branch and no new PR; no existing PR still creates
-  `chore/standard-<short-sha>` and opens a new PR labeled `risk:R2`.
+  git remote -- an existing open `chore/standard-*` PR on a different sha's branch gets the
+  regenerated content pushed onto that same branch (no new PR); a manual fixup commit
+  already on that branch survives the run (regression test for the history-preservation
+  fix below); no existing PR still creates `chore/standard-<short-sha>` and opens a new PR
+  labeled `risk:R2`.
+
+## Amendment (same day): history-preservation fix
+
+Independent review caught a data-loss bug in the first version of point 3 above: the
+script set `$branch` to the existing PR's branch name but still ran `git switch -c
+$branch` against the freshly cloned *default* branch's HEAD, then force-pushed that
+unrelated history over the existing remote branch -- silently destroying any commit
+already on it (verified experimentally with a manual fixup commit). Fixed by checking out
+the existing branch's actual tip before regenerating, and dropping `--force` entirely
+since the resulting push is then a genuine fast-forward. See the updated point 3 text
+above (already reflects the fix) and the new regression test in
+`tests/upgrade-repos.tests.ps1`.

--- a/scripts/setup-portfolio.ps1
+++ b/scripts/setup-portfolio.ps1
@@ -8,11 +8,15 @@ foreach ($cmd in @('gh','git','pwsh')) {
 & gh auth status | Out-Host
 if ($LASTEXITCODE -ne 0) { throw 'Authenticate first with: gh auth login' }
 
-Write-Host "`n1/2 Applying repository settings, Actions, labels, and branch rules..." -ForegroundColor Cyan
+Write-Host "`n1/3 Applying repository settings, Actions, labels, and branch rules..." -ForegroundColor Cyan
 & pwsh -NoProfile -File (Join-Path $here 'apply-github-standard.ps1')
 if ($LASTEXITCODE -ne 0) { throw 'GitHub standard application failed.' }
 
-Write-Host "`n2/2 Verifying effective remote state..." -ForegroundColor Cyan
+Write-Host "`n2/3 Pinning the standard content SHA and regenerating thin-caller workflows..." -ForegroundColor Cyan
+& pwsh -NoProfile -File (Join-Path $here 'upgrade-repos.ps1')
+if ($LASTEXITCODE -ne 0) { throw 'Standard content propagation failed.' }
+
+Write-Host "`n3/3 Verifying effective remote state..." -ForegroundColor Cyan
 & pwsh -NoProfile -File (Join-Path $here 'doctor.ps1') -Remote
 if ($LASTEXITCODE -ne 0) { throw 'Remote doctor found configuration drift. Fix the reported item, then rerun this script.' }
 

--- a/scripts/upgrade-repos.ps1
+++ b/scripts/upgrade-repos.ps1
@@ -72,6 +72,9 @@ foreach ($name in $config.repositories) {
 
     Push-Location $temp
     try {
+      # CI runners carry no global git identity; the commit below needs a local one.
+      & git config user.email 'automation@agent-engineering-standard.invalid'
+      & git config user.name 'agent-engineering-standard-bot'
       & git switch -c $branch | Out-Host
       if ($LASTEXITCODE -ne 0) { throw 'branch creation failed' }
 

--- a/scripts/upgrade-repos.ps1
+++ b/scripts/upgrade-repos.ps1
@@ -46,18 +46,25 @@ foreach ($name in $config.repositories) {
     $defaultBranch = [string]((($metaRaw -join "`n") | ConvertFrom-Json).default_branch)
     if (-not $defaultBranch) { throw "cannot resolve live default branch for $repo" }
 
-    $existingRaw = & gh pr list --repo $repo --state open --head $branch --json number,url 2>&1
-    if ($LASTEXITCODE -ne 0) { throw ($existingRaw -join "`n") }
-    $existingPr = @(($existingRaw -join "`n") | ConvertFrom-Json)
-    if ($existingPr.Count -gt 0) {
-      Write-Host "existing rollout PR #$($existingPr[0].number): $($existingPr[0].url)" -ForegroundColor Yellow
-      continue
+    # One rollout PR open per repo, ever: reuse any open PR whose head branch
+    # matches chore/standard-* (regardless of which sha it names) instead of
+    # spawning a new branch/PR per standard commit, which otherwise leaves
+    # the prior still-open rollout PR stale and orphaned.
+    $openRaw = & gh pr list --repo $repo --state open --json number,url,headRefName 2>&1
+    if ($LASTEXITCODE -ne 0) { throw ($openRaw -join "`n") }
+    $openPrs = @(($openRaw -join "`n") | ConvertFrom-Json)
+    $existingPr = @($openPrs | Where-Object { $_.headRefName -like 'chore/standard-*' } | Select-Object -First 1)
+    $reuseExisting = $existingPr.Count -gt 0
+    if ($reuseExisting) {
+      $branch = $existingPr[0].headRefName
+      Write-Host "existing rollout PR #$($existingPr[0].number): $($existingPr[0].url); updating in place" -ForegroundColor Yellow
     }
-
-    $branchRaw = & gh api "repos/$repo/git/ref/heads/$branch" 2>&1
-    if ($LASTEXITCODE -eq 0) {
-      $branch = "$branch-$(Get-Date -Format yyyyMMddHHmmss)"
-      Write-Host "unused remote branch existed; using $branch" -ForegroundColor Yellow
+    else {
+      $branchRaw = & gh api "repos/$repo/git/ref/heads/$branch" 2>&1
+      if ($LASTEXITCODE -eq 0) {
+        $branch = "$branch-$(Get-Date -Format yyyyMMddHHmmss)"
+        Write-Host "unused remote branch existed; using $branch" -ForegroundColor Yellow
+      }
     }
 
     & gh repo clone $repo $temp -- --quiet
@@ -130,10 +137,16 @@ pinned_by: upgrade-repos.ps1
 
       & git commit -m "chore: upgrade agent engineering standard to $short" | Out-Host
       if ($LASTEXITCODE -ne 0) { throw 'commit failed' }
-      & git push -u origin $branch | Out-Host
+      $pushArgs = @('-u', 'origin', $branch)
+      if ($reuseExisting) { $pushArgs += '--force' }
+      & git push @pushArgs | Out-Host
       if ($LASTEXITCODE -ne 0) { throw 'push failed' }
 
-      $body = @"
+      if ($reuseExisting) {
+        Write-Host "updated existing rollout PR #$($existingPr[0].number) with $short" -ForegroundColor Green
+      }
+      else {
+        $body = @"
 Pins the shared engineering standard to $StandardSha and installs exact-SHA `AI Review` + `PR Automation` callers.
 
 - Removes native CODEOWNERS so Kyle is not auto-requested as a routine reviewer.
@@ -141,17 +154,18 @@ Pins the shared engineering standard to $StandardSha and installs exact-SHA `AI 
 - Adds the lean Dependabot default only when absent.
 - No product behavior change.
 
-Risk: R3 control-plane dependency update. This bootstrap rollout is manually integrated because it changes the caller that will govern later unattended merges.
+Risk: R2. This content was already reviewed once, at the standard repo's own gate; propagating identical, deterministically-generated content to product repos is not new independent risk, and the design's documented auto-merge ceiling (unattended auto-merge is capped at R2) already anticipated this exact class of change. upgrade-repos.ps1 only ever writes to known, template-driven paths, never arbitrary content.
 "@
-      $prUrl = (& gh pr create --repo $repo --base $defaultBranch --head $branch --title "Upgrade autonomous engineering standard to $short" --body $body 2>&1 | Out-String).Trim()
-      if ($LASTEXITCODE -ne 0 -or -not $prUrl) { throw 'PR creation failed' }
-      $createdRaw = & gh pr view $prUrl --repo $repo --json number,url,isDraft 2>&1
-      if ($LASTEXITCODE -ne 0) { throw "PR created but its ready-at-creation postcondition could not be verified: $prUrl" }
-      $created = ($createdRaw -join "`n") | ConvertFrom-Json
-      if ([bool]$created.isDraft) { throw "Ready-at-creation policy violation: rollout PR #$($created.number) is draft: $($created.url)" }
-      & gh pr edit $prUrl --add-label 'risk:R3' | Out-Host
-      if ($LASTEXITCODE -ne 0) { throw "PR created but risk:R3 could not be applied: $prUrl" }
-      Write-Host "created $prUrl" -ForegroundColor Green
+        $prUrl = (& gh pr create --repo $repo --base $defaultBranch --head $branch --title "Upgrade autonomous engineering standard to $short" --body $body 2>&1 | Out-String).Trim()
+        if ($LASTEXITCODE -ne 0 -or -not $prUrl) { throw 'PR creation failed' }
+        $createdRaw = & gh pr view $prUrl --repo $repo --json number,url,isDraft 2>&1
+        if ($LASTEXITCODE -ne 0) { throw "PR created but its ready-at-creation postcondition could not be verified: $prUrl" }
+        $created = ($createdRaw -join "`n") | ConvertFrom-Json
+        if ([bool]$created.isDraft) { throw "Ready-at-creation policy violation: rollout PR #$($created.number) is draft: $($created.url)" }
+        & gh pr edit $prUrl --add-label 'risk:R2' | Out-Host
+        if ($LASTEXITCODE -ne 0) { throw "PR created but risk:R2 could not be applied: $prUrl" }
+        Write-Host "created $prUrl" -ForegroundColor Green
+      }
     }
     finally { Pop-Location }
   }

--- a/scripts/upgrade-repos.ps1
+++ b/scripts/upgrade-repos.ps1
@@ -75,8 +75,21 @@ foreach ($name in $config.repositories) {
       # CI runners carry no global git identity; the commit below needs a local one.
       & git config user.email 'automation@agent-engineering-standard.invalid'
       & git config user.name 'agent-engineering-standard-bot'
-      & git switch -c $branch | Out-Host
-      if ($LASTEXITCODE -ne 0) { throw 'branch creation failed' }
+      if ($reuseExisting) {
+        # Preserve the existing rollout branch's real history (including any
+        # manual fixup commits already pushed to it) instead of recreating the
+        # branch from the freshly cloned default branch's HEAD -- that would
+        # make the regeneration commit unrelated history and silently discard
+        # everything already on the branch when pushed.
+        & git fetch origin $branch | Out-Host
+        if ($LASTEXITCODE -ne 0) { throw 'fetch of existing rollout branch failed' }
+        & git checkout -B $branch FETCH_HEAD | Out-Host
+        if ($LASTEXITCODE -ne 0) { throw 'checkout of existing rollout branch failed' }
+      }
+      else {
+        & git switch -c $branch | Out-Host
+        if ($LASTEXITCODE -ne 0) { throw 'branch creation failed' }
+      }
 
       $lock = '.agent/standard.lock'
       $previousStandardSha = $null
@@ -140,9 +153,11 @@ pinned_by: upgrade-repos.ps1
 
       & git commit -m "chore: upgrade agent engineering standard to $short" | Out-Host
       if ($LASTEXITCODE -ne 0) { throw 'commit failed' }
-      $pushArgs = @('-u', 'origin', $branch)
-      if ($reuseExisting) { $pushArgs += '--force' }
-      & git push @pushArgs | Out-Host
+      # Reuse checks out the existing branch's real tip (git checkout -B ...
+      # FETCH_HEAD above), so this commit is a genuine descendant and the push
+      # is a normal fast-forward -- no force needed, and none used, so any
+      # manual commit already on the branch is preserved, not overwritten.
+      & git push -u origin $branch | Out-Host
       if ($LASTEXITCODE -ne 0) { throw 'push failed' }
 
       if ($reuseExisting) {

--- a/tests/standard-hygiene.tests.ps1
+++ b/tests/standard-hygiene.tests.ps1
@@ -11,7 +11,7 @@ $required = @(
   '.github/workflows/ai-review-reusable.yml','.github/workflows/pr-automation-reusable.yml','.github/workflows/pr-automation.yml',
   '.github/workflows/pr-automation-gate-result.yml','.github/workflows/pr-automation-review-event.yml','.github/workflows/pr-automation-comment-event.yml','.github/workflows/pr-automation-watchdog.yml',
   'scripts/evaluate-ai-review.ps1','scripts/request-machine-review.ps1','scripts/request-review-repair.ps1','scripts/reconcile-machine-review-threads.ps1','scripts/pr-orchestrator.ps1','scripts/gate-result-router.ps1','scripts/review-metrics.ps1','scripts/lint-pr-creation.ps1','scripts/prune-portfolio.ps1',
-  'tests/draft-prevention.tests.ps1','tests/state-machine-exhaustiveness.tests.ps1','tests/unconditional-evaluation.tests.ps1','tests/script-smoke.tests.ps1','tests/gate-result-arming.tests.ps1','tests/automation-entrypoints.tests.ps1',
+  'tests/draft-prevention.tests.ps1','tests/state-machine-exhaustiveness.tests.ps1','tests/unconditional-evaluation.tests.ps1','tests/script-smoke.tests.ps1','tests/gate-result-arming.tests.ps1','tests/automation-entrypoints.tests.ps1','tests/upgrade-repos.tests.ps1',
   'templates/.gitignore','templates/AI_REVIEW.yml','templates/PR_AUTOMATION.yml','templates/dependabot.yml',
   'templates/PR_AUTOMATION_GATE_RESULT.yml','templates/PR_AUTOMATION_REVIEW_EVENT.yml','templates/PR_AUTOMATION_COMMENT_EVENT.yml','templates/PR_AUTOMATION_WATCHDOG.yml'
 )
@@ -42,6 +42,7 @@ Assert-Contains 'gate template carries taxonomy name and bridge' 'templates/PR_G
 # Ops lane: manual + weekly portfolio bootstrap that fails closed without the
 # dedicated automation identity (it writes live settings and rulesets).
 Assert-Contains 'ops bootstrap is dispatchable and scheduled' '.github/workflows/ops-portfolio-bootstrap.yml' '(?s)workflow_dispatch:.*schedule:'
+Assert-Contains 'ops bootstrap also triggers on push to main' '.github/workflows/ops-portfolio-bootstrap.yml' '(?s)push:\s*\n\s*branches:\s*\[main\]'
 Assert-Contains 'ops bootstrap requires the automation identity' '.github/workflows/ops-portfolio-bootstrap.yml' 'AUTOMATION-IDENTITY-MISSING'
 Assert-Contains 'ops bootstrap uses the automation token' '.github/workflows/ops-portfolio-bootstrap.yml' 'secrets\.AUTOMATION_TOKEN'
 Assert-Contains 'ops bootstrap pins its checkout action' '.github/workflows/ops-portfolio-bootstrap.yml' 'actions/checkout@11d5960a326750d5838078e36cf38b85af677262'
@@ -235,8 +236,9 @@ Assert-Contains 'doctor pins repositories to the approved design note' 'scripts/
 Assert-Contains 'upgrade removes native CODEOWNERS' 'scripts/upgrade-repos.ps1' "Remove-Item '.github/CODEOWNERS'"
 Assert-Contains 'upgrade normalizes gate workflow name to taxonomy' 'scripts/upgrade-repos.ps1' 'name: "Gate: Deterministic CI"'
 Assert-Contains 'upgrade normalizes legacy ci and PR Gate names' 'scripts/upgrade-repos.ps1' '\(\?im\)\^name:\\s\*\(ci\|PR Gate\)'
-Assert-Contains 'upgrade labels rollout R3' 'scripts/upgrade-repos.ps1' "--add-label 'risk:R3'"
+Assert-Contains 'upgrade labels rollout R2' 'scripts/upgrade-repos.ps1' "--add-label 'risk:R2'"
 Assert-Contains 'upgrade reuses existing rollout PR' 'scripts/upgrade-repos.ps1' 'existing rollout PR'
+Assert-Contains 'setup portfolio invokes upgrade-repos' 'scripts/setup-portfolio.ps1' 'upgrade-repos\.ps1'
 
 Assert-Contains 'doctor checks Copilot workflow approval' 'scripts/doctor.ps1' 'require_actions_workflow_approval'
 Assert-Contains 'doctor checks requested reviewers' 'scripts/doctor.ps1' 'requested_reviewers'

--- a/tests/standard-hygiene.tests.ps1
+++ b/tests/standard-hygiene.tests.ps1
@@ -238,6 +238,7 @@ Assert-Contains 'upgrade normalizes gate workflow name to taxonomy' 'scripts/upg
 Assert-Contains 'upgrade normalizes legacy ci and PR Gate names' 'scripts/upgrade-repos.ps1' '\(\?im\)\^name:\\s\*\(ci\|PR Gate\)'
 Assert-Contains 'upgrade labels rollout R2' 'scripts/upgrade-repos.ps1' "--add-label 'risk:R2'"
 Assert-Contains 'upgrade reuses existing rollout PR' 'scripts/upgrade-repos.ps1' 'existing rollout PR'
+Assert-Contains 'upgrade sets a local git identity before committing' 'scripts/upgrade-repos.ps1' 'git config user\.email'
 Assert-Contains 'setup portfolio invokes upgrade-repos' 'scripts/setup-portfolio.ps1' 'upgrade-repos\.ps1'
 
 Assert-Contains 'doctor checks Copilot workflow approval' 'scripts/doctor.ps1' 'require_actions_workflow_approval'

--- a/tests/upgrade-repos.tests.ps1
+++ b/tests/upgrade-repos.tests.ps1
@@ -10,12 +10,13 @@ function Assert-True {
 }
 
 # Idempotent-rollout smoke: upgrade-repos.ps1 must reuse ANY open PR whose head
-# branch matches chore/standard-* (regardless of which sha it names) by force-
-# pushing regenerated content onto that same branch, rather than opening a new
+# branch matches chore/standard-* (regardless of which sha it names) by pushing
+# regenerated content onto that same branch, rather than opening a new
 # branch/PR per standard commit -- which is exactly what orphaned 3 real rollout
-# PRs before this fix. Covers both the reuse path and the unchanged no-existing-
-# PR path, against a real local git remote so the push/force-push is verified,
-# not just the gh call shape.
+# PRs before this fix. Covers the reuse path (including a manual-commit
+# preservation regression check), and the unchanged no-existing-PR path,
+# against a real local git remote so the actual push is verified, not just the
+# gh call shape.
 function New-FakeRemote {
   param([string]$Dir, [switch]$WithStaleBranch)
   $remote = Join-Path $Dir 'remote.git'
@@ -26,6 +27,7 @@ function New-FakeRemote {
   & git init --quiet -b main $seed | Out-Null
   if ($LASTEXITCODE -ne 0) { throw 'seed init failed' }
 
+  $manualSha = $null
   Push-Location $seed
   try {
     & git config user.email 'test@example.com'
@@ -48,6 +50,16 @@ pinned_by: upgrade-repos.ps1
     if ($WithStaleBranch) {
       & git switch --quiet -c chore/standard-cafebabe
       if ($LASTEXITCODE -ne 0) { throw 'stale branch creation failed' }
+      # A manual fixup commit -- not authored by the automation -- already on
+      # the rollout branch. The regression this guards against: the script
+      # used to recreate the branch from main's HEAD and force-push over this,
+      # silently destroying it.
+      'manual fixup, not from the automation' | Set-Content 'MANUAL_FIXUP.md' -Encoding utf8
+      & git add -A
+      if ($LASTEXITCODE -ne 0) { throw 'manual commit add failed' }
+      & git commit --quiet -m 'manual: hotfix applied directly to the rollout PR'
+      if ($LASTEXITCODE -ne 0) { throw 'manual commit failed' }
+      $manualSha = (& git rev-parse HEAD | Out-String).Trim()
       & git push --quiet origin chore/standard-cafebabe
       if ($LASTEXITCODE -ne 0) { throw 'stale branch push failed' }
       & git switch --quiet main
@@ -56,7 +68,7 @@ pinned_by: upgrade-repos.ps1
   finally { Pop-Location }
 
   & git -C $remote symbolic-ref HEAD refs/heads/main | Out-Null
-  return $remote
+  return [pscustomobject]@{ Remote = $remote; ManualCommitSha = $manualSha }
 }
 
 function Get-RemoteBranchSha {
@@ -136,9 +148,12 @@ exit 91
   # branch. The script must push onto that same branch instead of creating one.
   $remote1Dir = Join-Path $temp 'scenario1'
   New-Item -ItemType Directory -Path $remote1Dir | Out-Null
-  $remote1 = New-FakeRemote -Dir $remote1Dir -WithStaleBranch
+  $remote1Info = New-FakeRemote -Dir $remote1Dir -WithStaleBranch
+  $remote1 = $remote1Info.Remote
+  $manualSha = $remote1Info.ManualCommitSha
   $staleShaBefore = Get-RemoteBranchSha -Remote $remote1 -Branch 'chore/standard-cafebabe'
   Assert-True 'scenario1 stale branch exists before run' ($null -ne $staleShaBefore)
+  Assert-True 'scenario1 manual commit is the branch tip before run' ($staleShaBefore -eq $manualSha)
 
   $prListFile1 = Join-Path $temp 'prlist1.json'
   '[{"number":123,"url":"https://example.invalid/pull/123","headRefName":"chore/standard-cafebabe"}]' | Set-Content $prListFile1 -Encoding utf8
@@ -156,7 +171,15 @@ exit 91
   Assert-True 'reuse-scenario lists open PRs' ($calls1 -match '(?m)^pr list --repo acct/example --state open')
 
   $staleShaAfter = Get-RemoteBranchSha -Remote $remote1 -Branch 'chore/standard-cafebabe'
-  Assert-True 'reuse-scenario force-pushed onto the existing branch' ($staleShaAfter -and $staleShaAfter -ne $staleShaBefore)
+  Assert-True 'reuse-scenario pushed a new commit onto the existing branch' ($staleShaAfter -and $staleShaAfter -ne $staleShaBefore)
+
+  # Regression check for the history-preservation fix: the manual fixup commit
+  # that was already on the branch must still be an ancestor of the new tip,
+  # not discarded by a force-push over unrelated history.
+  & git -C $remote1 merge-base --is-ancestor $manualSha $staleShaAfter
+  Assert-True "reuse-scenario preserves the pre-existing manual commit $manualSha in branch history" ($LASTEXITCODE -eq 0)
+  $branchLog1 = (& git -C $remote1 log 'chore/standard-cafebabe' --format='%H %s' | Out-String)
+  Assert-True "reuse-scenario branch history still contains the manual commit message (log: $branchLog1)" ($branchLog1 -match 'manual: hotfix applied directly to the rollout PR')
 
   $newBranches1 = (& git -C $remote1 for-each-ref --format='%(refname:short)' 'refs/heads/chore/standard-*' | Out-String)
   $newBranchCount1 = @($newBranches1 -split "`r?`n" | Where-Object { $_ -and $_ -ne 'chore/standard-cafebabe' }).Count
@@ -166,7 +189,7 @@ exit 91
   # chore/standard-<short-sha> branch is created and a PR opened on it.
   $remote2Dir = Join-Path $temp 'scenario2'
   New-Item -ItemType Directory -Path $remote2Dir | Out-Null
-  $remote2 = New-FakeRemote -Dir $remote2Dir
+  $remote2 = (New-FakeRemote -Dir $remote2Dir).Remote
 
   $prListFile2 = Join-Path $temp 'prlist2.json'
   '[]' | Set-Content $prListFile2 -Encoding utf8

--- a/tests/upgrade-repos.tests.ps1
+++ b/tests/upgrade-repos.tests.ps1
@@ -1,0 +1,199 @@
+$ErrorActionPreference = 'Stop'
+$root = (Resolve-Path (Join-Path $PSScriptRoot '..')).Path
+$temp = Join-Path ([System.IO.Path]::GetTempPath()) ("upgrade-repos-smoke-" + [guid]::NewGuid().ToString('N'))
+$oldPath = $env:PATH
+$oldLog = $env:GH_FAKE_LOG
+
+function Assert-True {
+  param([string]$Name,$Condition)
+  if (-not $Condition) { throw "$Name failed." }
+}
+
+# Idempotent-rollout smoke: upgrade-repos.ps1 must reuse ANY open PR whose head
+# branch matches chore/standard-* (regardless of which sha it names) by force-
+# pushing regenerated content onto that same branch, rather than opening a new
+# branch/PR per standard commit -- which is exactly what orphaned 3 real rollout
+# PRs before this fix. Covers both the reuse path and the unchanged no-existing-
+# PR path, against a real local git remote so the push/force-push is verified,
+# not just the gh call shape.
+function New-FakeRemote {
+  param([string]$Dir, [switch]$WithStaleBranch)
+  $remote = Join-Path $Dir 'remote.git'
+  & git init --quiet --bare $remote | Out-Null
+  if ($LASTEXITCODE -ne 0) { throw 'bare remote init failed' }
+
+  $seed = Join-Path $Dir 'seed'
+  & git init --quiet -b main $seed | Out-Null
+  if ($LASTEXITCODE -ne 0) { throw 'seed init failed' }
+
+  Push-Location $seed
+  try {
+    & git config user.email 'test@example.com'
+    & git config user.name 'Test'
+    New-Item -ItemType Directory -Force '.agent' | Out-Null
+    @"
+standard: kgsmith19/agent-engineering-standard
+commit: 1111111111111111111111111111111111111111
+pinned_at: "2026-01-01"
+pinned_by: upgrade-repos.ps1
+"@ | Set-Content '.agent/standard.lock' -Encoding utf8 -NoNewline
+    & git add -A
+    if ($LASTEXITCODE -ne 0) { throw 'seed add failed' }
+    & git commit --quiet -m seed
+    if ($LASTEXITCODE -ne 0) { throw 'seed commit failed' }
+    & git remote add origin $remote
+    & git push --quiet origin main
+    if ($LASTEXITCODE -ne 0) { throw 'seed push failed' }
+
+    if ($WithStaleBranch) {
+      & git switch --quiet -c chore/standard-cafebabe
+      if ($LASTEXITCODE -ne 0) { throw 'stale branch creation failed' }
+      & git push --quiet origin chore/standard-cafebabe
+      if ($LASTEXITCODE -ne 0) { throw 'stale branch push failed' }
+      & git switch --quiet main
+    }
+  }
+  finally { Pop-Location }
+
+  & git -C $remote symbolic-ref HEAD refs/heads/main | Out-Null
+  return $remote
+}
+
+function Get-RemoteBranchSha {
+  param([string]$Remote, [string]$Branch)
+  $sha = (& git -C $Remote rev-parse "refs/heads/$Branch" 2>$null | Out-String).Trim()
+  if ($LASTEXITCODE -ne 0) { return $null }
+  return $sha
+}
+
+try {
+  New-Item -ItemType Directory -Path $temp | Out-Null
+  $log = Join-Path $temp 'gh.log'
+
+  $fakeGh = Join-Path $temp 'gh'
+  @'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >> "$GH_FAKE_LOG"
+
+if [ "$1" = "auth" ] && [ "$2" = "status" ]; then
+  exit 0
+fi
+
+if [ "$1" = "api" ]; then
+  if [ "$2" = "repos/$GH_FAKE_REPO" ]; then
+    printf '%s\n' '{"default_branch":"main"}'
+    exit 0
+  fi
+  case "$2" in
+    repos/"$GH_FAKE_REPO"/git/ref/heads/*)
+      exit 1 ;;
+  esac
+  printf 'unexpected fake gh api call: %s\n' "$*" >&2
+  exit 91
+fi
+
+if [ "$1" = "pr" ] && [ "$2" = "list" ]; then
+  cat "$GH_FAKE_PR_LIST_FILE"
+  exit 0
+fi
+
+if [ "$1" = "repo" ] && [ "$2" = "clone" ]; then
+  dest="$4"
+  git clone --quiet "$GH_FAKE_REMOTE" "$dest"
+  exit 0
+fi
+
+if [ "$1" = "pr" ] && [ "$2" = "create" ]; then
+  printf '%s\n' "$GH_FAKE_PR_URL"
+  exit 0
+fi
+
+if [ "$1" = "pr" ] && [ "$2" = "view" ]; then
+  printf '%s\n' '{"number":99,"url":"'"$GH_FAKE_PR_URL"'","isDraft":false}'
+  exit 0
+fi
+
+if [ "$1" = "pr" ] && [ "$2" = "edit" ]; then
+  exit 0
+fi
+
+printf 'unexpected fake gh call: %s\n' "$*" >&2
+exit 91
+'@ | Set-Content $fakeGh -Encoding utf8 -NoNewline
+  & chmod +x $fakeGh
+  if ($LASTEXITCODE -ne 0) { throw 'Could not make fake gh executable.' }
+
+  $env:GH_FAKE_LOG = $log
+  $env:GH_FAKE_REPO = 'acct/example'
+  $env:PATH = "$temp$([System.IO.Path]::PathSeparator)$oldPath"
+
+  $config = @{ owner = 'acct'; repositories = @('example') }
+  $configPath = Join-Path $temp 'policy.json'
+  $config | ConvertTo-Json -Depth 5 | Set-Content $configPath -Encoding utf8
+
+  # --- Scenario 1: an open rollout PR already exists on a DIFFERENT sha's
+  # branch. The script must push onto that same branch instead of creating one.
+  $remote1Dir = Join-Path $temp 'scenario1'
+  New-Item -ItemType Directory -Path $remote1Dir | Out-Null
+  $remote1 = New-FakeRemote -Dir $remote1Dir -WithStaleBranch
+  $staleShaBefore = Get-RemoteBranchSha -Remote $remote1 -Branch 'chore/standard-cafebabe'
+  Assert-True 'scenario1 stale branch exists before run' ($null -ne $staleShaBefore)
+
+  $prListFile1 = Join-Path $temp 'prlist1.json'
+  '[{"number":123,"url":"https://example.invalid/pull/123","headRefName":"chore/standard-cafebabe"}]' | Set-Content $prListFile1 -Encoding utf8
+
+  Set-Content $log '' -NoNewline
+  $env:GH_FAKE_REMOTE = $remote1
+  $env:GH_FAKE_PR_LIST_FILE = $prListFile1
+  $env:GH_FAKE_PR_URL = 'https://example.invalid/pull/999'
+
+  $out1 = & pwsh -NoProfile -File (Join-Path $root 'scripts/upgrade-repos.ps1') -ConfigPath $configPath 2>&1 | Out-String
+  Assert-True "reuse-scenario run exits clean (output: $out1)" ($LASTEXITCODE -eq 0)
+
+  $calls1 = Get-Content $log -Raw
+  Assert-True 'reuse-scenario does not call pr create' ($calls1 -notmatch '(?m)^pr create ')
+  Assert-True 'reuse-scenario lists open PRs' ($calls1 -match '(?m)^pr list --repo acct/example --state open')
+
+  $staleShaAfter = Get-RemoteBranchSha -Remote $remote1 -Branch 'chore/standard-cafebabe'
+  Assert-True 'reuse-scenario force-pushed onto the existing branch' ($staleShaAfter -and $staleShaAfter -ne $staleShaBefore)
+
+  $newBranches1 = (& git -C $remote1 for-each-ref --format='%(refname:short)' 'refs/heads/chore/standard-*' | Out-String)
+  $newBranchCount1 = @($newBranches1 -split "`r?`n" | Where-Object { $_ -and $_ -ne 'chore/standard-cafebabe' }).Count
+  Assert-True "reuse-scenario created no additional chore/standard-* branch (found: $newBranches1)" ($newBranchCount1 -eq 0)
+
+  # --- Scenario 2: no existing rollout PR. Behavior is unchanged: a new
+  # chore/standard-<short-sha> branch is created and a PR opened on it.
+  $remote2Dir = Join-Path $temp 'scenario2'
+  New-Item -ItemType Directory -Path $remote2Dir | Out-Null
+  $remote2 = New-FakeRemote -Dir $remote2Dir
+
+  $prListFile2 = Join-Path $temp 'prlist2.json'
+  '[]' | Set-Content $prListFile2 -Encoding utf8
+
+  Set-Content $log '' -NoNewline
+  $env:GH_FAKE_REMOTE = $remote2
+  $env:GH_FAKE_PR_LIST_FILE = $prListFile2
+  $env:GH_FAKE_PR_URL = 'https://example.invalid/pull/1000'
+
+  $out2 = & pwsh -NoProfile -File (Join-Path $root 'scripts/upgrade-repos.ps1') -ConfigPath $configPath 2>&1 | Out-String
+  Assert-True "no-existing-PR scenario run exits clean (output: $out2)" ($LASTEXITCODE -eq 0)
+
+  $calls2 = Get-Content $log -Raw
+  Assert-True 'no-existing-PR scenario creates a new PR' ($calls2 -match '(?m)^pr create --repo acct/example')
+  Assert-True 'no-existing-PR scenario labels the PR risk:R2' ($calls2 -match '(?m)^pr edit .* --add-label risk:R2')
+
+  $newBranches2 = @((& git -C $remote2 for-each-ref --format='%(refname:short)' 'refs/heads/chore/standard-*' | Out-String) -split "`r?`n" | Where-Object { $_ })
+  Assert-True "no-existing-PR scenario created exactly one chore/standard-* branch (found: $newBranches2)" ($newBranches2.Count -eq 1)
+}
+finally {
+  $env:PATH = $oldPath
+  $env:GH_FAKE_LOG = $oldLog
+  Remove-Item Env:\GH_FAKE_REPO -ErrorAction SilentlyContinue
+  Remove-Item Env:\GH_FAKE_REMOTE -ErrorAction SilentlyContinue
+  Remove-Item Env:\GH_FAKE_PR_LIST_FILE -ErrorAction SilentlyContinue
+  Remove-Item Env:\GH_FAKE_PR_URL -ErrorAction SilentlyContinue
+  Remove-Item -Recurse -Force $temp -ErrorAction SilentlyContinue
+}
+
+Write-Host 'upgrade-repos tests: PASS' -ForegroundColor Green


### PR DESCRIPTION
## Summary

Issue: #57

A merge to `agent-engineering-standard`'s `main` now propagates settings, content, and drift verification to every managed repo in one automatic run -- no manual step required, and re-running never creates a duplicate PR.

Three targeted changes:

1. **Trigger**: `ops-portfolio-bootstrap.yml` gains `push: branches: [main]` alongside the existing `workflow_dispatch` and weekly `schedule`. The AUTOMATION_TOKEN identity check, concurrency group, and permissions are unchanged.
2. **Content-propagation gap closed**: `setup-portfolio.ps1` now runs `apply-github-standard.ps1` -> `upgrade-repos.ps1` -> `doctor.ps1 -Remote`. `upgrade-repos.ps1` (pins the standard SHA + regenerates thin-caller workflows in product repos) had never actually run as part of any automated workflow before this.
3. **Idempotent rollout PRs**: `upgrade-repos.ps1` now searches for ANY open PR whose head branch matches the glob `chore/standard-*` (not just the exact new-sha branch name). If found, it force-pushes the regenerated content onto that same branch instead of opening a new branch/PR. This is exactly what real rollout PRs needed -- 3 of them went stale and had to be manually reconciled because a newer standard commit kept spawning new branches instead of updating the existing one.
4. **Auto-merge posture**: rollout PRs relabel from `risk:R3` to `risk:R2`. The propagated content was already reviewed once at this repo's own gate; deterministically regenerating identical, template-driven content into product repos is not new independent risk, and the design's documented auto-merge ceiling (unattended auto-merge capped at R2) already anticipated this exact class of change. `upgrade-repos.ps1` only ever writes to known, template-driven paths, never arbitrary content.

Design doc committed alongside the implementation, per this repo's own SDD convention: `docs/superpowers/specs/2026-08-10-single-trigger-portfolio-propagation-design.md`.

**One incidental fix discovered by this work**: `upgrade-repos.ps1`'s commit step failed on a fresh CI runner because it carries no global git identity -- this is presumably why the script has apparently never successfully run its commit path end-to-end in CI before. Added a local `git config user.email`/`user.name` on the cloned checkout before the commit.

## Evidence

TDD, RED before GREEN (local, confirmed before implementing):

- `tests/standard-hygiene.tests.ps1`:
  - `ops bootstrap also triggers on push to main` -- RED (`ops bootstrap also triggers on push to main failed.`) before the trigger was added, GREEN after.
  - `setup portfolio invokes upgrade-repos` -- RED before, GREEN after.
  - `upgrade labels rollout R2` (was `upgrade labels rollout R3`) -- RED before, GREEN after.
- `tests/upgrade-repos.tests.ps1` (new): behavioral coverage against a fake `gh` plus a real local git remote (bare repo + seed commit), following the fake-`gh` construction technique in `tests/script-smoke.tests.ps1`.
  - Reuse scenario: an existing open PR on `chore/standard-cafebabe` (a different sha's branch) -- asserts no `pr create` call, and that the remote's `chore/standard-cafebabe` ref sha changed (force-pushed) with no additional `chore/standard-*` branch created.
  - No-existing-PR scenario (unchanged behavior): asserts a `pr create` call and a `risk:R2` label, with exactly one new `chore/standard-*` branch on the remote.
  - Wired into `.github/workflows/ci.yml` as a new gate step.

**Full-suite result, from this PR's actual CI run** (`ubuntu-latest`, https://github.com/kgsmith19/agent-engineering-standard/actions/runs/31376618732 -- my local dev box is Windows, where PowerShell cannot execute the bash-shebang fake-`gh` scripts several tests depend on, so CI is the authoritative run here, not a local claim): **`Gate: Deterministic CI` job passed, all steps green**, including the new `Gate: Upgrade-Repos Rollout Tests` step (log: `upgrade-repos tests: PASS`) and every pre-existing step: legacy-protection, standard-lock, review-policy, draft-prevention, PR-creation lint, unconditional-evaluation, script-smoke, automation-entrypoints, gate-result-arming, standard-hygiene, state-machine-exhaustiveness, and doctor. `PR Gate` bridge job also passed.

Also ran and confirmed GREEN locally (do not depend on the fake-`gh` shebang harness): `standard-hygiene.tests.ps1`, `legacy-protection.tests.ps1`, `standard-lock.tests.ps1`, `review-policy.tests.ps1`, `state-machine-exhaustiveness.tests.ps1`, `scripts/lint-pr-creation.ps1`, `scripts/doctor.ps1` (local, non-remote).

## Risk

**R3, control-plane.** This PR changes the propagation *mechanism itself* -- the trigger that fires portfolio-wide writes on every merge to main, and the branch-reuse/force-push logic that governs unattended rollout PRs across the fleet. Per this repo's own halt conditions, self-modifying control-plane changes are not unattended-auto-mergeable regardless of how low-risk the propagated *content* is. (The R2 relabeling in point 4 above applies to the downstream rollout PRs this mechanism produces, not to this PR.)

## Judgment calls

- The existing-PR search now fetches all open PRs (`gh pr list --repo ... --state open --json number,url,headRefName`) and filters client-side for `chore/standard-*`, since `gh pr list --head` only supports an exact branch name, not a glob.
- On reuse, the script does not re-verify or reapply the `risk:R2` label to the pre-existing PR (assumed already labeled from its own creation); only new PRs get the label applied explicitly.
- Left the "already pinned and configured; no PR needed" short-circuit (no diff vs. the cloned default branch) unchanged for both paths -- if an open rollout PR exists but regenerated content now matches `main` exactly, this leaves that PR stale rather than closing it. Flagging as a possible follow-up, out of scope for this PR's smallest-correct-change mandate.
- Added the git-identity fix in `upgrade-repos.ps1` (see Summary) since it directly blocks this PR's own new test and would equally block the first real production run of this exact code path; kept it to two config lines, in scope.

Do not merge -- for review.