### PR TITLE
Assert the published and installed templates stay in sync

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,3 +25,8 @@ jobs:
           test -s AGENTS.md
           empty_tree="$(git hash-object -t tree /dev/null)"
           git diff --check "$empty_tree" HEAD --
+          # GitHub only reads templates from its own fixed paths, so the
+          # published copies in TEMPLATES/ and the installed ones must match.
+          diff TEMPLATES/PULL_REQUEST.md .github/PULL_REQUEST_TEMPLATE.md
+          tail -n "$(wc -l < TEMPLATES/ISSUE.md)" .github/ISSUE_TEMPLATE/work-item.md \
+            | diff TEMPLATES/ISSUE.md -


### PR DESCRIPTION
## 📋 Summary

Follow-up to #73. GitHub only reads pull request and issue templates from its own fixed paths, so `TEMPLATES/PULL_REQUEST.md` and `TEMPLATES/ISSUE.md` cannot themselves be the working templates — #73 installed copies under `.github/`. Each of those two templates is therefore stored twice, with nothing stopping the published copy from drifting away from the one the repository actually uses.

This adds two assertions so that drift fails the gate instead of shipping silently.

## 🔗 Related Issue

None — follow-up to #73.

## 🔨 Changes

- `.github/workflows/ci.yml` — two `diff` assertions appended to the existing `Validate repository` step.

No new workflow, no new job, no new required check. `PR Gate` remains the single gate, exactly as `AGENTS.md` describes.

The issue template is compared by taking the last N lines of the installed file, where N is the template's line count. That avoids hard-coding how many lines of front matter GitHub needs, so adding or removing a front-matter field will not silently break the check.

## 🧪 Verification

```text
diff TEMPLATES/PULL_REQUEST.md .github/PULL_REQUEST_TEMPLATE.md   — in sync
tail -n $(wc -l < TEMPLATES/ISSUE.md) work-item.md | diff ISSUE.md -   — in sync
append a line to .github/PULL_REQUEST_TEMPLATE.md                 — check fails (exit 1)
restore                                                            — check passes again
yaml.safe_load on ci.yml                                           — parses, job name still "PR Gate"
test -s README.md && test -s AGENTS.md, git diff --check           — pass
```

The negative test matters more than the positive one here: a sync check that cannot fail is worse than no check, so drift was deliberately introduced and confirmed to break the build before being reverted.

Not verified: the assertions running on GitHub's runner rather than locally. `PR Gate` has not completed a run since #72 — see the note below.

## ✅ Scope Check

- [x] The change is limited to the `Validate repository` step in `ci.yml`.
- [x] No rule changed; `PR Gate` is still the only gate.
- [x] Checks not run are stated above.
- [x] The pull request is prepared for the automatic `PR Gate`.

> [!NOTE]
> `PR Gate` did not run on #72 or #73 — every run since 2026-08-16 has ended in `startup_failure` with zero jobs created, which is an account or runner-level condition rather than anything in those diffs. This PR is the first that would actually exercise the new assertions, so it will only prove them out once that condition clears.

---
_Generated by [Claude Code](https://claude.ai/code/session_013ioxHQGV8vmraArohdEdcd)_