### PR TITLE
CANARY: auto-merge re-arm enforcement proof (do not merge)

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,3 +35,5 @@ git status --short && git diff --check
 ```
 
 <!-- canary #87: harmless draft-promotion test content -->
+
+<!-- canary #89: harmless auto-merge re-arm test content -->


### PR DESCRIPTION
## Summary

Enforcement canary for #80 sub-Issue E. Ready PR; auto-merge will be disabled deliberately (without an `owner:hold-merge` label) to prove the Merge Policy workflow re-arms it bound to the expected head on the `auto_merge_disabled` event.

## Related work

Closes #89

## Risk

R0

## Owner overrides

None.


---
_Generated by [Claude Code](https://claude.ai/code/session_018Fv4A3Q8fBPBcADZeeZ79q)_