### PR TITLE
fix #65 + #62: stop re-adding dependabot.yml, fork-check auto-merge.ps1, reconcile draft-promotion doc

### DIFF
--- a/DELIVERY_GITHUB.md
+++ b/DELIVERY_GITHUB.md
@@ -103,7 +103,8 @@ Draft PRs are not part of the autonomous state machine. GitHub natively refuses 
 - REST, SDK, GraphQL, and connector callers set `draft: false` and verify the returned state.
 - `gh pr create` callers omit `--draft`, then verify `isDraft == false`.
 - A draft event fails `PR Gate`, applies `status:blocked`, posts one actionable diagnostic, and never reaches auto-merge.
-- Legacy manual conversion to Ready may clear the block, but automated conversion is forbidden.
+- For the owner and `github-actions[bot]`, only legacy manual conversion to Ready clears the block; automated conversion is forbidden for these authors.
+- The sole automated exception: an external agent's draft (any author besides the owner or `github-actions[bot]` — Dependabot, Copilot cloud agent, ...), when `pr_automation.external_draft_promotion` is on, is converted to Ready by the identity-gated `promote-external-draft.ps1` (`GH_TOKEN_ADMIN`-only, fork heads refused, not retried). This exists because those platforms open drafts by their own behavior, not by an agent skipping ready-at-creation; see the recovery matrix (§7) and `docs/AUTONOMOUS-PR-STATE-MACHINE.md`.
 
 `status:ready` remains an Issue-queue label only. It never changes PR draft state.
 

--- a/scripts/auto-merge.ps1
+++ b/scripts/auto-merge.ps1
@@ -22,9 +22,17 @@ function Get-LatestActionsCheckRun {
   return $latest[0]
 }
 
-$prRaw = & gh pr view $Pr --repo $Repo --json isDraft,state,labels,baseRefName,headRefName,headRefOid,author 2>&1
+$prRaw = & gh pr view $Pr --repo $Repo --json isDraft,state,labels,baseRefName,headRefName,headRefOid,author,headRepositoryOwner,headRepository 2>&1
 if ($LASTEXITCODE -ne 0) { throw ($prRaw -join "`n") }
 $prData = ($prRaw -join "`n") | ConvertFrom-Json
+# Defense-in-depth (#62): pr-orchestrator.ps1 fork-denies before ever calling
+# this script, but auto-merge.ps1 must refuse to arm a fork PR on its own,
+# standalone, so a direct invocation or a future caller that forgets to
+# fork-check first can never arm a cross-repository PR.
+if (Test-ForkPr -PrData $prData -Repo $Repo) {
+  $headRepo = "$([string]$prData.headRepositoryOwner.login)/$([string]$prData.headRepository.name)"
+  throw "Auto-merge refused: PR #$Pr head repository '$headRepo' is not the target repository '$Repo'; fork PRs never enter the unattended lane."
+}
 if ($prData.state -ne 'OPEN') { throw "PR #$Pr is not open." }
 if ($prData.isDraft) { throw "Ready-at-creation policy violation: $Repo PR #$Pr is draft. Auto-merge was not attempted." }
 if (@($prData.labels | ForEach-Object { $_.name }) -contains 'status:blocked') { throw "PR #$Pr is status:blocked." }

--- a/scripts/bootstrap-repo.ps1
+++ b/scripts/bootstrap-repo.ps1
@@ -55,11 +55,6 @@ else {
   }
 }
 
-$dependabotPath = Join-Path $target '.github/dependabot.yml'
-if (-not (Test-Path $dependabotPath)) {
-  Copy-Item (Join-Path $standardRoot 'templates/dependabot.yml') $dependabotPath -Force
-}
-
 Copy-Item (Join-Path $standardRoot 'templates/AGENTS.md') (Join-Path $target 'AGENTS.md') -Force
 Copy-Item (Join-Path $standardRoot 'templates/PRD.md') (Join-Path $target 'PRD.md') -Force
 Copy-Item (Join-Path $standardRoot 'templates/ISSUE.md') (Join-Path $target '.github/ISSUE_TEMPLATE/work-item.md') -Force
