### PR TITLE
Improve presentation of TEMPLATES Markdown files

### DIFF
--- a/TEMPLATES/AGENTS.md
+++ b/TEMPLATES/AGENTS.md
@@ -1,8 +1,9 @@
 # Contributor and Agent Guidance
 
-This file provides experimental, non-enforcing guidance. Follow the repository's explicit instructions and verified project commands.
+> [!NOTE]
+> This file provides experimental, non-enforcing guidance. Follow the repository's explicit instructions and verified project commands.
 
-## Working approach
+## 🧭 Working Approach
 
 1. Start from a GitHub Issue with a clear outcome.
 2. Implement the smallest coherent change that satisfies the Issue.
@@ -14,16 +15,16 @@ This file provides experimental, non-enforcing guidance. Follow the repository's
 
 Prefer direct, maintainable solutions. Avoid unrelated cleanup and speculative abstractions.
 
-## Evidence
+## ✅ Evidence
 
 Inspect the final diff, check for whitespace errors, run affected formatters and tests, and report the exact commands and results. State clearly when a relevant check could not be run.
 
-## AI agent boundaries
+## 🔒 AI Agent Boundaries
 
-An AI coding agent may create Issues, branches, commits, pull requests, descriptions, code, tests, and documentation only when explicitly tasked.
+**May**, only when explicitly tasked: create Issues, branches, commits, pull requests, descriptions, code, tests, and documentation.
 
-An AI agent must not submit reviews, request reviewers, approve changes, block a pipeline, or post an unsolicited comment. It may answer a direct question when explicitly tagged in an Issue or pull request.
+**Must not**: submit reviews, request reviewers, approve changes, block a pipeline, or post an unsolicited comment. An agent may answer a direct question when explicitly tagged in an Issue or pull request.
 
-## External guidance
+## 🔗 External Guidance
 
 A reference to shared guidance is informational. Adoption is deliberate and does not automatically change this repository. Repository-specific instructions take precedence.

--- a/TEMPLATES/ISSUE.md
+++ b/TEMPLATES/ISSUE.md
@@ -1,23 +1,26 @@
-## Classification
+## 🏷️ Classification
 
-`FEAT:` a new capability or behavior change. `BUG:` existing behavior is wrong. Prefix the Issue title with one.
+Prefix the Issue title with one:
 
-## Outcome
+- `FEAT:` — a new capability or behavior change.
+- `BUG:` — existing behavior is wrong.
+
+## 🎯 Outcome
 
 Describe the user-visible or operational result this Issue should produce.
 
-## Context
+## 📚 Context
 
 Explain the current behavior, the reason for the change, and any facts needed to understand the work.
 
-## Acceptance criteria
+## ✅ Acceptance Criteria
 
 - [ ] State each observable condition required for completion.
 
-## Scope
+## 📋 Scope
 
 List important constraints and anything intentionally excluded.
 
-## Verification
+## 🧪 Verification
 
 List the checks or evidence that will demonstrate the outcome.

--- a/TEMPLATES/PULL_REQUEST.md
+++ b/TEMPLATES/PULL_REQUEST.md
@@ -1,16 +1,16 @@
-## Summary
+## 📋 Summary
 
 Explain what changed and why.
 
-## Related Issue
+## 🔗 Related Issue
 
 Closes #
 
-## Changes
+## 🔨 Changes
 
 - Describe the smallest meaningful set of changes.
 
-## Verification
+## 🧪 Verification
 
 List each command or check run and its result.
 
