### PR TITLE
Adopt the TEMPLATES conventions in this repository

### DIFF
--- a/.github/ISSUE_TEMPLATE/work-item.md
+++ b/.github/ISSUE_TEMPLATE/work-item.md
@@ -1,0 +1,31 @@
+---
+name: Work item
+about: "A FEAT: or BUG: work item"
+---
+
+## 🏷️ Classification
+
+Prefix the Issue title with one:
+
+- `FEAT:` — a new capability or behavior change.
+- `BUG:` — existing behavior is wrong.
+
+## 🎯 Outcome
+
+Describe the user-visible or operational result this Issue should produce.
+
+## 📚 Context
+
+Explain the current behavior, the reason for the change, and any facts needed to understand the work.
+
+## ✅ Acceptance Criteria
+
+- [ ] State each observable condition required for completion.
+
+## 📋 Scope
+
+List important constraints and anything intentionally excluded.
+
+## 🧪 Verification
+
+List the checks or evidence that will demonstrate the outcome.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,26 @@
+## 📋 Summary
+
+Explain what changed and why.
+
+## 🔗 Related Issue
+
+Closes #
+
+## 🔨 Changes
+
+- Describe the smallest meaningful set of changes.
+
+## 🧪 Verification
+
+List each command or check run and its result.
+
+```text
+command — result
+```
+
+## ✅ Scope Check
+
+- [ ] The change is limited to the related Issue.
+- [ ] Tests or documentation were updated when relevant.
+- [ ] Known limitations or checks not run are stated above.
+- [ ] The pull request is prepared for the automatic `PR Gate`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,8 +1,9 @@
 # Contributor and Agent Guidance
 
-This repository is experimental and non-enforcing. Use these practices as concise working guidance, then follow the explicit instructions and verified commands of the repository being changed.
+> [!NOTE]
+> This repository is experimental and non-enforcing. Use these practices as concise working guidance, then follow the explicit instructions and verified commands of the repository being changed.
 
-## Working approach
+## 🧭 Working Approach
 
 1. Start from a GitHub Issue with a clear outcome.
 2. Make the smallest coherent change that satisfies that outcome.
@@ -14,7 +15,7 @@ This repository is experimental and non-enforcing. Use these practices as concis
 
 Prefer direct, maintainable solutions. Avoid unrelated cleanup, speculative abstractions, and new process artifacts that do not help deliver the requested outcome.
 
-## Evidence
+## ✅ Evidence
 
 Before handing off a change:
 
@@ -24,24 +25,24 @@ Before handing off a change:
 - report commands and results accurately; and
 - identify any check that could not be run.
 