@@ -148,7 +143,7 @@ Replace the bootstrap-only PR Gate with the smallest objective gate appropriate 
 - Detect and record verified build/test/type/lint/E2E commands in `.agent/project.yaml`.
 - Replace `.github/workflows/pr-gate.yml` so workflow name and required job context remain exactly `PR Gate`.
 - Preserve exact-SHA-pinned `.github/workflows/ai-review.yml` and the five per-event `.github/workflows/pr-automation*.yml` callers.
-- Extend `.github/dependabot.yml` only with package ecosystems this repo actually uses; group patch/minor updates when it reduces CI/review noise.
+- `.github/dependabot.yml` is deliberately absent (fleet-wide default is off); add it only if the owner explicitly wants Dependabot for this repo, scoped to the package ecosystems actually used.
 - Keep native `.github/CODEOWNERS` absent so Kyle is never auto-requested as a routine reviewer.
 - Finish the coherent slice locally, then create the PR Ready. REST/SDK/connector callers set `draft:false`; CLI callers use the Ready default.
 - Add only tests/tools justified by actual product risk; do not invent a framework for conformity.

--- a/scripts/lib/review-policy.ps1
+++ b/scripts/lib/review-policy.ps1
@@ -237,6 +237,21 @@ function Get-RiskFromLabels {
   return $risk[0].Substring(5)
 }
 