@@ -18,7 +18,7 @@ List each command or check run and its result.
 command — result
 ```
 
-## Scope check
+## ✅ Scope Check
 
 - [ ] The change is limited to the related Issue.
 - [ ] Tests or documentation were updated when relevant.

--- a/TEMPLATES/README.md
+++ b/TEMPLATES/README.md
@@ -2,14 +2,20 @@
 
 Reference material for a repository adopting this standard. Nothing here is enforced automatically — copy what fits, adapt the wording to the repository, and skip what doesn't apply.
 
-## Contents
+## 📋 Contents
 
-- `README.md` / `CLAUDE.md` / `AGENTS.md` — starting point for a repository's own root docs. `CLAUDE.md` is a one-line pointer to `AGENTS.md`; keep both in sync with the repository's actual workflow rather than copying this text verbatim.
-- `PULL_REQUEST.md` — copy to `.github/PULL_REQUEST_TEMPLATE.md`.
-- `ISSUE.md` — copy to `.github/ISSUE_TEMPLATE/work-item.md`.
-- `TEST_LEDGER.md` — copy to the repository root as `TEST_LEDGER.md`; a running record of what's tested and its last known status, not a gate.
-- `project.yaml` — copy to the repository root; fill in the repository's actual facts.
+| Template | Copy to | Purpose |
+| --- | --- | --- |
+| [`README.md`](./README.md) | repository root | Starting point for a repository's own root docs |
+| [`AGENTS.md`](./AGENTS.md) | repository root | Contributor and coding-agent guidance |
+| [`CLAUDE.md`](./CLAUDE.md) | repository root | One-line pointer to `AGENTS.md` |
+| [`ISSUE.md`](./ISSUE.md) | `.github/ISSUE_TEMPLATE/work-item.md` | Work-item template |
+| [`PULL_REQUEST.md`](./PULL_REQUEST.md) | `.github/PULL_REQUEST_TEMPLATE.md` | Pull request template |
+| [`TEST_LEDGER.md`](./TEST_LEDGER.md) | repository root | Running record of what's tested and its last known status — not a gate |
+| [`project.yaml`](./project.yaml) | repository root | Repository metadata; fill in the repository's actual facts |
 
-## Adoption
+Keep `AGENTS.md` and `CLAUDE.md` in sync with the repository's actual workflow rather than copying this text verbatim.
+
+## 🧭 Adoption
 
 Adoption is deliberate and per-repository. Copying these files into a repository does not create an ongoing dependency on this one; a `standard.lock` file in the consuming repository records which version was used as a reference, informationally only.

--- a/TEMPLATES/TEST_LEDGER.md
+++ b/TEMPLATES/TEST_LEDGER.md
@@ -1,9 +1,12 @@
 # Test Ledger
 
-A running record of this repository's test suites: what exists, what it covers, and the result of its most recent run. Historical context for contributors, not a merge gate — `PR Gate` is the gate.
+A running record of this repository's test suites: what exists, what it covers, and the result of its most recent run.
+
+> [!NOTE]
+> Historical context for contributors, not a merge gate — `PR Gate` is the gate.
 
 | Suite | Covers | Command | Last run | Result |
 | --- | --- | --- | --- | --- |
 | _example_ | _what it exercises_ | `npm test` | YYYY-MM-DD | pass |
 
-Add a row when a new suite is introduced. Update the row's "Last run"/"Result" when it materially changes (new failure mode fixed, suite retired, coverage expanded) — this is not meant to be updated on every CI run.
+Add a row when a new suite is introduced. Update **Last run** and **Result** when it materially changes — a new failure mode fixed, a suite retired, coverage expanded. This is not meant to be updated on every CI run.


### PR DESCRIPTION
## 📋 Summary

A presentation, organization, and Markdown-quality pass over the six templates in `TEMPLATES/`. They were correct and lean but visually flat — plain headings, no icons, no callouts, and an index that buried copy destinations inside prose bullets.

No engineering rule, restriction, workflow step, terminology, ownership boundary, `PR Gate` behavior, or guidance-vs-enforcement distinction changes. Styling only.

## 🔗 Related Issue

None — this change was requested directly rather than from an Issue.

## 🔨 Changes

- One scanning icon per `##` heading, using a consistent concept mapping across templates (🧭 workflow, ✅ evidence/acceptance, 🧪 verification, 📋 scope/summary, 🎯 outcome, 📚 context, 🔒 boundaries, 🔗 references). Titles stay icon-free.
- `README.md` — contents bullet list becomes a table naming each template's copy destination and purpose, with each entry linked.
- `AGENTS.md` — the non-enforcing framing moves into a `[!NOTE]` callout; the boundaries section becomes **May** / **Must not** leads. Same permissions, same prohibitions, same "only when explicitly tasked" limit.
- `ISSUE.md` — the run-on classification sentence splits into `FEAT:` and `BUG:` bullets.
- `TEST_LEDGER.md` — the not-a-merge-gate rule moves into a `[!NOTE]`. Kept as `[!NOTE]` rather than `[!WARNING]` so the informational tone is not strengthened.
- `PULL_REQUEST.md` — headings only.
- `CLAUDE.md` — unchanged; already a minimal pointer, and `@AGENTS.md` is a functional import.

Conventions held throughout: two heading levels only, at most one callout per file, and links only in `README.md` — the one template that is not copied into a consuming repository, where sibling relative links would break.

## 🧪 Verification

```text
git diff --check                                    — clean
git diff --check <empty-tree> HEAD --               — clean (same check PR Gate runs tree-wide)
test -s README.md && test -s AGENTS.md              — both pass (PR Gate's other checks)
grep '^###' TEMPLATES/*.md                          — no matches (no deep nesting)
grep '](' TEMPLATES/*.md except README.md           — no matches (no links in copied files)
link targets in TEMPLATES/README.md                 — all 7 exist on disk
wc -w, table pipes stripped                         — prose flat: README +0, AGENTS -3, ISSUE +2, TEST_LEDGER +5
```

The raw word count rises 650 → 693, but the entire +43 is table and callout markup; prose is flat to slightly down.

Line-by-line preservation review of the diff confirmed the seven workflow steps, the evidence paragraph, the `Closes #` linkage, the ` ```text ` evidence fence, all four scope-check boxes, and the ledger's maintenance guidance are carried over intact.

Not verified: GitHub's rendered output for the two callouts, the tables, and the task lists — that needs eyes on this PR's Files-changed view.

## ✅ Scope Check

- [x] The change is limited to `TEMPLATES/*.md`.
- [x] No rule was lost, weakened, strengthened, or reinterpreted.
- [x] Checks not run are stated above.
- [x] The pull request is prepared for the automatic `PR Gate`.

Root `README.md`, `AGENTS.md`, and `CLAUDE.md` were deliberately left alone as out of scope, so they now read plainer than the templates. Aligning them is available as a follow-up.

---
_Generated by [Claude Code](https://claude.ai/code/session_013ioxHQGV8vmraArohdEdcd)_