-## CI baseline
+## ⚙️ CI Baseline
 
 Workflow enforcement is a single required check named `PR Gate` (or a repository's own `ci.yml` acting as one). Once repository settings permit it, native squash auto-merge is enabled to fire automatically when `PR Gate` passes and there are no merge conflicts — no separate automation is needed to arm it.
 
-## Forbidden artifacts
+## ⚠️ Forbidden Artifacts
 
 Do not commit, and remove on sight: `SPEC` files or directories, `PRD` documents, `System_Requirements.md`, data-flow diagrams, changelogs, ADRs, `AI_REVIEW` / "AI Review" workflows or references, `AGENT_VIEW`, `watchdog` automation, or any forced manual governance block (required human sign-off steps, review-request automation, merge-blocking bots beyond `PR Gate`). These were deliberately removed from this repository's own history; the guidance here is prospective as well as retrospective — repositories adopting this standard should not reintroduce them.
 
-## Local scratchpad
+## 📝 Local Scratchpad
 
 An agent may draft a spec, design note, or outline locally to think through a GitHub Issue before writing it — but only in a `.gitignore`d workspace folder. Nothing drafted this way may be committed; the Issue itself is the durable artifact.
 
-## AI agent boundaries
+## 🔒 AI Agent Boundaries
 
-An AI coding agent may create work artifacts only when the task explicitly authorizes them. This can include Issues, branches, commits, pull requests, descriptions, code, tests, and documentation.
+**May**, only when the task explicitly authorizes them: create work artifacts. These can include Issues, branches, commits, pull requests, descriptions, code, tests, and documentation.
 
-An AI agent must not submit reviews, request reviewers, approve changes, block a pipeline, or post an unsolicited comment. It may answer a direct question when explicitly tagged in an Issue or pull request.
+**Must not**: submit reviews, request reviewers, approve changes, block a pipeline, or post an unsolicited comment. An agent may answer a direct question when explicitly tagged in an Issue or pull request.
 
-## Repository references
+## 🔗 Repository References
 
 A repository may deliberately reference a specific version of this guidance. The reference is informational and does not automatically change that repository. Repository-specific instructions take precedence.

--- a/README.md
+++ b/README.md
@@ -1,12 +1,15 @@
 # Agent Engineering Standard
 
-This repository contains experimental engineering guidance for repositories that use coding agents. It is a learning resource, not an enforcement mechanism. Its contents will evolve as the practices are tested and refined.
+Experimental engineering guidance for repositories that use coding agents.
 
-## Purpose
+> [!NOTE]
+> This is a learning resource, not an enforcement mechanism. Its contents will evolve as the practices are tested and refined.
+
+## 🎯 Purpose
 
 The guidance favors lean changes, clear intent, maintainable code, focused tests, and evidence that a pull request is ready to merge. Each repository remains responsible for choosing and configuring the practices that fit its product and technology.
 
-## Suggested lifecycle
+## 🧭 Suggested Lifecycle
 
 1. Record the desired outcome in a GitHub Issue.
 2. Implement the smallest coherent change that satisfies the Issue.
@@ -17,7 +20,7 @@ The guidance favors lean changes, clear intent, maintainable code, focused tests
 
 A pull request should make the change, its rationale, and its verification easy to understand.
 
-## Engineering guidance
+## 📋 Engineering Guidance
 
 - Keep each change narrow enough to inspect and recover safely.
 - Prefer simple code and explicit behavior over speculative abstractions.
@@ -26,21 +29,21 @@ A pull request should make the change, its rationale, and its verification easy 
 - Preserve unrelated work and document any known limitation.
 - Treat a passing gate as evidence that configured checks ran, not as a substitute for engineering judgment.
 
-## Templates
+## 📚 Templates
 
-`TEMPLATES/` holds reference material — root docs, a pull request template, an issue template, a test ledger, and a `project.yaml` metadata schema — for a repository to copy and adapt. See `TEMPLATES/README.md`. Copying these files does not create an ongoing dependency; a repository's own `standard.lock` records, informationally, which version of this standard it was drawn from.
+[`TEMPLATES/`](./TEMPLATES/) holds reference material — root docs, a pull request template, an issue template, a test ledger, and a `project.yaml` metadata schema — for a repository to copy and adapt. See [`TEMPLATES/README.md`](./TEMPLATES/README.md). Copying these files does not create an ongoing dependency; a repository's own `standard.lock` records, informationally, which version of this standard it was drawn from.
 
-## Use by other repositories
+## 🔗 Use by Other Repositories
 
 Other repositories may reference a specific version of this repository. Adoption is deliberate and repository-specific; no content here updates another repository automatically. A reference communicates which guidance was considered, but does not impose behavior or replace the repository's own instructions.
 
-## AI agent participation
+## 🔒 AI Agent Participation
 
-When explicitly tasked, an AI coding agent may create or update Issues, branches, commits, pull requests, descriptions, code, tests, and documentation within the authorized scope.
+**May**, when explicitly tasked: create or update Issues, branches, commits, pull requests, descriptions, code, tests, and documentation within the authorized scope.
 
-AI agents may not submit reviews, request reviewers, approve changes, block pipelines, or post unsolicited comments. An AI agent may answer a direct question when it is explicitly tagged in an Issue or pull request.
+**May not**: submit reviews, request reviewers, approve changes, block pipelines, or post unsolicited comments. An AI agent may answer a direct question when it is explicitly tagged in an Issue or pull request.
 
-## Useful local commands
+## ⚙️ Useful Local Commands
 
 Use the commands defined by the repository being changed. Common evidence includes:
 

--- a/TEST_LEDGER.md
+++ b/TEST_LEDGER.md
@@ -1,0 +1,12 @@
+# Test Ledger
+
+A running record of this repository's test suites: what exists, what it covers, and the result of its most recent run.
+
+> [!NOTE]
+> Historical context for contributors, not a merge gate — `PR Gate` is the gate.
+
+| Suite | Covers | Command | Last run | Result |
+| --- | --- | --- | --- | --- |
+| _none yet_ | — | — | — | — |
+
+Add a row when a new suite is introduced. Update **Last run** and **Result** when it materially changes — a new failure mode fixed, a suite retired, coverage expanded. This is not meant to be updated on every CI run.

--- a/project.yaml
+++ b/project.yaml
@@ -1,0 +1,14 @@
+project:
+  name: agent-engineering-standard
+  type: Experimental engineering guidance and templates for repositories that use coding agents
+
+ci:
+  workflow: .github/workflows/ci.yml
+  required_check: "PR Gate"
+
+work_tracking:
+  system: github-issues
+
+standard:
+  repo: kgsmith19/agent-engineering-standard
+  lock_file: standard.lock

--- a/standard.lock
+++ b/standard.lock
@@ -1,3 +1,3 @@
 standard: kgsmith19/agent-engineering-standard
-commit: eb769955a895e8a3f2c985ab8d9ff675c4910d8e
-pinned_at: "2026-08-12"
+commit: 44153c93eb11f4a0c7bc3010f3a0db51bbd76199
+pinned_at: "2026-08-16"


### PR DESCRIPTION
## 📋 Summary

Follow-up to #72. That PR upgraded the templates; this one makes the repository practice what it publishes — applying the same presentation conventions to the root documents, installing the artifacts `TEMPLATES/README.md` says an adopting repository should copy in, and refreshing `standard.lock`.

No engineering rule, restriction, workflow step, terminology, ownership boundary, or `PR Gate` behavior changes. The root docs are a styling pass; the new files are copies of the templates.

## 🔗 Related Issue

None — requested directly as a follow-up to #72.

## 🔨 Changes

**Restyled** (same conventions as #72: one icon per `##`, a single `[!NOTE]` per file, Title Case, no `###`):

- `README.md` — icons; the non-enforcing framing lifted into a `[!NOTE]`; `TEMPLATES/` and `TEMPLATES/README.md` are now links; AI-agent section restructured into **May** / **May not** leads, preserving this file's "may not" wording rather than `AGENTS.md`'s "must not".
- `AGENTS.md` — icons; intro into a `[!NOTE]`; boundaries into **May** / **Must not**. The "can include" phrasing is preserved so the artifact list stays illustrative rather than exhaustive. The `CI baseline`, `Forbidden artifacts`, and `Local scratchpad` sections — which the template does not carry — are retained in full.
- `CLAUDE.md` — unchanged; already a minimal pointer.

**Installed from `TEMPLATES/`:**

- `.github/PULL_REQUEST_TEMPLATE.md` — byte-identical to `TEMPLATES/PULL_REQUEST.md`.
- `.github/ISSUE_TEMPLATE/work-item.md` — the `ISSUE.md` body, plus two front-matter fields (`name`, `about`) that GitHub needs to name the template in its chooser. This is the only content not present in the template.
- `project.yaml` — filled in with this repository's facts; the "fill these in" comment dropped now that it is filled in.
- `TEST_LEDGER.md` — placeholder `_example_` row replaced with `_none yet_`, since this repository has no test suites. Recording a fake `npm test` row would have been worse than an honest empty one.

**`standard.lock`** — `eb76995` → `44153c9` (the commit that established the template baseline these docs now follow), `pinned_at` → `2026-08-16`. It was already two commits stale before this change.

## 🧪 Verification

```text
test -s README.md && test -s AGENTS.md          — pass (PR Gate's own checks)
git diff --check --cached                       — clean (PR Gate's whitespace check)
diff TEMPLATES/PULL_REQUEST.md .github/PULL_REQUEST_TEMPLATE.md   — identical
diff TEMPLATES/ISSUE.md <(tail -n +5 work-item.md)                — identical
diff TEMPLATES/TEST_LEDGER.md TEST_LEDGER.md                      — differs only in the example row
yaml.safe_load on project.yaml, standard.lock, issue front matter — all parse
wc -w — README.md 431 -> 425, AGENTS.md 431 -> 428
```

Line-by-line review of the root-doc diffs confirms every rule survives as unchanged context: the seven workflow steps, the five evidence bullets, the CI-baseline paragraph, the full forbidden-artifacts list, the scratchpad rule, and the six lifecycle steps.

Not verified: GitHub's rendered output for the callouts, the issue-template chooser entry, and the PR template — the first PR opened after this merges is the real test.

## ✅ Scope Check

- [x] The change is limited to root docs, `standard.lock`, and the installed template copies.
- [x] No rule was lost, weakened, strengthened, or reinterpreted; both restyled docs are shorter.
- [x] Checks not run are stated above.
- [x] The pull request is prepared for the automatic `PR Gate`.

> [!NOTE]
> `PR Gate` did not run on #72 — runs 327 and 328 both ended in `startup_failure` with zero jobs created, which is an account/runner-level condition rather than anything in the diff. If it recurs here, its three checks are reproduced in the verification block above.

---
_Generated by [Claude Code](https://claude.ai/code/session_013ioxHQGV8vmraArohdEdcd)_