+function Test-ForkPr {
+  # Shared by every privileged entrypoint (#62): a PR whose head repository is
+  # not the target repository is a fork and must never enter unattended
+  # automation. $PrData is the parsed gh pr JSON; both the `gh pr view --json`
+  # shape (headRepositoryOwner.login/headRepository.name) and the REST `gh api
+  # .../pulls/<n>` shape (head.repo.full_name) are accepted so callers using
+  # either fetch style get the identical, single-source-of-truth check.
+  param($PrData,[Parameter(Mandatory)][string]$Repo)
+  $headRepo = [string]$PrData.head.repo.full_name
+  if ([string]::IsNullOrWhiteSpace($headRepo)) {
+    $headRepo = "$([string]$PrData.headRepositoryOwner.login)/$([string]$PrData.headRepository.name)"
+  }
+  return $headRepo -ne $Repo
+}
+
 function Test-ControlPlanePath {
   param([Parameter(Mandatory)][string]$Path)
   $patterns = @(

--- a/scripts/pr-orchestrator.ps1
+++ b/scripts/pr-orchestrator.ps1
@@ -31,11 +31,13 @@ function Get-Pr {
   return (($raw -join "`n") | ConvertFrom-Json)
 }
 function Deny-ForkPr {
-  # Fail closed before any privileged mutation: fork heads never enter the lane.
+  # Fail closed before any privileged mutation: fork heads never enter the
+  # lane. Test-ForkPr (scripts/lib/review-policy.ps1) is the single-source
+  # comparison also used standalone by auto-merge.ps1 (#62).
   param([int]$Number)
   $prData = Get-Pr $Number
+  if (-not (Test-ForkPr -PrData $prData -Repo $Repo)) { return $false }
   $headRepo = "$([string]$prData.headRepositoryOwner.login)/$([string]$prData.headRepository.name)"
-  if ($headRepo -eq $Repo) { return $false }
   Write-Host "FORK-DENIED: $Repo PR #$Number head repository '$headRepo' is not the target repository; unattended automation refuses cross-repository PRs."
   Set-Blocked $Number 'fork-pr' "Cross-repository (fork) PR from '$headRepo'. Re-home this change into a branch of the managed repository; the unattended lane never runs privileged automation for fork heads." $prData
   return $true

--- a/scripts/upgrade-repos.ps1
+++ b/scripts/upgrade-repos.ps1
@@ -126,11 +126,6 @@ pinned_by: upgrade-repos.ps1
       Render-Template (Join-Path $standardRoot 'templates/PR_AUTOMATION_WATCHDOG.yml') '.github/workflows/pr-automation-watchdog.yml'
       Remove-Item '.github/CODEOWNERS' -Force -ErrorAction SilentlyContinue
 
-      if (-not (Test-Path '.github/dependabot.yml')) {
-        New-Item -ItemType Directory -Force '.github' | Out-Null
-        Copy-Item (Join-Path $standardRoot 'templates/dependabot.yml') '.github/dependabot.yml' -Force
-      }
-
       # workflow_run identifies the deterministic gate by workflow name, and the
       # ruleset requires it exactly. Preserve a dedicated pr-gate.yml; otherwise
       # normalize a bare "ci" workflow name, or an earlier repo's leftover
@@ -180,7 +175,7 @@ Pins the shared engineering standard to $StandardSha and installs exact-SHA `AI 
 
 - Removes native CODEOWNERS so Kyle is not auto-requested as a routine reviewer.
 - Preserves the repository-specific deterministic gate and normalizes CI/ci workflow name to exact `PR Gate` only when no dedicated `pr-gate.yml` exists.
-- Adds the lean Dependabot default only when absent.
+- Does not add a Dependabot config file: the owner disabled Dependabot fleet-wide, and the rollout no longer fights that removal.
 - No product behavior change.
 
 Risk: R2. This content was already reviewed once, at the standard repo's own gate; propagating identical, deterministically-generated content to product repos is not new independent risk, and the design's documented auto-merge ceiling (unattended auto-merge is capped at R2) already anticipated this exact class of change. upgrade-repos.ps1 only ever writes to known, template-driven paths, never arbitrary content.

--- a/tests/automation-entrypoints.tests.ps1
+++ b/tests/automation-entrypoints.tests.ps1
@@ -19,9 +19,16 @@ try {
 set -euo pipefail
 printf '%s\n' "$*" >> "$GH_FAKE_LOG"
 
-if [[ "$GH_FAKE_SCENARIO" == "auto-merge-drift" || "$GH_FAKE_SCENARIO" == "auto-merge-ready" ]]; then
+if [[ "$GH_FAKE_SCENARIO" == "auto-merge-fork" ]]; then
   if [[ "$1 $2" == "pr view" ]]; then
-    printf '%s\n' '{"state":"OPEN","isDraft":false,"labels":[{"name":"risk:R2"}],"baseRefName":"main","headRefName":"dependabot/npm_and_yarn/example","headRefOid":"1717171717171717171717171717171717171717","author":{"login":"dependabot[bot]"}}'
+    printf '%s\n' '{"state":"OPEN","isDraft":false,"labels":[{"name":"risk:R2"}],"baseRefName":"main","headRefName":"patch-1","headRefOid":"1717171717171717171717171717171717171717","author":{"login":"attacker"},"headRepositoryOwner":{"login":"attacker"},"headRepository":{"name":"example"}}'
+  else
+    printf 'unexpected auto-merge-fork fake gh call: %s\n' "$*" >&2
+    exit 91
+  fi
+elif [[ "$GH_FAKE_SCENARIO" == "auto-merge-drift" || "$GH_FAKE_SCENARIO" == "auto-merge-ready" ]]; then
+  if [[ "$1 $2" == "pr view" ]]; then
+    printf '%s\n' '{"state":"OPEN","isDraft":false,"labels":[{"name":"risk:R2"}],"baseRefName":"main","headRefName":"dependabot/npm_and_yarn/example","headRefOid":"1717171717171717171717171717171717171717","author":{"login":"dependabot[bot]"},"headRepositoryOwner":{"login":"kgsmith19"},"headRepository":{"name":"example"}}'
   elif [[ "$1" == "api" && "$*" == *"check-runs?check_name=PR%20Gate"* ]]; then
     printf '%s\n' '{"check_runs":[{"id":41,"name":"PR Gate","app":{"slug":"github-actions"},"conclusion":"success","output":{"summary":"deterministic"}}]}'
   elif [[ "$1" == "api" && "$*" == *"check-runs?check_name="* ]]; then
@@ -102,6 +109,22 @@ fi
   $readyCalls = Get-Content $log -Raw
   Assert-True 'eligible dependency PR arms native squash auto-merge' ($readyCalls -match 'pr merge 17 --repo kgsmith19/example --auto --squash')
   Assert-True 'arming path verifies the GitHub Actions-bound PR Gate ruleset' ($readyCalls -match 'api repos/kgsmith19/example/rulesets/101')
+
+  # #62: auto-merge.ps1 must refuse a fork PR on its own, standalone, without
+  # relying on pr-orchestrator.ps1's Deny-ForkPr running first.
+  Clear-Content $log
+  $env:GH_FAKE_SCENARIO = 'auto-merge-fork'
+  $forkFailure = $null
+  try {
+    & (Join-Path $root 'scripts/auto-merge.ps1') -Repo 'kgsmith19/example' -Pr 17 -Risk R2
+  }
+  catch { $forkFailure = $_.Exception.Message }
+
+  Assert-True 'auto-merge refuses a fork PR called directly' ($forkFailure -match 'fork')
+  Assert-True 'auto-merge fork refusal names the actual head repository' ($forkFailure -match 'attacker/example')
+  $forkCalls = Get-Content $log -Raw
+  Assert-True 'auto-merge fork refusal happens before any other privileged call' (($forkCalls.Trim() -split "`r?`n").Count -eq 1)
+  Assert-True 'auto-merge never arms merge for a fork PR' ($forkCalls -notmatch 'pr merge')
 
   $fixture = Join-Path $temp 'review-fixture'
   New-Item -ItemType Directory -Path (Join-Path $fixture 'scripts/lib') -Force | Out-Null

--- a/tests/standard-hygiene.tests.ps1
+++ b/tests/standard-hygiene.tests.ps1
@@ -246,6 +246,13 @@ Assert-Contains 'upgrade reuses existing rollout PR' 'scripts/upgrade-repos.ps1'
 Assert-Contains 'upgrade sets a local git identity before committing' 'scripts/upgrade-repos.ps1' 'git config user\.email'
 Assert-Contains 'setup portfolio invokes upgrade-repos' 'scripts/setup-portfolio.ps1' 'upgrade-repos\.ps1'
 
+# Fleet-wide dependabot disable (#65): the owner explicitly removed
+# .github/dependabot.yml from every managed repo, so neither the rollout
+# upgrader nor bootstrap may re-add it as a silent default. Off until
+# explicitly re-enabled, in both existing and newly onboarded repos.
+Assert-NotContains 'upgrade does not re-add dependabot.yml' 'scripts/upgrade-repos.ps1' 'Copy-Item.*dependabot'
+Assert-NotContains 'bootstrap does not add dependabot.yml by default' 'scripts/bootstrap-repo.ps1' 'Copy-Item.*dependabot'
+
 Assert-Contains 'doctor checks Copilot workflow approval' 'scripts/doctor.ps1' 'require_actions_workflow_approval'
 Assert-Contains 'doctor checks requested reviewers' 'scripts/doctor.ps1' 'requested_reviewers'
 Assert-Contains 'doctor validates every reusable workflow ref pin' 'scripts/doctor.ps1' '\$usesRefs'


### PR DESCRIPTION
## risk:R3 (control-plane change: scripts/, DELIVERY_GITHUB.md)

Resolves #65 and #62.

### #65 — upgrade-repos.ps1 re-adds dependabot.yml on every rollout
The owner disabled Dependabot fleet-wide; `upgrade-repos.ps1`'s add-if-absent step silently fought that removal on every rollout (confirmed live: had to manually strip it from 7 rollout PRs).

- Removed the add-if-absent step from `scripts/upgrade-repos.ps1` entirely — dependabot stays off until explicitly re-enabled, matching current fleet-wide intent.
- `scripts/bootstrap-repo.ps1` (used to onboard brand-new repos) had the identical step. **Judgment call:** a newly onboarded repo should start with the same "off until asked" posture as the rest of the fleet rather than silently diverging from it on day one, so this step is removed there too. Updated the generated finalize-gate Issue body accordingly (it no longer tells the agent to "extend" a file that won't exist by default).
- `templates/dependabot.yml` is kept as the reference template for explicit opt-in.
- `tests/standard-hygiene.tests.ps1` gains negative assertions that neither script contains the dependabot copy step.

### #62 Part A — auto-merge.ps1 has no independent fork check
`pr-orchestrator.ps1` is the only current caller and fork-denies before calling `auto-merge.ps1`, so the live path is protected today — but `auto-merge.ps1` had zero fork-check of its own (defense-in-depth gap for any direct/future caller).

- Extracted the fork-repository comparison into a shared `Test-ForkPr` helper in `scripts/lib/review-policy.ps1` (already imported by both scripts), accepting either PR JSON shape in use (`gh pr view --json headRepositoryOwner,headRepository` and `gh api .../pulls/<n>`'s `head.repo.full_name`).
- `auto-merge.ps1` now requests those fields on its existing initial `gh pr view` call and refuses — before any other API call — if the head repository isn't the target repo.
- `pr-orchestrator.ps1`'s `Deny-ForkPr` now calls the same helper instead of duplicating the comparison.
- **TDD:** `tests/automation-entrypoints.tests.ps1` gained an `auto-merge-fork` fixture scenario, added and confirmed failing (RED) before the fix, proving `auto-merge.ps1` invoked directly refuses a fork PR, names the actual head repository, makes exactly one `gh` call before refusing, and never reaches `pr merge`.

### #62 Part B — draft-promotion path-B vs. prevention-only policy
Read `scripts/promote-external-draft.ps1` in full against `DELIVERY_GITHUB.md`'s stated draft policy (not just a grep, which is why an earlier triage pass couldn't confirm or deny the original PR #55 P1 finding).

**Finding: no real contradiction between code and overall policy.** External-agent draft promotion is a deliberate, documented, gated feature — policy-flagged (`pr_automation.external_draft_promotion`), identity-gated (`GH_TOKEN_ADMIN` only), fork-refused — and it's explicitly listed in `DELIVERY_GITHUB.md`'s own recovery matrix and in `docs/AUTONOMOUS-PR-STATE-MACHINE.md`'s recovery matrix. The original PR #55 reviewer flagged it before the owner decided, in that same merged commit, to keep it as a narrow exception rather than remove it — and documented that decision in two other places in the same files.

The real (narrow) problem: `DELIVERY_GITHUB.md` section 5 stated the rule in absolute terms ("automated conversion is forbidden") with no cross-reference to the exception documented two sections later in its own recovery matrix. The document contradicted itself, not the code — which is what led the original reviewer to read section 5 in isolation and call it a violation.

**Fixed the doc, not the code:** section 5 now scopes the forbidden-automated-conversion rule to the owner/`github-actions[bot]`, and names the sole automated exception with a cross-reference to the recovery matrix and state-machine doc.

## Test plan
- [x] RED confirmed before each fix (dependabot hygiene assertions, auto-merge fork-check test)
- [x] GREEN after each fix, locally, on pwsh 7.6.4 (verified, not Windows PowerShell 5.1)
- [x] `tests/standard-hygiene.tests.ps1`, `tests/legacy-protection.tests.ps1`, `tests/review-policy.tests.ps1`, `tests/standard-lock.tests.ps1`, `tests/state-machine-exhaustiveness.tests.ps1` — all PASS locally
- [x] `scripts/doctor.ps1` (local mode) — `LOCAL: READY`
- [x] `tests/automation-entrypoints.tests.ps1`, `tests/upgrade-repos.tests.ps1`, `tests/script-smoke.tests.ps1`, `tests/gate-result-arming.tests.ps1`, `tests/unconditional-evaluation.tests.ps1`, `tests/draft-prevention.tests.ps1` spawn a bash-shebang fake `gh` via pwsh subprocess creation, which Windows pwsh cannot exec directly ("Cannot run a document in the middle of a pipeline") — reproduced identically on a pristine clone before any changes, so this is a pre-existing Windows-only local-runner limitation, not a regression. These run for real on this PR's live `ubuntu-latest` CI (`PR Gate`).
- [ ] Live CI green (polled on this PR)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_011TJ1XogAdPYdpv4JCWpaXg